### PR TITLE
GeoIP Lookups from Lua

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,7 @@
 AM_CPPFLAGS = -I pdns $(LUA_CFLAGS) $(YAHTTP_CFLAGS) -O3 -Wall -pthread 
 
+GEOIP_LIBS=-lGeoIP
+
 SUBDIRS=pdns/ext/yahttp
 
 BUILT_SOURCES=htmlfiles.h
@@ -16,6 +18,7 @@ wforce_SOURCES = \
 	wforce-db.cc \
 	wforce-lua.cc \
 	wforce-web.cc \
+	wforce-geoip.cc \
 	dolog.hh \
 	iputils.cc iputils.hh \
 	misc.cc misc.hh \
@@ -34,5 +37,5 @@ wforce_LDFLAGS = \
 
 wforce_LDADD = \
 	-lreadline -lrt -ltermcap \
-	$(LUA_LIBS) $(YAHTTP_LIBS) ${libsodium_LIBS}
+	$(LUA_LIBS) $(YAHTTP_LIBS) ${libsodium_LIBS} $(GEOIP_LIBS)
 

--- a/wforce-geoip.cc
+++ b/wforce-geoip.cc
@@ -1,0 +1,42 @@
+#include "wforce-geoip.hh"
+
+WFGeoIPDB g_wfgeodb;
+
+void WFGeoIPDB::initGeoIPDB()
+  {
+    if (gi_v4)
+      GeoIP_delete(gi_v4);
+    if (GeoIP_db_avail(GEOIP_COUNTRY_EDITION)) {
+      gi_v4 = GeoIP_open_type(GEOIP_COUNTRY_EDITION, GEOIP_MEMORY_CACHE);
+      if (!gi_v4)
+	throw std::runtime_error("Unable to open geoip v4 country db");
+    }
+    else 
+      throw std::runtime_error("No geoip v4 country db available");
+    if (gi_v6)
+      GeoIP_delete(gi_v6);
+    if (GeoIP_db_avail(GEOIP_COUNTRY_EDITION_V6)) {
+      gi_v6 = GeoIP_open_type(GEOIP_COUNTRY_EDITION_V6, GEOIP_MEMORY_CACHE);
+      if (!gi_v6)
+	throw std::runtime_error("Unable to open geoip v6 country db");
+    }
+    else 
+      throw std::runtime_error("No geoip v6 country db available");
+  }
+
+std::string const WFGeoIPDB::lookupCountry(const ComboAddress& address)
+  {
+    GeoIPLookup gl;
+    const char* retstr;
+    std::string ret="";
+
+    if (address.sin4.sin_family == AF_INET && gi_v4 != NULL) {
+      retstr = GeoIP_country_code_by_ipnum_gl(gi_v4, ntohl(address.sin4.sin_addr.s_addr), &gl);
+    }
+    else if (gi_v6 != NULL) { // it's a v6 address (included mapped v4 of course)
+      retstr = GeoIP_country_code_by_ipnum_v6_gl(gi_v6, address.sin6.sin6_addr, &gl);
+    }
+    if (retstr)
+      ret = retstr;
+    return ret;
+  }

--- a/wforce-geoip.hh
+++ b/wforce-geoip.hh
@@ -1,0 +1,35 @@
+#pragma once
+#include <string>
+#include <GeoIP.h>
+#include "wforce.hh"
+
+class WFGeoIPDB
+{
+public:
+  WFGeoIPDB()
+  {
+    gi_v4 = gi_v6 = NULL;
+  }
+
+  ~WFGeoIPDB()
+  {
+    if (gi_v4) {
+      GeoIP_delete(gi_v4);
+    }
+    if (gi_v6) {
+      GeoIP_delete(gi_v6);
+    }
+  }
+
+  // Only load it if someone wants to use GeoIP, otherwise it's a waste of RAM
+  void initGeoIPDB();
+  // This will lookup in either the v4 or v6 GeoIP DB, depending on what address is
+  std::string const lookupCountry(const ComboAddress& address);
+
+private:
+  // GeoIPDB seems to have different DBs for v4 and v6 addresses, hence two DBs
+  GeoIP *gi_v4;
+  GeoIP *gi_v6;
+};
+
+extern WFGeoIPDB g_wfgeodb;

--- a/wforce-lua.cc
+++ b/wforce-lua.cc
@@ -1,4 +1,5 @@
 #include "wforce.hh"
+#include "wforce-geoip.hh"
 #include <thread>
 #include "dolog.hh"
 #include "sodcrypto.hh"
@@ -197,6 +198,14 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
     });
   g_lua.writeFunction("countDiffFailures", [](ComboAddress remote, int seconds) {
       return g_wfdb.countDiffFailures(remote, seconds);
+    });
+
+  g_lua.writeFunction("initGeoIPDB", []() {
+      g_wfgeodb.initGeoIPDB();
+    });
+
+  g_lua.writeFunction("lookupCountry", [](ComboAddress address) {
+      return g_wfgeodb.lookupCountry(address);
     });
 
   g_lua.registerMember("t", &LoginTuple::t);

--- a/wforce.conf
+++ b/wforce.conf
@@ -12,11 +12,20 @@ bulkRetrievers = newNetmaskGroup()
 bulkRetrievers:addMask("130.161.0.0/16");
 bulkRetrievers:addMask("145.132.0.0/16");
 
+-- Only initialize the GeoIPDB if you need it
+--initGeoIPDB()
+
 function allow(wfdb, lt)
 	if(bulkRetrievers:match(lt.remote))
 	then
 		return 0
 	end
+
+	-- Example GeoIP lookup
+	--if (lookupCountry(lt.remote) ~= "GB")
+	--then
+	--	return -1
+	--end
 
 	if(wfdb:countDiffFailuresAddress(lt.remote, 10) > 50)
 	then


### PR DESCRIPTION
Added GeoIP Lookups into weakforced. Only looks up countries at the moment, not cities.

Depends on libgeoip-dev package, which I manually added as a link step to Makefile.am, as I don't know how to use autoconf yet.

Add two new lua functions:
initGeoIPDB() - this loads the ipv4 and ipv6 geoip databases. This is a pre-requisite for running the lookup function(s).
lookupCountry(comboAddress) - Returns the two-letter country code where the IP address is located. Automatically figures out which DB to use (v4 or v6). If for example the v6 DB is not available, ipv6 lookups won't work.

New GeoIP DB class defined in wforce-geoip.x, it's really simple.