### PR TITLE
Time-Window based stats DB

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -17,6 +17,9 @@ wforce_SOURCES = \
 	wforce-lua.cc \
 	wforce-web.cc \
 	wforce-geoip.cc \
+	twmap.cc \
+	murmur3.cc \
+	count_min_sketch.cpp \
 	dolog.hh \
 	iputils.cc iputils.hh \
 	misc.cc misc.hh \

--- a/Makefile.am
+++ b/Makefile.am
@@ -18,8 +18,6 @@ wforce_SOURCES = \
 	wforce-web.cc \
 	wforce-geoip.cc \
 	twmap.cc \
-	murmur3.cc \
-	count_min_sketch.cpp \
 	dolog.hh \
 	iputils.cc iputils.hh \
 	misc.cc misc.hh \
@@ -30,7 +28,9 @@ wforce_SOURCES = \
 	sstuff.hh pdns/ext/luawrapper/include/LuaContext.hpp \
 	pdns/ext/json11/json11.cpp \
 	pdns/ext/json11/json11.hpp \
-	pdns/ext/incbin/incbin.h
+	pdns/ext/incbin/incbin.h \
+	ext/murmur3.cc \
+	ext/count_min_sketch.cpp
 
 wforce_LDFLAGS = \
 	$(AM_LDFLAGS) \

--- a/ext/count_min_sketch.cpp
+++ b/ext/count_min_sketch.cpp
@@ -1,0 +1,127 @@
+# include <iostream>
+# include <cmath>
+# include <cstdlib>
+# include <ctime>
+# include <limits>
+# include "count_min_sketch.hpp"
+using namespace std;
+
+/**
+   Class definition for CountMinSketch.
+   public operations:
+   // overloaded updates
+   void update(int item, int c);
+   void update(char *item, int c);
+   // overloaded estimates
+   unsigned int estimate(int item);
+   unsigned int estimate(char *item);
+**/
+
+
+// CountMinSketch constructor
+// ep -> error 0.01 < ep < 1 (the smaller the better)
+// gamma -> probability for error (the smaller the better) 0 < gamm < 1
+CountMinSketch::CountMinSketch(float ep, float gamm) {
+  if (!(0.009 <= ep && ep < 1)) {
+    cout << "eps must be in this range: [0.01, 1)" << endl;
+    exit(EXIT_FAILURE);
+  } else if (!(0 < gamm && gamm < 1)) {
+    cout << "gamma must be in this range: (0,1)" << endl;
+    exit(EXIT_FAILURE);
+  }
+  eps = ep;
+  gamma = gamm;
+  w = ceil(exp(1)/eps);
+  d = ceil(log(1/gamma));
+  total = 0;
+  // initialize counter array of arrays, C
+  C = new int *[d];
+  unsigned int i, j;
+  for (i = 0; i < d; i++) {
+    C[i] = new int[w];
+    for (j = 0; j < w; j++) {
+      C[i][j] = 0;
+    }
+  }
+  // initialize d pairwise independent hashes
+  srand(time(NULL));
+  hashes = new int* [d];
+  for (i = 0; i < d; i++) {
+    hashes[i] = new int[2];
+    genajbj(hashes, i);
+  }
+}
+
+// CountMinSkectch destructor
+CountMinSketch::~CountMinSketch() {
+  // free array of counters, C
+  unsigned int i;
+  for (i = 0; i < d; i++) {
+    delete[] C[i];
+  }
+  delete[] C;
+  
+  // free array of hash values
+  for (i = 0; i < d; i++) {
+    delete[] hashes[i];
+  }
+  delete[] hashes;
+}
+
+// CountMinSketch totalcount returns the
+// total count of all items in the sketch
+unsigned int CountMinSketch::totalcount() {
+  return total;
+}
+
+// countMinSketch update item count (int)
+void CountMinSketch::update(int item, int c) {
+  total = total + c;
+  unsigned int hashval = 0;
+  for (unsigned int j = 0; j < d; j++) {
+    hashval = (hashes[j][0]*item+hashes[j][1])%w;
+    C[j][hashval] = C[j][hashval] + c;
+  }
+}
+
+// countMinSketch update item count (string)
+void CountMinSketch::update(const char *str, int c) {
+  int hashval = hashstr(str);
+  update(hashval, c);
+}
+
+// CountMinSketch estimate item count (int)
+unsigned int CountMinSketch::estimate(int item) {
+  int minval = numeric_limits<int>::max();
+  unsigned int hashval = 0;
+  for (unsigned int j = 0; j < d; j++) {
+    hashval = (hashes[j][0]*item+hashes[j][1])%w;
+    minval = MIN(minval, C[j][hashval]);
+  }
+  return minval;
+}
+
+// CountMinSketch estimate item count (string)
+unsigned int CountMinSketch::estimate(const char *str) {
+  int hashval = hashstr(str);
+  return estimate(hashval);
+}
+
+// generates aj,bj from field Z_p for use in hashing
+void CountMinSketch::genajbj(int** hashes, int i) {
+  hashes[i][0] = int(float(rand())*float(LONG_PRIME)/float(RAND_MAX) + 1);
+  hashes[i][1] = int(float(rand())*float(LONG_PRIME)/float(RAND_MAX) + 1);
+}
+
+// generates a hash value for a sting
+// same as djb2 hash function
+unsigned int CountMinSketch::hashstr(const char *str) {
+  unsigned long hash = 5381;
+  int c;
+  while (c = *str++) {
+    hash = ((hash << 5) + hash) + c; /* hash * 33 + c */
+  }
+  return hash;
+}
+
+

--- a/ext/count_min_sketch.cpp
+++ b/ext/count_min_sketch.cpp
@@ -1,3 +1,11 @@
+/** 
+    Author: Daniel Alabi
+    http://alabidan.me
+    Github: alabid/countminsketch
+    Count-Min Sketch Implementation based on paper by
+    Muthukrishnan and Cormode, 2004
+**/
+
 # include <iostream>
 # include <cmath>
 # include <cstdlib>
@@ -105,6 +113,16 @@ unsigned int CountMinSketch::estimate(int item) {
 unsigned int CountMinSketch::estimate(const char *str) {
   int hashval = hashstr(str);
   return estimate(hashval);
+}
+
+// erase counts
+void CountMinSketch::erase() {
+  unsigned int i, j;
+  for (i = 0; i < d; i++) {
+    for (j = 0; j < w; j++) {
+      C[i][j] = 0;
+    }
+  }
 }
 
 // generates aj,bj from field Z_p for use in hashing

--- a/ext/count_min_sketch.hpp
+++ b/ext/count_min_sketch.hpp
@@ -1,0 +1,66 @@
+/** 
+    Daniel Alabi
+    Count-Min Sketch Implementation based on paper by
+    Muthukrishnan and Cormode, 2004
+**/
+
+// define some constants
+# define LONG_PRIME 32993
+# define MIN(a,b)  (a < b ? a : b)
+
+/** CountMinSketch class definition here **/
+class CountMinSketch {
+  // width, depth 
+  unsigned int w,d;
+  
+  // eps (for error), 0.01 < eps < 1
+  // the smaller the better
+  float eps;
+  
+  // gamma (probability for accuracy), 0 < gamma < 1
+  // the bigger the better
+  float gamma;
+  
+  // aj, bj \in Z_p
+  // both elements of fild Z_p used in generation of hash
+  // function
+  unsigned int aj, bj;
+
+  // total count so far
+  unsigned int total; 
+
+  // array of arrays of counters
+  int **C;
+
+  // array of hash values for a particular item 
+  // contains two element arrays {aj,bj}
+  int **hashes;
+
+  // generate "new" aj,bj
+  void genajbj(int **hashes, int i);
+
+public:
+  // constructor
+  CountMinSketch(float eps, float gamma);
+  
+  // update item (int) by count c
+  void update(int item, int c);
+  // update item (string) by count c
+  void update(const char *item, int c);
+
+  // estimate count of item i and return count
+  unsigned int estimate(int item);
+  unsigned int estimate(const char *item);
+
+  // return total count
+  unsigned int totalcount();
+
+  // generates a hash value for a string
+  // same as djb2 hash function
+  unsigned int hashstr(const char *str);
+
+  // destructor
+  ~CountMinSketch();
+};
+
+

--- a/ext/count_min_sketch.hpp
+++ b/ext/count_min_sketch.hpp
@@ -1,5 +1,7 @@
 /** 
-    Daniel Alabi
+    Author: Daniel Alabi
+    http://alabidan.me
+    Github: alabid/countminsketch
     Count-Min Sketch Implementation based on paper by
     Muthukrishnan and Cormode, 2004
 **/
@@ -58,6 +60,9 @@ public:
   // generates a hash value for a string
   // same as djb2 hash function
   unsigned int hashstr(const char *str);
+
+  // erase counts
+  void erase();
 
   // destructor
   ~CountMinSketch();

--- a/ext/hyperloglog.hpp
+++ b/ext/hyperloglog.hpp
@@ -1,0 +1,375 @@
+#pragma once
+#if !defined(HYPERLOGLOG_HPP)
+#define HYPERLOGLOG_HPP
+
+/**
+ * @file hyperloglog.hpp
+ * @brief HyperLogLog cardinality estimator
+ * @date Created 2013/3/20
+ * @author Hideaki Ohno
+ */
+
+#include <vector>
+#include <cmath>
+#include <sstream>
+#include <stdexcept>
+#include <algorithm>
+#include "murmur3.h"
+
+#define HLL_HASH_SEED 313
+
+#if defined(__has_builtin) && (defined(__GNUC__) || defined(__clang__))
+
+#define _GET_CLZ(x, b) (uint8_t)std::min(b, ::__builtin_clz(x)) + 1
+
+#else
+
+inline uint8_t _get_leading_zero_count(uint32_t x, uint8_t b) {
+
+#if defined (_MSC_VER)
+    uint32_t leading_zero_len = 32;
+    ::_BitScanReverse(&leading_zero_len, x);
+    --leading_zero_len;
+    return std::min(b, (uint8_t)leading_zero_len);
+#else
+    uint8_t v = 1;
+    while (v <= b && !(x & 0x80000000)) {
+        v++;
+        x <<= 1;
+    }
+    return v;
+#endif
+
+}
+#define _GET_CLZ(x, b) _get_leading_zero_count(x, b)
+#endif /* defined(__GNUC__) */
+
+namespace hll {
+
+static const double pow_2_32 = 4294967296.0; ///< 2^32
+static const double neg_pow_2_32 = -4294967296.0; ///< -(2^32)
+
+/** @class HyperLogLog
+ *  @brief Implement of 'HyperLogLog' estimate cardinality algorithm
+ */
+class HyperLogLog {
+public:
+
+    /**
+     * Constructor
+     *
+     * @param[in] b bit width (register size will be 2 to the b power).
+     *            This value must be in the range[4,30].Default value is 4.
+     *
+     * @exception std::invalid_argument the argument is out of range.
+     */
+    HyperLogLog(uint8_t b = 4) throw (std::invalid_argument) :
+            b_(b), m_(1 << b), M_(m_, 0) {
+
+        if (b < 4 || 30 < b) {
+            throw std::invalid_argument("bit width must be in the range [4,30]");
+        }
+
+        double alpha;
+        switch (m_) {
+            case 16:
+                alpha = 0.673;
+                break;
+            case 32:
+                alpha = 0.697;
+                break;
+            case 64:
+                alpha = 0.709;
+                break;
+            default:
+                alpha = 0.7213 / (1.0 + 1.079 / m_);
+                break;
+        }
+        alphaMM_ = alpha * m_ * m_;
+    }
+
+    /**
+     * Adds element to the estimator
+     *
+     * @param[in] str string to add
+     * @param[in] len length of string
+     */
+    void add(const char* str, uint32_t len) {
+        uint32_t hash;
+        MurmurHash3_x86_32(str, len, HLL_HASH_SEED, (void*) &hash);
+        uint32_t index = hash & ((1 <<  b_) - 1);
+        uint8_t rank = _GET_CLZ((hash << b_), 32 - b_);
+        if (rank > M_[index]) {
+            M_[index] = rank;
+        }
+    }
+
+    /**
+     * Estimates cardinality value.
+     *
+     * @return Estimated cardinality value.
+     */
+    double estimate() const {
+        double estimate;
+        double sum = 0.0;
+        for (uint32_t i = 0; i < m_; i++) {
+            sum += 1.0 / (1 << M_[i]);
+        }
+        estimate = alphaMM_ / sum; // E in the original paper
+        if (estimate <= 2.5 * m_) {
+            uint32_t zeros = 0;
+            for (uint32_t i = 0; i < m_; i++) {
+                if (M_[i] == 0) {
+                    zeros++;
+                }
+            }
+            if (zeros != 0) {
+                estimate = m_ * std::log(static_cast<double>(m_)/ zeros);
+            }
+        } else if (estimate > (1.0 / 30.0) * pow_2_32) {
+            estimate = neg_pow_2_32 * log(1.0 - (estimate / pow_2_32));
+        }
+        return estimate;
+    }
+
+    /**
+     * Merges the estimate from 'other' into this object, returning the estimate of their union.
+     * The number of registers in each must be the same.
+     *
+     * @param[in] other HyperLogLog instance to be merged
+     * 
+     * @exception std::invalid_argument number of registers doesn't match.
+     */
+    void merge(const HyperLogLog& other) throw (std::invalid_argument) {
+        if (m_ != other.m_) {
+            std::stringstream ss;
+            ss << "number of registers doesn't match: " << m_ << " != " << other.m_;
+            throw std::invalid_argument(ss.str().c_str());
+        }
+        for (uint32_t r = 0; r < m_; ++r) {
+            if (M_[r] < other.M_[r]) {
+                M_[r] |= other.M_[r];
+            }
+        }
+    }
+
+    /**
+     * Clears all internal registers.
+     */
+    void clear() {
+        std::fill(M_.begin(), M_.end(), 0);
+    }
+
+    /**
+     * Returns size of register.
+     *
+     * @return Register size
+     */
+    uint32_t registerSize() const {
+        return m_;
+    }
+
+    /**
+     * Exchanges the content of the instance
+     *
+     * @param[in,out] rhs Another HyperLogLog instance
+     */
+    void swap(HyperLogLog& rhs) {
+        std::swap(b_, rhs.b_);
+        std::swap(m_, rhs.m_);
+        std::swap(alphaMM_, rhs.alphaMM_);
+        M_.swap(rhs.M_);       
+    }
+
+    /**
+     * Dump the current status to a stream
+     *
+     * @param[out] os The output stream where the data is saved
+     *
+     * @exception std::runtime_error When failed to dump.
+     */
+    void dump(std::ostream& os) const throw(std::runtime_error){
+        os.write((char*)&b_, sizeof(b_));
+        os.write((char*)&M_[0], sizeof(M_[0]) * M_.size());
+        if(os.fail()){
+            throw std::runtime_error("Failed to dump");
+        }
+    }
+
+    /**
+     * Restore the status from a stream
+     * 
+     * @param[in] is The input stream where the status is saved
+     *
+     * @exception std::runtime_error When failed to restore.
+     */
+    void restore(std::istream& is) throw(std::runtime_error){
+        uint8_t b = 0;
+        is.read((char*)&b, sizeof(b));
+        HyperLogLog tempHLL(b);
+        is.read((char*)&(tempHLL.M_[0]), sizeof(M_[0]) * tempHLL.m_);
+        if(is.fail()){
+           throw std::runtime_error("Failed to restore");
+        }       
+        swap(tempHLL);
+    }
+
+protected:
+    uint8_t b_; ///< register bit width
+    uint32_t m_; ///< register size
+    double alphaMM_; ///< alpha * m^2
+    std::vector<uint8_t> M_; ///< registers
+};
+
+/**
+ * @brief HIP estimator on HyperLogLog counter.
+ */
+class HyperLogLogHIP : public HyperLogLog {
+public:
+
+    /**
+     * Constructor
+     *
+     * @param[in] b bit width (register size will be 2 to the b power).
+     *            This value must be in the range[4,30].Default value is 4.
+     *
+     * @exception std::invalid_argument the argument is out of range.
+     */
+    HyperLogLogHIP(uint8_t b = 4) throw (std::invalid_argument) : HyperLogLog(b), register_limit_((1 << 5) - 1), c_(0.0), p_(1 << b) {
+    }
+
+    /**
+     * Adds element to the estimator
+     *
+     * @param[in] str string to add
+     * @param[in] len length of string
+     */
+    void add(const char* str, uint32_t len) {
+        uint32_t hash;
+        MurmurHash3_x86_32(str, len, HLL_HASH_SEED, (void*) &hash);
+        uint32_t index = hash >> (32 - b_);
+        uint8_t rank = _GET_CLZ((hash << b_), 32 - b_);
+        rank = rank == 0 ? register_limit_ : std::min(register_limit_, rank);
+        const uint8_t old = M_[index];
+        if (rank > old) {
+            c_ += 1.0 / (p_/m_);
+            p_ -= 1.0/(1 << old);
+            M_[index] = rank;
+            if(rank < 31){
+                p_ += 1.0/(uint32_t(1) << rank);
+            }
+        }
+    }
+
+    /**
+     * Estimates cardinality value.
+     *
+     * @return Estimated cardinality value.
+     */
+    double estimate() const {
+        return c_;
+    }
+
+    /**
+     * Merges the estimate from 'other' into this object, returning the estimate of their union.
+     * The number of registers in each must be the same.
+     *
+     * @param[in] other HyperLogLog instance to be merged
+     * 
+     * @exception std::invalid_argument number of registers doesn't match.
+     */
+    void merge(const HyperLogLogHIP& other) throw (std::invalid_argument) {
+        if (m_ != other.m_) {
+            std::stringstream ss;
+            ss << "number of registers doesn't match: " << m_ << " != " << other.m_;
+            throw std::invalid_argument(ss.str().c_str());
+        }
+        for (uint32_t r = 0; r < m_; ++r) {
+            const uint8_t b = M_[r];
+            const uint8_t b_other = other.M_[r];
+            if (b < b_other) {
+                c_ += 1.0 / (p_/m_);
+                p_ -= 1.0/(1 << b);
+                M_[r] |= b_other;
+                if(b_other < register_limit_){
+                    p_ += 1.0/(1 << b_other);
+                }
+            }
+        }
+    }
+
+    /**
+     * Clears all internal registers.
+     */
+    void clear() {
+        std::fill(M_.begin(), M_.end(), 0);
+        c_ = 0.0;
+        p_ = 1 << b_;
+    }
+
+    /**
+     * Returns size of register.
+     *
+     * @return Register size
+     */
+    uint32_t registerSize() const {
+        return m_;
+    }
+
+    /**
+     * Exchanges the content of the instance
+     *
+     * @param[in,out] rhs Another HyperLogLog instance
+     */
+    void swap(HyperLogLogHIP& rhs) {
+        std::swap(b_, rhs.b_);
+        std::swap(m_, rhs.m_);
+        std::swap(c_, rhs.c_);
+        M_.swap(rhs.M_);       
+    }
+
+    /**
+     * Dump the current status to a stream
+     *
+     * @param[out] os The output stream where the data is saved
+     *
+     * @exception std::runtime_error When failed to dump.
+     */
+    void dump(std::ostream& os) const throw(std::runtime_error){
+        os.write((char*)&b_, sizeof(b_));
+        os.write((char*)&M_[0], sizeof(M_[0]) * M_.size());
+        os.write((char*)&c_, sizeof(c_));
+        os.write((char*)&p_, sizeof(p_));
+        if(os.fail()){
+            throw std::runtime_error("Failed to dump");
+        }
+    }
+
+    /**
+     * Restore the status from a stream
+     * 
+     * @param[in] is The input stream where the status is saved
+     *
+     * @exception std::runtime_error When failed to restore.
+     */
+    void restore(std::istream& is) throw(std::runtime_error){
+        uint8_t b = 0;
+        is.read((char*)&b, sizeof(b));
+        HyperLogLogHIP tempHLL(b);
+        is.read((char*)&(tempHLL.M_[0]), sizeof(M_[0]) * tempHLL.m_);
+        is.read((char*)&(tempHLL.c_), sizeof(double));
+        is.read((char*)&(tempHLL.p_), sizeof(double));
+        if(is.fail()){
+           throw std::runtime_error("Failed to restore");
+        }       
+        swap(tempHLL);
+    }
+private: 
+    const uint8_t register_limit_;
+    double c_;
+    double p_;
+};
+
+} // namespace hll
+
+#endif // !defined(HYPERLOGLOG_HPP)

--- a/ext/hyperloglog.hpp
+++ b/ext/hyperloglog.hpp
@@ -7,6 +7,17 @@
  * @brief HyperLogLog cardinality estimator
  * @date Created 2013/3/20
  * @author Hideaki Ohno
+ * 
+ * (The MIT License)
+
+Copyright (c) 2013 Hideaki Ohno <hide.o.j55{at}gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
  */
 
 #include <vector>

--- a/ext/murmur3.cc
+++ b/ext/murmur3.cc
@@ -1,0 +1,75 @@
+#include "murmur3.h"
+#include <iostream>
+#include <unistd.h>
+
+//-----------------------------------------------------------------------------
+// Finalization mix - force all bits of a hash block to avalanche
+
+uint32_t fmix32( uint32_t h )
+{
+  h ^= h >> 16;
+  h *= 0x85ebca6b;
+  h ^= h >> 13;
+  h *= 0xc2b2ae35;
+  h ^= h >> 16;
+
+  return h;
+}
+
+//-----------------------------------------------------------------------------
+
+
+void MurmurHash3_x86_32( const void * key, int len, uint32_t seed, void * out )
+{
+  const uint8_t * data = (const uint8_t*)key;
+  const int nblocks = len / 4;
+  int i;
+
+  uint32_t h1 = seed;
+
+  uint32_t c1 = 0xcc9e2d51;
+  uint32_t c2 = 0x1b873593;
+
+  //----------
+  // body
+
+  const uint32_t * blocks = (const uint32_t *)(data + nblocks*4);
+
+  for(i = -nblocks; i; i++)
+  {
+    uint32_t k1 = getblock(blocks,i);
+
+    k1 *= c1;
+    k1 = ROTL32(k1,15);
+    k1 *= c2;
+
+    h1 ^= k1;
+    h1 = ROTL32(h1,13);
+    h1 = h1*5+0xe6546b64;
+  }
+
+  //----------
+  // tail
+  {
+    const uint8_t * tail = (const uint8_t*)(data + nblocks*4);
+    
+    uint32_t k1 = 0;
+    
+    switch(len & 3)
+    {
+    case 3: k1 ^= tail[2] << 16;
+    case 2: k1 ^= tail[1] << 8;
+    case 1: k1 ^= tail[0];
+            k1 *= c1; k1 = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
+    };
+  }
+
+  //----------
+  // finalization
+
+  h1 ^= len;
+
+  h1 = fmix32(h1);
+
+  *(uint32_t*)out = h1;
+}

--- a/ext/murmur3.cc
+++ b/ext/murmur3.cc
@@ -1,3 +1,12 @@
+//-----------------------------------------------------------------------------
+// MurmurHash3 was written by Austin Appleby, and is placed in the public
+// domain. The author hereby disclaims copyright to this source code.
+
+// Note - The x86 and x64 versions do _not_ produce the same results, as the
+// algorithms are optimized for their respective platforms. You can still
+// compile and run any of them on any platform, but your performance with the
+// non-native version will be less than optimal.
+
 #include "murmur3.h"
 #include <iostream>
 #include <unistd.h>

--- a/ext/murmur3.h
+++ b/ext/murmur3.h
@@ -1,0 +1,89 @@
+#pragma once
+#ifndef MURMUR3_H
+#define MURMUR3_H
+
+//-----------------------------------------------------------------------------
+// MurmurHash3 was written by Austin Appleby, and is placed in the public
+// domain. The author hereby disclaims copyright to this source code.
+
+// Note - The x86 and x64 versions do _not_ produce the same results, as the
+// algorithms are optimized for their respective platforms. You can still
+// compile and run any of them on any platform, but your performance with the
+// non-native version will be less than optimal.
+
+//-----------------------------------------------------------------------------
+// Platform-specific functions and macros
+
+// Microsoft Visual Studio
+
+#if defined(_MSC_VER)
+
+typedef unsigned char uint8_t;
+typedef unsigned long uint32_t;
+typedef unsigned __int64 uint64_t;
+
+// Other compilers
+
+#else   // defined(_MSC_VER)
+
+#include <stdint.h>
+
+#endif // !defined(_MSC_VER)
+
+#define FORCE_INLINE __attribute__((always_inline))
+
+inline uint32_t rotl32 ( uint32_t x, uint8_t r )
+{
+  return (x << r) | (x >> (32 - r));
+}
+
+#define ROTL32(x,y) rotl32(x,y)
+
+#define BIG_CONSTANT(x) (x##LLU)
+
+/* NO-OP for little-endian platforms */
+#if defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__)
+# if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#   define BYTESWAP(x) (x)
+# endif
+/* if __BYTE_ORDER__ is not predefined (like FreeBSD), use arch */
+#elif defined(__i386)  || defined(__x86_64) \
+  ||  defined(__alpha) || defined(__vax)
+
+# define BYTESWAP(x) (x)
+/* use __builtin_bswap32 if available */
+#elif defined(__GNUC__) || defined(__clang__)
+#ifdef __has_builtin
+#if __has_builtin(__builtin_bswap32)
+#define BYTESWAP(x) __builtin_bswap32(x)
+#endif // __has_builtin(__builtin_bswap32)
+#endif // __has_builtin
+#endif // defined(__GNUC__) || defined(__clang__)
+/* last resort (big-endian w/o __builtin_bswap) */
+#ifndef BYTESWAP
+# define BYTESWAP(x)   ((((x)&0xFF)<<24) \
+         |(((x)>>24)&0xFF) \
+         |(((x)&0x0000FF00)<<8)    \
+         |(((x)&0x00FF0000)>>8)    )
+#endif
+
+//-----------------------------------------------------------------------------
+// Block read - if your platform needs to do endian-swapping or can only
+// handle aligned reads, do the conversion here
+
+#define getblock(p, i) BYTESWAP(p[i])
+
+//-----------------------------------------------------------------------------
+// Finalization mix - force all bits of a hash block to avalanche
+
+uint32_t fmix32( uint32_t h );
+
+//-----------------------------------------------------------------------------
+
+#ifdef __cplusplus
+extern "C"
+#else
+extern
+#endif
+void MurmurHash3_x86_32( const void * key, int len, uint32_t seed, void * out );
+#endif

--- a/twmap.cc
+++ b/twmap.cc
@@ -1,0 +1,93 @@
+#include "twmap.hh"
+#include <iostream>
+
+static TWStatsTypeMap g_field_types;
+
+template <typename T>
+bool TWStatsDB<T>::setFields(std::shared_ptr<FieldMap> fieldsp)
+{
+  for (auto f : *fieldsp) {
+    if (g_field_types.type_map.find(f.second) == g_field_types.type_map.end()) {
+      return false;
+    }
+  }
+  field_map = fieldsp; // copy - only small
+  return true;
+}
+
+template <typename T>
+bool TWStatsDB<T>::find_create_key_field(const T& key, const std::string& field_name, std::vector<TWStatsMemberP>& ret_vec)
+{
+  // first check if the field name is in the field map - if not we throw the query out straight away
+  auto myfield = field_map->find(field_name);
+  if (myfield == field_map->end())
+    return false;
+
+  // Now we get the field type from the registered field types map
+  auto mytype = g_field_types.type_map.find(myfield->second);
+  if (mytype == g_field_types.type_map.end())
+    return false;
+
+  // otherwise look to see if the key and field name have been already inserted
+  auto mysdb = stats_db.find(key);
+  if (mysdb != stats_db.end()) {
+    // the key already exists let's look for the field
+    auto myfm = mysdb->second.find(field_name);
+    if (myfm != mysdb->second.end()) {
+      // awesome this key/field combination has already been created
+      auto mystats = myfm->second;
+      ret_vec = mystats;
+      return true;
+    }
+    else {
+      // if we get here it means the key exists, but not the field so we need to add it
+      auto mystat = mytype->second;
+      for (int i=0; i< num_windows; i++) {
+	ret_vec.push_back(mystat());
+      }
+      mysdb->second.insert(std::pair<std::string, std::vector<TWStatsMemberP>>(field_name, ret_vec));
+    }
+  }
+  else {
+    // if we get here, we have no key and no field
+    auto mystat = mytype->second;
+    for (int i=0; i< num_windows; i++) {
+      ret_vec.push_back(mystat());
+    }
+    std::map<std::string, std::vector<TWStatsMemberP>> myfm;
+    myfm.insert(std::pair<std::string, std::vector<TWStatsMemberP>>(field_name, ret_vec));
+    stats_db.insert(std::pair<T, std::map<std::string, std::vector<TWStatsMemberP>>>(key, myfm));
+  }
+  return true;
+}
+
+template <typename T>
+int TWStatsDB<T>::incr(const T& key, const std::string& field_name)
+{
+  std::vector<TWStatsMemberP> myvec;
+
+  if (find_create_key_field(key, field_name, myvec) != true) {
+    return 0;
+  }
+}
+
+
+main (int argc, char** argv)
+{
+  auto ap=createInstance<TWStatsMemberInt>();
+  auto bp=createInstance<TWStatsMemberInt>();
+  std::vector<TWStatsMemberP> vec;
+
+  ap->add(10);
+  bp->add(10);
+  vec.push_back(ap);
+  vec.push_back(bp);
+
+  // std::cout << ap->sum(vec) << "\n";
+
+  TWStatsDB<std::string> sdb(600,6);
+  auto field_map = std::make_shared<FieldMap>();
+  (*field_map)[std::string("numWidgets")] = std::string("int");
+  sdb.setFields(field_map);
+  sdb.incr("neil.cook", "numWidgets");
+}

--- a/twmap.cc
+++ b/twmap.cc
@@ -1,5 +1,6 @@
 #include "twmap.hh"
 #include <iostream>
+#include <unistd.h>
 
 static TWStatsTypeMap g_field_types;
 
@@ -16,8 +17,35 @@ bool TWStatsDB<T>::setFields(std::shared_ptr<FieldMap> fieldsp)
 }
 
 template <typename T>
-bool TWStatsDB<T>::find_create_key_field(const T& key, const std::string& field_name, std::vector<TWStatsMemberP>& ret_vec)
+void TWStatsDB<T>::clean_windows(TWStatsBuf& twsb)
 {
+  // this function checks the time difference since each array member was first written
+  // and expires (zeros) any windows as necessary. This needs to be done before any data is read or written
+  std::time_t now, expire_diff;
+  std::time(&now);
+  expire_diff = window_size * num_windows;
+
+  for (TWStatsBuf::iterator i = twsb.begin(); i != twsb.end(); ++i) {
+    std::time_t last_write = i->first;
+    auto sm = i->second;
+    if ((last_write != 0) && (now - last_write) >= expire_diff) {
+      sm->erase();
+      i->first = 0;
+    }
+  }
+}
+
+template <typename T>
+bool TWStatsDB<T>::find_key_field(const T& key, const std::string& field_name, TWStatsBuf*& ret_vec)
+{
+  return find_create_key_field(key, field_name, ret_vec, false);
+}
+
+template <typename T>
+bool TWStatsDB<T>::find_create_key_field(const T& key, const std::string& field_name, TWStatsBuf*& ret_vec, 
+					 bool create)
+{
+  TWStatsBuf myrv;
   // first check if the field name is in the field map - if not we throw the query out straight away
   auto myfield = field_map->find(field_name);
   if (myfield == field_map->end())
@@ -35,59 +63,203 @@ bool TWStatsDB<T>::find_create_key_field(const T& key, const std::string& field_
     auto myfm = mysdb->second.find(field_name);
     if (myfm != mysdb->second.end()) {
       // awesome this key/field combination has already been created
-      auto mystats = myfm->second;
-      ret_vec = mystats;
-      return true;
+      ret_vec = &(myfm->second);
+      // whenever we retrieve a set of windows, we clean them to remove expired windows
+      clean_windows(myfm->second);
+      cur_window = current_window();
+      return(true);
     }
     else {
-      // if we get here it means the key exists, but not the field so we need to add it
-      auto mystat = mytype->second;
-      for (int i=0; i< num_windows; i++) {
-	ret_vec.push_back(mystat());
+      if (create) {
+	// if we get here it means the key exists, but not the field so we need to add it
+	auto mystat = mytype->second;
+	for (int i=0; i< num_windows; i++) {
+	  myrv.push_back(std::pair<std::time_t, TWStatsMemberP>((std::time_t)0, mystat()));
+	}
+	mysdb->second.insert(std::pair<std::string, TWStatsBuf>(field_name, myrv));
       }
-      mysdb->second.insert(std::pair<std::string, std::vector<TWStatsMemberP>>(field_name, ret_vec));
     }
   }
   else {
-    // if we get here, we have no key and no field
-    auto mystat = mytype->second;
-    for (int i=0; i< num_windows; i++) {
-      ret_vec.push_back(mystat());
+    if (create) {
+      // if we get here, we have no key and no field
+      auto mystat = mytype->second;
+      for (int i=0; i< num_windows; i++) {
+	myrv.push_back(std::pair<std::time_t, TWStatsMemberP>((std::time_t)0, mystat()));
+      }
+      std::map<std::string, TWStatsBuf> myfm;
+      myfm.insert(std::pair<std::string, TWStatsBuf>(field_name, myrv));
+      stats_db.insert(std::pair<T, std::map<std::string, TWStatsBuf>>(key, myfm));
     }
-    std::map<std::string, std::vector<TWStatsMemberP>> myfm;
-    myfm.insert(std::pair<std::string, std::vector<TWStatsMemberP>>(field_name, ret_vec));
-    stats_db.insert(std::pair<T, std::map<std::string, std::vector<TWStatsMemberP>>>(key, myfm));
   }
-  return true;
+  // update the current window
+  cur_window = current_window();
+  // we created the field, now just look it up again so we get the actual pointer not a copy
+  return (find_create_key_field(key, field_name, ret_vec, false));
 }
 
 template <typename T>
 int TWStatsDB<T>::incr(const T& key, const std::string& field_name)
 {
-  std::vector<TWStatsMemberP> myvec;
+  return add(key, field_name, 1);
+}
+
+template <typename T>
+int TWStatsDB<T>::decr(const T& key, const std::string& field_name)
+{
+  return sub(key, field_name, 1);
+}
+
+template <typename T>
+int TWStatsDB<T>::add(const T& key, const std::string& field_name, int a)
+{
+  TWStatsBuf* myvec;
+  std::lock_guard<std::mutex> lock(mutx);
 
   if (find_create_key_field(key, field_name, myvec) != true) {
     return 0;
   }
+  auto sm = (*myvec)[cur_window];
+
+  sm.second->add(a);
+  update_write_timestamp((*myvec)[cur_window]);
+  return sm.second->sum(*myvec);
 }
 
+template <typename T>
+int TWStatsDB<T>::add(const T& key, const std::string& field_name, const std::string& s)
+{
+  TWStatsBuf* myvec;
+  std::lock_guard<std::mutex> lock(mutx);
+
+  if (find_create_key_field(key, field_name, myvec) != true) {
+    return 0;
+  }
+  auto sm = (*myvec)[cur_window];
+
+  sm.second->add(s);
+  update_write_timestamp((*myvec)[cur_window]);
+  return sm.second->sum(*myvec);
+}
+
+template <typename T>
+int TWStatsDB<T>::sub(const T& key, const std::string& field_name, int a)
+{
+  TWStatsBuf* myvec;
+  std::lock_guard<std::mutex> lock(mutx);
+
+  if (find_create_key_field(key, field_name, myvec) != true) {
+    return 0;
+  }
+  auto sm = (*myvec)[cur_window];
+
+  sm.second->sub(a);
+  update_write_timestamp((*myvec)[cur_window]);
+  return sm.second->sum(*myvec);
+}
+
+template <typename T>
+int TWStatsDB<T>::sub(const T& key, const std::string& field_name, const std::string& s)
+{
+  TWStatsBuf* myvec;
+  std::lock_guard<std::mutex> lock(mutx);
+
+  if (find_create_key_field(key, field_name, myvec) != true) {
+    return 0;
+  }
+  auto sm = (*myvec)[cur_window];
+
+  sm.second->sub(s);
+  update_write_timestamp((*myvec)[cur_window]);
+  return sm.second->sum(*myvec);
+}
+
+template <typename T>
+int TWStatsDB<T>::get(const T& key, const std::string& field_name)
+{
+  TWStatsBuf* myvec;
+  std::lock_guard<std::mutex> lock(mutx);
+
+  if (find_key_field(key, field_name, myvec) != true) {
+    return 0;
+  }
+  auto sm = (*myvec)[cur_window];
+
+  return sm.second->sum(*myvec);
+}
+
+template <typename T>
+int TWStatsDB<T>::get_current(const T& key, const std::string& field_name)
+{
+  TWStatsBuf* myvec;
+  std::lock_guard<std::mutex> lock(mutx);
+
+  if (find_key_field(key, field_name, myvec) != true) {
+    return 0;
+  }
+  auto sm = (*myvec)[cur_window];
+
+  return sm.second->get();
+}
+
+template <typename T>
+bool TWStatsDB<T>::get_windows(const T& key, const std::string& field_name, std::vector<int>& ret_vec)
+{
+  TWStatsBuf* myvec;
+  std::lock_guard<std::mutex> lock(mutx);
+
+  if (find_key_field(key, field_name, myvec) != true) {
+    return false;
+  }
+  for (auto sm : (*myvec)) {
+    ret_vec.push_back(sm.second->get());
+  }
+
+  return(true);
+}
+
+#include <string.h>
+#include "hyperloglog.hpp"
 
 main (int argc, char** argv)
 {
-  auto ap=createInstance<TWStatsMemberInt>();
-  auto bp=createInstance<TWStatsMemberInt>();
-  std::vector<TWStatsMemberP> vec;
-
-  ap->add(10);
-  bp->add(10);
-  vec.push_back(ap);
-  vec.push_back(bp);
-
-  // std::cout << ap->sum(vec) << "\n";
-
-  TWStatsDB<std::string> sdb(600,6);
+  TWStatsDB<std::string> sdb(1,60);
   auto field_map = std::make_shared<FieldMap>();
+
   (*field_map)[std::string("numWidgets")] = std::string("int");
+  (*field_map)[std::string("diffWidgets")] = std::string("hll");
   sdb.setFields(field_map);
-  sdb.incr("neil.cook", "numWidgets");
+
+  // test integers
+  for (int i=0; i<10; i++) {
+    sdb.incr("neil.cook", "numWidgets");
+    sdb.incr("neil.cook", "numWidgets");
+    int k = sdb.decr("neil.cook", "numWidgets");
+    sleep(1);
+    // std::cout << k << "\n";
+  }
+  std::cout << "get_current is " << sdb.get_current("neil.cook", "numWidgets") << "\n";
+  std::cout << "get is " << sdb.get("neil.cook", "numWidgets") << "\n";
+  std::vector<int> vec;
+  sdb.get_windows("neil.cook", "numWidgets", vec);
+  for (auto i : vec) {
+    std::cout << "window has value " << i << "\n";
+  }  
+
+  // test hyperloglog
+  for (int i=0; i<10; i++) {
+    sdb.add("neil.cook", "diffWidgets", "widget1");
+    sdb.add("neil.cook", "diffWidgets", "widget2");
+    sdb.add("neil.cook", "diffWidgets", "widget3");
+    sleep(1);
+    // std::cout << k << "\n";
+  }
+  std::cout << "get_current is " << sdb.get_current("neil.cook", "diffWidgets") << "\n";
+  std::cout << "get is " << sdb.get("neil.cook", "diffWidgets") << "\n";
+  vec.clear();
+  sdb.get_windows("neil.cook", "diffWidgets", vec);
+  for (auto i : vec) {
+    std::cout << "window has value " << i << "\n";
+  }  
+  
 }

--- a/twmap.cc
+++ b/twmap.cc
@@ -2,264 +2,80 @@
 #include <iostream>
 #include <unistd.h>
 
-static TWStatsTypeMap g_field_types;
+TWStatsTypeMap g_field_types{};
 
-template <typename T>
-bool TWStatsDB<T>::setFields(std::shared_ptr<FieldMap> fieldsp)
-{
-  for (auto f : *fieldsp) {
-    if (g_field_types.type_map.find(f.second) == g_field_types.type_map.end()) {
-      return false;
-    }
-  }
-  field_map = fieldsp; // copy - only small
-  return true;
-}
-
-template <typename T>
-void TWStatsDB<T>::clean_windows(TWStatsBuf& twsb)
-{
-  // this function checks the time difference since each array member was first written
-  // and expires (zeros) any windows as necessary. This needs to be done before any data is read or written
-  std::time_t now, expire_diff;
-  std::time(&now);
-  expire_diff = window_size * num_windows;
-
-  for (TWStatsBuf::iterator i = twsb.begin(); i != twsb.end(); ++i) {
-    std::time_t last_write = i->first;
-    auto sm = i->second;
-    if ((last_write != 0) && (now - last_write) >= expire_diff) {
-      sm->erase();
-      i->first = 0;
-    }
-  }
-}
-
-template <typename T>
-bool TWStatsDB<T>::find_key_field(const T& key, const std::string& field_name, TWStatsBuf*& ret_vec)
-{
-  return find_create_key_field(key, field_name, ret_vec, false);
-}
-
-template <typename T>
-bool TWStatsDB<T>::find_create_key_field(const T& key, const std::string& field_name, TWStatsBuf*& ret_vec, 
-					 bool create)
-{
-  TWStatsBuf myrv;
-  // first check if the field name is in the field map - if not we throw the query out straight away
-  auto myfield = field_map->find(field_name);
-  if (myfield == field_map->end())
-    return false;
-
-  // Now we get the field type from the registered field types map
-  auto mytype = g_field_types.type_map.find(myfield->second);
-  if (mytype == g_field_types.type_map.end())
-    return false;
-
-  // otherwise look to see if the key and field name have been already inserted
-  auto mysdb = stats_db.find(key);
-  if (mysdb != stats_db.end()) {
-    // the key already exists let's look for the field
-    auto myfm = mysdb->second.find(field_name);
-    if (myfm != mysdb->second.end()) {
-      // awesome this key/field combination has already been created
-      ret_vec = &(myfm->second);
-      // whenever we retrieve a set of windows, we clean them to remove expired windows
-      clean_windows(myfm->second);
-      cur_window = current_window();
-      return(true);
-    }
-    else {
-      if (create) {
-	// if we get here it means the key exists, but not the field so we need to add it
-	auto mystat = mytype->second;
-	for (int i=0; i< num_windows; i++) {
-	  myrv.push_back(std::pair<std::time_t, TWStatsMemberP>((std::time_t)0, mystat()));
-	}
-	mysdb->second.insert(std::pair<std::string, TWStatsBuf>(field_name, myrv));
-      }
-    }
-  }
-  else {
-    if (create) {
-      // if we get here, we have no key and no field
-      auto mystat = mytype->second;
-      for (int i=0; i< num_windows; i++) {
-	myrv.push_back(std::pair<std::time_t, TWStatsMemberP>((std::time_t)0, mystat()));
-      }
-      std::map<std::string, TWStatsBuf> myfm;
-      myfm.insert(std::pair<std::string, TWStatsBuf>(field_name, myrv));
-      stats_db.insert(std::pair<T, std::map<std::string, TWStatsBuf>>(key, myfm));
-    }
-  }
-  // update the current window
-  cur_window = current_window();
-  // we created the field, now just look it up again so we get the actual pointer not a copy
-  return (find_create_key_field(key, field_name, ret_vec, false));
-}
-
-template <typename T>
-int TWStatsDB<T>::incr(const T& key, const std::string& field_name)
-{
-  return add(key, field_name, 1);
-}
-
-template <typename T>
-int TWStatsDB<T>::decr(const T& key, const std::string& field_name)
-{
-  return sub(key, field_name, 1);
-}
-
-template <typename T>
-int TWStatsDB<T>::add(const T& key, const std::string& field_name, int a)
-{
-  TWStatsBuf* myvec;
-  std::lock_guard<std::mutex> lock(mutx);
-
-  if (find_create_key_field(key, field_name, myvec) != true) {
-    return 0;
-  }
-  auto sm = (*myvec)[cur_window];
-
-  sm.second->add(a);
-  update_write_timestamp((*myvec)[cur_window]);
-  return sm.second->sum(*myvec);
-}
-
-template <typename T>
-int TWStatsDB<T>::add(const T& key, const std::string& field_name, const std::string& s)
-{
-  TWStatsBuf* myvec;
-  std::lock_guard<std::mutex> lock(mutx);
-
-  if (find_create_key_field(key, field_name, myvec) != true) {
-    return 0;
-  }
-  auto sm = (*myvec)[cur_window];
-
-  sm.second->add(s);
-  update_write_timestamp((*myvec)[cur_window]);
-  return sm.second->sum(*myvec);
-}
-
-template <typename T>
-int TWStatsDB<T>::sub(const T& key, const std::string& field_name, int a)
-{
-  TWStatsBuf* myvec;
-  std::lock_guard<std::mutex> lock(mutx);
-
-  if (find_create_key_field(key, field_name, myvec) != true) {
-    return 0;
-  }
-  auto sm = (*myvec)[cur_window];
-
-  sm.second->sub(a);
-  update_write_timestamp((*myvec)[cur_window]);
-  return sm.second->sum(*myvec);
-}
-
-template <typename T>
-int TWStatsDB<T>::sub(const T& key, const std::string& field_name, const std::string& s)
-{
-  TWStatsBuf* myvec;
-  std::lock_guard<std::mutex> lock(mutx);
-
-  if (find_create_key_field(key, field_name, myvec) != true) {
-    return 0;
-  }
-  auto sm = (*myvec)[cur_window];
-
-  sm.second->sub(s);
-  update_write_timestamp((*myvec)[cur_window]);
-  return sm.second->sum(*myvec);
-}
-
-template <typename T>
-int TWStatsDB<T>::get(const T& key, const std::string& field_name)
-{
-  TWStatsBuf* myvec;
-  std::lock_guard<std::mutex> lock(mutx);
-
-  if (find_key_field(key, field_name, myvec) != true) {
-    return 0;
-  }
-  auto sm = (*myvec)[cur_window];
-
-  return sm.second->sum(*myvec);
-}
-
-template <typename T>
-int TWStatsDB<T>::get_current(const T& key, const std::string& field_name)
-{
-  TWStatsBuf* myvec;
-  std::lock_guard<std::mutex> lock(mutx);
-
-  if (find_key_field(key, field_name, myvec) != true) {
-    return 0;
-  }
-  auto sm = (*myvec)[cur_window];
-
-  return sm.second->get();
-}
-
-template <typename T>
-bool TWStatsDB<T>::get_windows(const T& key, const std::string& field_name, std::vector<int>& ret_vec)
-{
-  TWStatsBuf* myvec;
-  std::lock_guard<std::mutex> lock(mutx);
-
-  if (find_key_field(key, field_name, myvec) != true) {
-    return false;
-  }
-  for (auto sm : (*myvec)) {
-    ret_vec.push_back(sm.second->get());
-  }
-
-  return(true);
-}
-
+#ifdef MAIN
 #include <string.h>
-#include "hyperloglog.hpp"
 
 main (int argc, char** argv)
 {
-  TWStatsDB<std::string> sdb(1,60);
-  auto field_map = std::make_shared<FieldMap>();
+  FieldMap field_map;
 
-  (*field_map)[std::string("numWidgets")] = std::string("int");
-  (*field_map)[std::string("diffWidgets")] = std::string("hll");
-  sdb.setFields(field_map);
+  std::cout << std::lround(3.9) << "\n";
+
+  field_map[std::string("numWidgets")] = std::string("int");
+  field_map[std::string("diffWidgets")] = std::string("hll");
+  field_map[std::string("numWidgetTypes")] = std::string("countmin");
+
+  auto sw = TWStringStatsDBWrapper(1, 60);
+  sw.setFields(field_map);
 
   // test integers
   for (int i=0; i<10; i++) {
-    sdb.incr("neil.cook", "numWidgets");
-    sdb.incr("neil.cook", "numWidgets");
-    int k = sdb.decr("neil.cook", "numWidgets");
+    sw.sdbp->add("neil.cook", "numWidgets", 1);
+    sw.sdbp->add("neil.cook", "numWidgets", 1);
+    int k = sw.sdbp->sub("neil.cook", "numWidgets", 1);
     sleep(1);
     // std::cout << k << "\n";
   }
-  std::cout << "get_current is " << sdb.get_current("neil.cook", "numWidgets") << "\n";
-  std::cout << "get is " << sdb.get("neil.cook", "numWidgets") << "\n";
+  std::cout << "get_current is " << sw.sdbp->get_current("neil.cook", "numWidgets") << "\n";
+  std::cout << "get is " << sw.sdbp->get("neil.cook", "numWidgets") << "\n";
   std::vector<int> vec;
-  sdb.get_windows("neil.cook", "numWidgets", vec);
+  sw.sdbp->get_windows("neil.cook", "numWidgets", vec);
   for (auto i : vec) {
     std::cout << "window has value " << i << "\n";
   }  
 
   // test hyperloglog
   for (int i=0; i<10; i++) {
-    sdb.add("neil.cook", "diffWidgets", "widget1");
-    sdb.add("neil.cook", "diffWidgets", "widget2");
-    sdb.add("neil.cook", "diffWidgets", "widget3");
+    sw.sdbp->add("neil.cook", "diffWidgets", "widget1");
+    sw.sdbp->add("neil.cook", "diffWidgets", "widget2");
+    sw.sdbp->add("neil.cook", "diffWidgets", "widget3");
+    sw.sdbp->add("neil.cook", "diffWidgets", "widget4");
     sleep(1);
     // std::cout << k << "\n";
   }
-  std::cout << "get_current is " << sdb.get_current("neil.cook", "diffWidgets") << "\n";
-  std::cout << "get is " << sdb.get("neil.cook", "diffWidgets") << "\n";
+  std::cout << "get_current is " << sw.sdbp->get_current("neil.cook", "diffWidgets") << "\n";
+  std::cout << "get is " << sw.sdbp->get("neil.cook", "diffWidgets") << "\n";
   vec.clear();
-  sdb.get_windows("neil.cook", "diffWidgets", vec);
+  sw.sdbp->get_windows("neil.cook", "diffWidgets", vec);
   for (auto i : vec) {
     std::cout << "window has value " << i << "\n";
   }  
-  
+
+  // test countmin
+  for (int i=0; i<10; i++) {
+    sw.sdbp->add("neil.cook", "numWidgetTypes", "widget1", 20);
+    sw.sdbp->add("neil.cook", "numWidgetTypes", "widget2", 40);
+    sw.sdbp->add("neil.cook", "numWidgetTypes", "widget3", 60);
+    sleep(1);
+    // std::cout << k << "\n";
+  }
+  std::cout << "get_current is " << sw.sdbp->get_current("neil.cook", "numWidgetTypes") << "\n";
+  std::cout << "get is " << sw.sdbp->get("neil.cook", "numWidgetTypes") << "\n";
+  std::cout << "get widget1 is " << sw.sdbp->get("neil.cook", "numWidgetTypes", "widget1") << "\n";
+  std::cout << "get widget2 is " << sw.sdbp->get("neil.cook", "numWidgetTypes", "widget2") << "\n";
+  std::cout << "get widget2 is " << sw.sdbp->get("neil.cook", "numWidgetTypes", "widget3") << "\n";
+  std::cout << "get nonExistent is " << sw.sdbp->get("neil.cook", "numWidgetTypes", "nonExistent") << "\n";
+  std::cout << "get nonExistent key is " << sw.sdbp->get("dddneil.cook", "numWidgetTypes", "nonExistent") << "\n";
+  std::cout << "get nonExistent field is " << sw.sdbp->get("neil.cook", "dddnumWidgetTypes", "nonExistent") << "\n";
+  vec.clear();
+  sw.sdbp->get_windows("neil.cook", "numWidgetTypes", vec);
+  for (auto i : vec) {
+    std::cout << "window has value " << i << "\n";
+  }  
+
+
 }
+
+#endif

--- a/twmap.hh
+++ b/twmap.hh
@@ -1,0 +1,105 @@
+#include <string>
+#include <vector>
+#include <memory>
+#include <map>
+#include <ctime>
+
+class TWStatsMember;
+
+typedef std::shared_ptr<TWStatsMember> TWStatsMemberP;
+
+// Not all stats member subclasses will implement all of these methods in a useful way (e.g. incr is meaningless to a hll)
+class TWStatsMember
+{
+public:
+  virtual int incr() = 0; // add 1 to the stored value
+  virtual int decr() = 0; // subtract 1 from the stored value
+  virtual int add(int a) = 0; // add an integer to the stored value
+  virtual int add(const std::string& s) = 0; // add a string to the stored window (this has different semantics for each subclass)
+  virtual int sub(int a) = 0; // subtract an integer from the stored value
+  virtual int sub(const std::string& s) = 0; // remove a string from the stored value
+  virtual int get() = 0; // return the current stat
+  virtual void set(int) = 0; // Set the stored value to the supplied integer
+  virtual void set(const std::string& s) = 0; // Set the stored value based on the supplied string
+  virtual int sum(const std::vector<TWStatsMemberP>& vec) = 0; // combine an array of stored values
+};
+
+class TWStatsMemberInt;
+
+typedef std::shared_ptr<TWStatsMemberInt> TWStatsMemberIntP;
+
+class TWStatsMemberInt : public TWStatsMember
+{
+public:
+  int incr() { i++; return i; }
+  int decr() { i--; return i; }
+  int add(int a) { i += a; return i; }
+  int add(const std::string& s) { return i; }
+  int sub(int a) { i -= a; return i; }
+  int sub(const std::string& s) { return i; }
+  int get() { return i; }
+  void set(int a) { i = a; }
+  void set(const std::string& s) { return; }
+  int sum(const std::vector<TWStatsMemberP>& vec)
+  {
+    int count = 0;
+    for (auto a : vec)
+      {
+        count += a->get();
+      }
+    return count;
+  }
+private:
+  int i=0;
+};
+
+template<typename T> TWStatsMemberP createInstance() { return std::make_shared<T>(); }
+
+typedef std::map<std::string, TWStatsMemberP(*)()> map_type;
+
+// This needs to be instanstiated
+struct TWStatsTypeMap
+{
+  map_type type_map;
+  TWStatsTypeMap()
+  {
+    type_map["int"] = &createInstance<TWStatsMemberInt>;
+  }
+};
+
+// key is field name, value is field type
+typedef std::map<std::string, std::string> FieldMap;
+
+template <typename T>
+class TWStatsDB
+{
+public:
+  explicit TWStatsDB(int w_siz, int num_w)
+  {
+    window_size = w_siz;
+    num_windows = num_w;
+    std::time(&start_time);
+  }
+  bool setFields(std::shared_ptr<FieldMap> fieldsp);
+  int incr(const T& key, const std::string& field_name);
+  int decr(const T& key, const std::string& field_name);
+  int add(const T& key, const std::string& field_name, int a);
+  int add(const T& key, const std::string& field_name, const std::string& s);
+  int sub(const T& key, const std::string& field_name, int a);
+  int sub(const T& key, const std::string& field_name, const std::string& s);
+  int get(const T& key, const std::string& field_name); // gets all fields summed/combined over all windows
+  int get_current(const T& key, const std::string& field_name); // gets the value just for the current window
+  std::vector<int> get_windows(const T& key, const std::string& field_name); // gets each window value returned in a vector
+  void set(const T& key, const std::string& field_name, int a);
+  void set(const T& key, const std::string& field_name, const std::string& s);
+protected:
+  bool find_create_key_field(const T& key, const std::string& field_name, std::vector<TWStatsMemberP>& ret_vecfg
+);
+private:
+  typedef std::map<T, std::map<std::string, std::vector<TWStatsMemberP>>> TWStatsDBMap;
+  TWStatsDBMap stats_db;
+  std::shared_ptr<FieldMap> field_map;
+  int window_size;
+  int num_windows;
+  std::time_t start_time;
+};

--- a/twmap.hh
+++ b/twmap.hh
@@ -1,3 +1,4 @@
+#pragma once
 #include <string>
 #include <vector>
 #include <memory>
@@ -6,26 +7,33 @@
 #include <ctime>
 #include <mutex>
 #include <thread>
+#include <boost/variant.hpp>
+#include <boost/optional.hpp>
 #include "hyperloglog.hpp"
+#include "count_min_sketch.hpp"
+#include "iputils.hh"
 
 class TWStatsMember;
 
 typedef std::shared_ptr<TWStatsMember> TWStatsMemberP;
 typedef std::vector<std::pair<std::time_t, TWStatsMemberP>> TWStatsBuf;
 
-// Not all stats member subclasses will implement all of these methods in a useful way (e.g. incr is meaningless to a hll)
+// Not all stats member subclasses will implement all of these methods in a useful way (e.g. add string is meaningless to an integer-based class)
 class TWStatsMember
 {
 public:
   virtual void add(int a) = 0; // add an integer to the stored value
   virtual void add(const std::string& s) = 0; // add a string to the stored window (this has different semantics for each subclass)
+  virtual void add(const std::string& s, int a) = 0; // add a string/integer combo to the stored window (only applies to some stats types)
   virtual void sub(int a) = 0; // subtract an integer from the stored value
   virtual void sub(const std::string& s) = 0; // remove a string from the stored value
   virtual int get() = 0; // return the current stat
+  virtual int get(const std::string& s) = 0; // return the current stat
   virtual void set(int) = 0; // Set the stored value to the supplied integer
   virtual void set(const std::string& s) = 0; // Set the stored value based on the supplied string
   virtual void erase() = 0; // Remove all data - notice this isn't necessarily the same as set(0) or set("")
   virtual int sum(const TWStatsBuf& vec) = 0; // combine an array of stored values
+  virtual int sum(const std::string& s, const TWStatsBuf& vec) = 0; // combine an array of stored values
 };
 
 class TWStatsMemberInt;
@@ -36,10 +44,12 @@ class TWStatsMemberInt : public TWStatsMember
 {
 public:
   void add(int a) { i += a; }
-  void add(const std::string& s) { return; }
+  void add(const std::string& s) { int a = std::stoi(s); i += a; return; }
+  void add(const std::string& s, int a) { return; }
   void sub(int a) { i -= a;  }
-  void sub(const std::string& s) { return; }
+  void sub(const std::string& s) { int a = std::stoi(s); i += a; return; }
   int get() { return i; }
+  int get(const std::string& s) { return i; }
   void set(int a) { i = a; }
   void set(const std::string& s) { return; }
   void erase() { i = 0; }
@@ -52,6 +62,7 @@ public:
       }
     return count;
   }
+  int sum(const std::string& s, const TWStatsBuf& vec) { return 0; }
 private:
   int i=0;
 };
@@ -67,15 +78,16 @@ public:
   }
   void add(int a) { char buf[64]; int len = snprintf(buf, 63, "%d", a); hllp->add(buf, len); return; }
   void add(const std::string& s) { hllp->add(s.c_str(), s.length()); return; }
+  void add(const std::string& s, int a) { return; }
   void sub(int a) { return; }
   void sub(const std::string& s) { return; }
-  int get() { return hllp->estimate(); }
+  int get() { return std::lround(hllp->estimate()); }
+  int get(const std::string& s) { hllp->add(s.c_str(), s.length()); return std::lround(hllp->estimate()); } // add and return value
   void set(int a) { return; }
   void set(const std::string& s) { hllp->clear(); hllp->add(s.c_str(), s.length()); }
   void erase() { hllp->clear(); }
   int sum(const TWStatsBuf& vec)
   {
-    int count = 0;
     hll::HyperLogLog hllsum(HLL_NUM_REGISTER_BITS);
     for (auto a : vec)
       {
@@ -83,18 +95,62 @@ public:
 	std::shared_ptr<TWStatsMemberHLL> twp = std::dynamic_pointer_cast<TWStatsMemberHLL>(a.second);
 	hllsum.merge((*(twp->hllp)));
       }
-    return hllsum.estimate();
+    return std::lround(hllsum.estimate());
   }
+  int sum(const std::string& s, const TWStatsBuf& vec) { return 0; }
 private:
   std::shared_ptr<hll::HyperLogLog> hllp;
 };
 
+#define COUNTMIN_EPS 0.01
+#define COUNTMIN_GAMMA 0.1
+
+class TWStatsMemberCountMin : public TWStatsMember
+{
+public:
+  TWStatsMemberCountMin()
+  {
+    cm = std::make_shared<CountMinSketch>(COUNTMIN_EPS, COUNTMIN_GAMMA);
+  }
+  void add(int a) { return; }
+  void add(const std::string& s) { return; }
+  void add(const std::string& s, int a) { cm->update(s.c_str(), a); }
+  void sub(int a) { return; }
+  void sub(const std::string& s) { return; }
+  int get() { return cm->totalcount(); }
+  int get(const std::string& s) { return cm->estimate(s.c_str()); }
+  void set(int a) { return; }
+  void set(const std::string& s) { return; }
+  void erase() { return; }
+  int sum(const TWStatsBuf& vec)
+  {
+    int count = 0;
+    for (auto a : vec)
+      {
+	count += a.second->get();
+      }
+    return count;
+  }
+  int sum(const std::string&s, const TWStatsBuf& vec)
+  {
+    int count = 0;
+    for (auto a : vec)
+      {
+	count += a.second->get(s);
+      }
+    return count;
+  }
+private:
+  std::shared_ptr<CountMinSketch> cm;
+};
 
 template<typename T> TWStatsMemberP createInstance() { return std::make_shared<T>(); }
 
 typedef std::map<std::string, TWStatsMemberP(*)()> map_type;
 
+// The idea here is that the type mechanism is extensible, e.g. could add a bloom filter etc.
 // This is instantiated in twmap.cc
+// XXX Should make this dynamically extensible
 struct TWStatsTypeMap
 {
   map_type type_map;
@@ -102,8 +158,11 @@ struct TWStatsTypeMap
   {
     type_map["int"] = &createInstance<TWStatsMemberInt>;
     type_map["hll"] = &createInstance<TWStatsMemberHLL>;
+    type_map["countmin"] = &createInstance<TWStatsMemberCountMin>;
   }
 };
+
+extern TWStatsTypeMap g_field_types;
 
 // key is field name, value is field type
 typedef std::map<std::string, std::string> FieldMap;
@@ -117,17 +176,22 @@ public:
     window_size = w_siz ? w_siz : 1;
     num_windows = num_w ? num_w : 1;
     std::time(&start_time);
+    
   }
-  bool setFields(std::shared_ptr<FieldMap> fieldsp);
+  bool setFields(const FieldMap& fields);
   int incr(const T& key, const std::string& field_name);
   int decr(const T& key, const std::string& field_name);
   int add(const T& key, const std::string& field_name, int a); // returns all fields summed/combined
   int add(const T& key, const std::string& field_name, const std::string& s); // returns all fields summed/combined
+  int add(const T& key, const std::string& field_name, const std::string& s, int a); // returns all fields summed/combined
   int sub(const T& key, const std::string& field_name, int a); // returns all fields summed/combined
   int sub(const T& key, const std::string& field_name, const std::string& s); // returns all fields summed/combined
   int get(const T& key, const std::string& field_name); // gets all fields summed/combined over all windows
+  int get(const T& key, const std::string& field_name, const std::string& s); // gets all fields summed/combined over all windows for a particular value
   int get_current(const T& key, const std::string& field_name); // gets the value just for the current window
+  int get_current(const T& key, const std::string& field_name, const std::string& s); // gets the value just for the current window for a particular value
   bool get_windows(const T& key, const std::string& field_name, std::vector<int>& ret_vec); // gets each window value returned in a vector
+  bool get_windows(const T& key, const std::string& field_name, const std::string& s, std::vector<int>& ret_vec); // gets each window value returned in a vector for a particular value
   void set(const T& key, const std::string& field_name, int a);
   void set(const T& key, const std::string& field_name, const std::string& s);
 protected:
@@ -138,6 +202,7 @@ protected:
     std::time(&now);
     diff = now - start_time;
     int cw = (diff/window_size) % num_windows;
+    return cw;
   }
   void update_write_timestamp(std::pair<std::time_t, TWStatsMemberP>& vec)
   {
@@ -153,10 +218,429 @@ protected:
 private:
   typedef std::unordered_map<T, std::map<std::string, TWStatsBuf>> TWStatsDBMap;
   TWStatsDBMap stats_db;
-  std::shared_ptr<FieldMap> field_map;
+  FieldMap field_map;
   int window_size;
   int num_windows;
   int cur_window = 0;
   std::time_t start_time;
   mutable std::mutex mutx;
 };
+
+// Template methods
+template <typename T>
+bool TWStatsDB<T>::setFields(const FieldMap& fields)
+{
+  for (auto f : fields) {
+    if (g_field_types.type_map.find(f.second) == g_field_types.type_map.end()) {
+      return false;
+    }
+  }
+  field_map = fields;
+  return true;
+}
+
+// XXX this function probably needs to move into a background thread housekeeping task
+// XXX Since I use a circular buffer, it should run at least every window_size seconds
+// XXX If the class was changed to one which just pushed new windows onto the front, we could expire
+// XXX windows off the back in our own time rather than have the restriction of window_size
+template <typename T>
+void TWStatsDB<T>::clean_windows(TWStatsBuf& twsb)
+{
+  // this function checks the time difference since each array member was first written
+  // and expires (zeros) any windows as necessary. This needs to be done before any data is read or written
+  std::time_t now, expire_diff;
+  std::time(&now);
+  expire_diff = window_size * num_windows;
+
+  for (TWStatsBuf::iterator i = twsb.begin(); i != twsb.end(); ++i) {
+    std::time_t last_write = i->first;
+    auto sm = i->second;
+    if ((last_write != 0) && (now - last_write) >= expire_diff) {
+      sm->erase();
+      i->first = 0;
+    }
+  }
+}
+
+template <typename T>
+bool TWStatsDB<T>::find_key_field(const T& key, const std::string& field_name, TWStatsBuf*& ret_vec)
+{
+  return find_create_key_field(key, field_name, ret_vec, false);
+}
+
+template <typename T>
+bool TWStatsDB<T>::find_create_key_field(const T& key, const std::string& field_name, TWStatsBuf*& ret_vec, 
+					 bool create)
+{
+  TWStatsBuf myrv;
+  // first check if the field name is in the field map - if not we throw the query out straight away
+  auto myfield = field_map.find(field_name);
+  if (myfield == field_map.end())
+    return false;
+
+  // Now we get the field type from the registered field types map
+  auto mytype = g_field_types.type_map.find(myfield->second);
+  if (mytype == g_field_types.type_map.end())
+    return false;
+
+  // otherwise look to see if the key and field name have been already inserted
+  auto mysdb = stats_db.find(key);
+  if (mysdb != stats_db.end()) {
+    // the key already exists let's look for the field
+    auto myfm = mysdb->second.find(field_name);
+    if (myfm != mysdb->second.end()) {
+      // awesome this key/field combination has already been created
+      ret_vec = &(myfm->second);
+      // whenever we retrieve a set of windows, we clean them to remove expired windows
+      clean_windows(myfm->second);
+      cur_window = current_window();
+      return(true);
+    }
+    else {
+      if (create) {
+	// if we get here it means the key exists, but not the field so we need to add it
+	auto mystat = mytype->second;
+	for (int i=0; i< num_windows; i++) {
+	  myrv.push_back(std::pair<std::time_t, TWStatsMemberP>((std::time_t)0, mystat()));
+	}
+	mysdb->second.insert(std::pair<std::string, TWStatsBuf>(field_name, myrv));
+      }
+    }
+  }
+  else {
+    if (create) {
+      // if we get here, we have no key and no field
+      auto mystat = mytype->second;
+      for (int i=0; i< num_windows; i++) {
+	myrv.push_back(std::pair<std::time_t, TWStatsMemberP>((std::time_t)0, mystat()));
+      }
+      std::map<std::string, TWStatsBuf> myfm;
+      myfm.insert(std::pair<std::string, TWStatsBuf>(field_name, myrv));
+      stats_db.insert(std::pair<T, std::map<std::string, TWStatsBuf>>(key, myfm));
+    }
+  }
+  // update the current window
+  cur_window = current_window();
+  // we created the field, now just look it up again so we get the actual pointer not a copy
+  if (create)
+    return (find_create_key_field(key, field_name, ret_vec, false));
+  else
+    return(false);
+}
+
+template <typename T>
+int TWStatsDB<T>::incr(const T& key, const std::string& field_name)
+{
+  return add(key, field_name, 1);
+}
+
+template <typename T>
+int TWStatsDB<T>::decr(const T& key, const std::string& field_name)
+{
+  return sub(key, field_name, 1);
+}
+
+template <typename T>
+int TWStatsDB<T>::add(const T& key, const std::string& field_name, int a)
+{
+  TWStatsBuf* myvec;
+  std::lock_guard<std::mutex> lock(mutx);
+
+  if (find_create_key_field(key, field_name, myvec) != true) {
+    return 0;
+  }
+  auto sm = (*myvec)[cur_window];
+
+  sm.second->add(a);
+  update_write_timestamp((*myvec)[cur_window]);
+  return sm.second->sum(*myvec);
+}
+
+template <typename T>
+int TWStatsDB<T>::add(const T& key, const std::string& field_name, const std::string& s)
+{
+  TWStatsBuf* myvec;
+  std::lock_guard<std::mutex> lock(mutx);
+
+  if (find_create_key_field(key, field_name, myvec) != true) {
+    return 0;
+  }
+  auto sm = (*myvec)[cur_window];
+
+  sm.second->add(s);
+  update_write_timestamp((*myvec)[cur_window]);
+  return sm.second->sum(*myvec);
+}
+
+template <typename T>
+int TWStatsDB<T>::add(const T& key, const std::string& field_name, const std::string& s, int a)
+{
+  TWStatsBuf* myvec;
+  std::lock_guard<std::mutex> lock(mutx);
+
+  if (find_create_key_field(key, field_name, myvec) != true) {
+    return 0;
+  }
+  auto sm = (*myvec)[cur_window];
+
+  sm.second->add(s, a);
+  update_write_timestamp((*myvec)[cur_window]);
+  return sm.second->sum(s, *myvec);
+}
+
+template <typename T>
+int TWStatsDB<T>::sub(const T& key, const std::string& field_name, int a)
+{
+  TWStatsBuf* myvec;
+  std::lock_guard<std::mutex> lock(mutx);
+
+  if (find_create_key_field(key, field_name, myvec) != true) {
+    return 0;
+  }
+  auto sm = (*myvec)[cur_window];
+
+  sm.second->sub(a);
+  update_write_timestamp((*myvec)[cur_window]);
+  return sm.second->sum(*myvec);
+}
+
+template <typename T>
+int TWStatsDB<T>::sub(const T& key, const std::string& field_name, const std::string& s)
+{
+  TWStatsBuf* myvec;
+  std::lock_guard<std::mutex> lock(mutx);
+
+  if (find_create_key_field(key, field_name, myvec) != true) {
+    return 0;
+  }
+  auto sm = (*myvec)[cur_window];
+
+  sm.second->sub(s);
+  update_write_timestamp((*myvec)[cur_window]);
+  return sm.second->sum(*myvec);
+}
+
+template <typename T>
+int TWStatsDB<T>::get(const T& key, const std::string& field_name)
+{
+  TWStatsBuf* myvec;
+  std::lock_guard<std::mutex> lock(mutx);
+
+  if (find_key_field(key, field_name, myvec) != true) {
+    return 0;
+  }
+  auto sm = (*myvec)[cur_window];
+
+  return sm.second->sum(*myvec);
+}
+
+template <typename T>
+int TWStatsDB<T>::get(const T& key, const std::string& field_name, const std::string& s)
+{
+  TWStatsBuf* myvec;
+  std::lock_guard<std::mutex> lock(mutx);
+
+  if (find_key_field(key, field_name, myvec) != true) {
+    return 0;
+  }
+  auto sm = (*myvec)[cur_window];
+
+  return sm.second->sum(s, *myvec);
+}
+
+
+template <typename T>
+int TWStatsDB<T>::get_current(const T& key, const std::string& field_name)
+{
+  TWStatsBuf* myvec;
+  std::lock_guard<std::mutex> lock(mutx);
+
+  if (find_key_field(key, field_name, myvec) != true) {
+    return 0;
+  }
+  auto sm = (*myvec)[cur_window];
+
+  return sm.second->get();
+}
+
+template <typename T>
+int TWStatsDB<T>::get_current(const T& key, const std::string& field_name, const std::string& val)
+{
+  TWStatsBuf* myvec;
+  std::lock_guard<std::mutex> lock(mutx);
+
+  if (find_key_field(key, field_name, myvec) != true) {
+    return 0;
+  }
+  auto sm = (*myvec)[cur_window];
+
+  return sm.second->get(val);
+}
+
+
+template <typename T>
+bool TWStatsDB<T>::get_windows(const T& key, const std::string& field_name, std::vector<int>& ret_vec)
+{
+  TWStatsBuf* myvec;
+  std::lock_guard<std::mutex> lock(mutx);
+
+  if (find_key_field(key, field_name, myvec) != true) {
+    return false;
+  }
+  for (auto sm : (*myvec)) {
+    ret_vec.push_back(sm.second->get());
+  }
+
+  return(true);
+}
+
+template <typename T>
+bool TWStatsDB<T>::get_windows(const T& key, const std::string& field_name, const std::string& val, std::vector<int>& ret_vec)
+{
+  TWStatsBuf* myvec;
+  std::lock_guard<std::mutex> lock(mutx);
+
+  if (find_key_field(key, field_name, myvec) != true) {
+    return false;
+  }
+  for (auto sm : (*myvec)) {
+    ret_vec.push_back(sm.second->get(val));
+  }
+
+  return(true);
+}
+
+// This is a Lua-friendly wrapper to the Stats DB
+class TWStringStatsDBWrapper
+{
+public:
+  std::shared_ptr<TWStatsDB<std::string>> sdbp;
+
+  TWStringStatsDBWrapper(int window_size, int num_windows)
+  {
+    sdbp = std::make_shared<TWStatsDB<std::string>>(window_size, num_windows);
+  }
+
+  bool setFields(const FieldMap& fm) 
+  {
+    return(sdbp->setFields(fm));
+  }
+
+  typedef boost::variant<std::string, int, ComboAddress> TWKeyType;
+
+  std::string getStringKey(const TWKeyType vkey)
+  {
+    if (vkey.which() == 0) {
+      return boost::get<std::string>(vkey);
+    }
+    else if (vkey.which() == 1) {
+      return std::to_string(boost::get<int>(vkey));
+    }
+    else if (vkey.which() == 2) {
+      return boost::get<ComboAddress>(vkey).toString();
+    }
+    else
+      return std::string{};
+  }
+
+  void add(const TWKeyType vkey, const std::string& field_name, const boost::variant<std::string, int, ComboAddress>& param1, boost::optional<int> param2) 
+  {
+    std::string key = getStringKey(vkey);
+
+    // we're using the three argument version
+    if (param2) {
+      if ((param1.which() != 0) && (param1.which() != 2))
+	return;
+      else if (param1.which() == 0) {
+	std::string mystr = boost::get<std::string>(param1);
+	sdbp->add(key, field_name, mystr, *param2);
+      }
+      else if (param1.which() == 2) {
+	ComboAddress ca = boost::get<ComboAddress>(param1);
+	sdbp->add(key, field_name, ca.toString(), *param2);
+      }
+    }
+    else {
+      if (param1.which() == 0) {
+	std::string mystr = boost::get<std::string>(param1);
+	sdbp->add(key, field_name, mystr);
+      }
+      else if (param1.which() == 1) {
+	int myint = boost::get<int>(param1);
+	sdbp->add(key, field_name, myint);
+      }
+      else if (param1.which() == 2) {
+	ComboAddress ca = boost::get<ComboAddress>(param1);
+	sdbp->add(key, field_name, ca.toString());
+      }
+    }
+  }
+
+  void sub(const std::string& key, const std::string& field_name, const boost::variant<std::string, int>& val)
+  {
+    if (val.which() == 0) {
+      std::string mystr = boost::get<std::string>(val);
+      sdbp->sub(key, field_name, mystr);
+    }
+    else {
+      int myint = boost::get<int>(val);
+      sdbp->sub(key, field_name, myint);
+    }
+  }
+  
+  int get(const std::string& key, const std::string& field_name, const boost::optional<boost::variant<std::string, ComboAddress>> param1)
+  {
+    if (param1) {
+      if (param1->which() == 0) {
+	std::string s = boost::get<std::string>(*param1);  
+	return sdbp->get(key, field_name, s);
+      }
+      else {
+	ComboAddress ca = boost::get<ComboAddress>(*param1);
+	return sdbp->get(key, field_name, ca.toString());
+      }
+    }
+    else {
+      return sdbp->get(key, field_name);
+    }
+  }
+
+  int get_current(const std::string& key, const std::string& field_name, const boost::optional<boost::variant<std::string, ComboAddress>> param1)
+  {
+    if (param1) {
+      if (param1->which() == 0) {
+	std::string s = boost::get<std::string>(*param1);  
+	return sdbp->get_current(key, field_name, s);
+      }
+      else {
+	ComboAddress ca = boost::get<ComboAddress>(*param1);
+	return sdbp->get_current(key, field_name, ca.toString());
+      }
+    }
+    else {
+      return sdbp->get_current(key, field_name);
+    }
+  }
+
+  std::vector<int> get_windows(const std::string& key, const std::string& field_name, const boost::optional<boost::variant<std::string, ComboAddress>> param1)
+  {
+    std::vector<int> retvec;
+    
+    if (param1) {
+      if (param1->which() == 0) {
+	std::string s = boost::get<std::string>(*param1);  
+	(void) sdbp->get_windows(key, field_name, s, retvec);
+      }
+      else {
+	ComboAddress ca = boost::get<ComboAddress>(*param1);
+	(void) sdbp->get_windows(key, field_name, ca.toString(), retvec);
+      }      
+    }
+    else
+      (void) sdbp->get_windows(key, field_name, retvec);
+
+    return retvec; // copy
+  }
+
+};
+  

--- a/twmap.hh
+++ b/twmap.hh
@@ -2,26 +2,30 @@
 #include <vector>
 #include <memory>
 #include <map>
+#include <unordered_map>
 #include <ctime>
+#include <mutex>
+#include <thread>
+#include "hyperloglog.hpp"
 
 class TWStatsMember;
 
 typedef std::shared_ptr<TWStatsMember> TWStatsMemberP;
+typedef std::vector<std::pair<std::time_t, TWStatsMemberP>> TWStatsBuf;
 
 // Not all stats member subclasses will implement all of these methods in a useful way (e.g. incr is meaningless to a hll)
 class TWStatsMember
 {
 public:
-  virtual int incr() = 0; // add 1 to the stored value
-  virtual int decr() = 0; // subtract 1 from the stored value
-  virtual int add(int a) = 0; // add an integer to the stored value
-  virtual int add(const std::string& s) = 0; // add a string to the stored window (this has different semantics for each subclass)
-  virtual int sub(int a) = 0; // subtract an integer from the stored value
-  virtual int sub(const std::string& s) = 0; // remove a string from the stored value
+  virtual void add(int a) = 0; // add an integer to the stored value
+  virtual void add(const std::string& s) = 0; // add a string to the stored window (this has different semantics for each subclass)
+  virtual void sub(int a) = 0; // subtract an integer from the stored value
+  virtual void sub(const std::string& s) = 0; // remove a string from the stored value
   virtual int get() = 0; // return the current stat
   virtual void set(int) = 0; // Set the stored value to the supplied integer
   virtual void set(const std::string& s) = 0; // Set the stored value based on the supplied string
-  virtual int sum(const std::vector<TWStatsMemberP>& vec) = 0; // combine an array of stored values
+  virtual void erase() = 0; // Remove all data - notice this isn't necessarily the same as set(0) or set("")
+  virtual int sum(const TWStatsBuf& vec) = 0; // combine an array of stored values
 };
 
 class TWStatsMemberInt;
@@ -31,21 +35,20 @@ typedef std::shared_ptr<TWStatsMemberInt> TWStatsMemberIntP;
 class TWStatsMemberInt : public TWStatsMember
 {
 public:
-  int incr() { i++; return i; }
-  int decr() { i--; return i; }
-  int add(int a) { i += a; return i; }
-  int add(const std::string& s) { return i; }
-  int sub(int a) { i -= a; return i; }
-  int sub(const std::string& s) { return i; }
+  void add(int a) { i += a; }
+  void add(const std::string& s) { return; }
+  void sub(int a) { i -= a;  }
+  void sub(const std::string& s) { return; }
   int get() { return i; }
   void set(int a) { i = a; }
   void set(const std::string& s) { return; }
-  int sum(const std::vector<TWStatsMemberP>& vec)
+  void erase() { i = 0; }
+  int sum(const TWStatsBuf& vec)
   {
     int count = 0;
     for (auto a : vec)
       {
-        count += a->get();
+        count += a.second->get();
       }
     return count;
   }
@@ -53,17 +56,52 @@ private:
   int i=0;
 };
 
+#define HLL_NUM_REGISTER_BITS 10
+
+class TWStatsMemberHLL : public TWStatsMember
+{
+public:
+  TWStatsMemberHLL()
+  {
+    hllp = std::make_shared<hll::HyperLogLog>(HLL_NUM_REGISTER_BITS);
+  }
+  void add(int a) { char buf[64]; int len = snprintf(buf, 63, "%d", a); hllp->add(buf, len); return; }
+  void add(const std::string& s) { hllp->add(s.c_str(), s.length()); return; }
+  void sub(int a) { return; }
+  void sub(const std::string& s) { return; }
+  int get() { return hllp->estimate(); }
+  void set(int a) { return; }
+  void set(const std::string& s) { hllp->clear(); hllp->add(s.c_str(), s.length()); }
+  void erase() { hllp->clear(); }
+  int sum(const TWStatsBuf& vec)
+  {
+    int count = 0;
+    hll::HyperLogLog hllsum(HLL_NUM_REGISTER_BITS);
+    for (auto a : vec)
+      {
+	// XXX yes not massively pretty
+	std::shared_ptr<TWStatsMemberHLL> twp = std::dynamic_pointer_cast<TWStatsMemberHLL>(a.second);
+	hllsum.merge((*(twp->hllp)));
+      }
+    return hllsum.estimate();
+  }
+private:
+  std::shared_ptr<hll::HyperLogLog> hllp;
+};
+
+
 template<typename T> TWStatsMemberP createInstance() { return std::make_shared<T>(); }
 
 typedef std::map<std::string, TWStatsMemberP(*)()> map_type;
 
-// This needs to be instanstiated
+// This is instantiated in twmap.cc
 struct TWStatsTypeMap
 {
   map_type type_map;
   TWStatsTypeMap()
   {
     type_map["int"] = &createInstance<TWStatsMemberInt>;
+    type_map["hll"] = &createInstance<TWStatsMemberHLL>;
   }
 };
 
@@ -76,30 +114,49 @@ class TWStatsDB
 public:
   explicit TWStatsDB(int w_siz, int num_w)
   {
-    window_size = w_siz;
-    num_windows = num_w;
+    window_size = w_siz ? w_siz : 1;
+    num_windows = num_w ? num_w : 1;
     std::time(&start_time);
   }
   bool setFields(std::shared_ptr<FieldMap> fieldsp);
   int incr(const T& key, const std::string& field_name);
   int decr(const T& key, const std::string& field_name);
-  int add(const T& key, const std::string& field_name, int a);
-  int add(const T& key, const std::string& field_name, const std::string& s);
-  int sub(const T& key, const std::string& field_name, int a);
-  int sub(const T& key, const std::string& field_name, const std::string& s);
+  int add(const T& key, const std::string& field_name, int a); // returns all fields summed/combined
+  int add(const T& key, const std::string& field_name, const std::string& s); // returns all fields summed/combined
+  int sub(const T& key, const std::string& field_name, int a); // returns all fields summed/combined
+  int sub(const T& key, const std::string& field_name, const std::string& s); // returns all fields summed/combined
   int get(const T& key, const std::string& field_name); // gets all fields summed/combined over all windows
   int get_current(const T& key, const std::string& field_name); // gets the value just for the current window
-  std::vector<int> get_windows(const T& key, const std::string& field_name); // gets each window value returned in a vector
+  bool get_windows(const T& key, const std::string& field_name, std::vector<int>& ret_vec); // gets each window value returned in a vector
   void set(const T& key, const std::string& field_name, int a);
   void set(const T& key, const std::string& field_name, const std::string& s);
 protected:
-  bool find_create_key_field(const T& key, const std::string& field_name, std::vector<TWStatsMemberP>& ret_vecfg
-);
+  bool find_create_key_field(const T& key, const std::string& field_name, TWStatsBuf*& ret_vec, bool create=1);
+  bool find_key_field(const T& key, const std::string& field_name, TWStatsBuf*& ret_vec);  
+  int current_window() {
+    std::time_t now, diff;
+    std::time(&now);
+    diff = now - start_time;
+    int cw = (diff/window_size) % num_windows;
+  }
+  void update_write_timestamp(std::pair<std::time_t, TWStatsMemberP>& vec)
+  {
+    // only do this if the window first mod time is 0
+    if (vec.first == 0) {
+      std::time_t now, write_time;
+      std::time(&now);
+      write_time = now - ((now - start_time) % window_size);
+      vec.first = write_time;
+    }
+  }
+  void clean_windows(TWStatsBuf& twsbuf);
 private:
-  typedef std::map<T, std::map<std::string, std::vector<TWStatsMemberP>>> TWStatsDBMap;
+  typedef std::unordered_map<T, std::map<std::string, TWStatsBuf>> TWStatsDBMap;
   TWStatsDBMap stats_db;
   std::shared_ptr<FieldMap> field_map;
   int window_size;
   int num_windows;
+  int cur_window = 0;
   std::time_t start_time;
+  mutable std::mutex mutx;
 };

--- a/twmap.hh
+++ b/twmap.hh
@@ -121,7 +121,7 @@ public:
   int get(const std::string& s) { return cm->estimate(s.c_str()); }
   void set(int a) { return; }
   void set(const std::string& s) { return; }
-  void erase() { return; }
+  void erase() { cm->erase(); return; }
   int sum(const TWStatsBuf& vec)
   {
     int count = 0;

--- a/wforce-lua.cc
+++ b/wforce-lua.cc
@@ -4,6 +4,7 @@
 #include "dolog.hh"
 #include "sodcrypto.hh"
 #include "base64.hh"
+#include "twmap.hh"
 #include <fstream>
 
 #ifdef HAVE_GEOIP
@@ -13,6 +14,8 @@
 using std::thread;
 
 static vector<std::function<void(void)>>* g_launchWork;
+
+TWStringStatsDBWrapper g_sdb{300,12};
 
 vector<std::function<void(void)>> setupLua(bool client, const std::string& config)
 {
@@ -32,7 +35,7 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
 	v.push_back(std::make_shared<Sibling>(ComboAddress(p.second, 4001)));
       }
       g_siblings.setState(v);
-  });
+    });
 
 
   g_lua.writeFunction("siblingListener", [](const std::string& address) {
@@ -65,7 +68,7 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
 	nmg.addMask(p.second);
       }
       g_ACL.setState(nmg);
-  });
+    });
   g_lua.writeFunction("showACL", []() {
       vector<string> vec;
 
@@ -116,8 +119,8 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
 	SBind(sock, local);
 	SListen(sock, 5);
 	auto launch=[sock, local]() {
-	    thread t(controlThread, sock, local);
-	    t.detach();
+	  thread t(controlThread, sock, local);
+	  t.detach();
 	};
 	if(g_launchWork) 
 	  g_launchWork->push_back(launch);
@@ -144,7 +147,7 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
   g_lua.writeFunction("stats", []() {
       boost::format fmt("%d reports, %d allow-queries (%d denies), %d entries in database\n");
       g_outputBuffer = (fmt % g_stats.reports % g_stats.allows % g_stats.denieds % g_wfdb.size()).str();
-      
+
     });
   g_lua.writeFunction("clearDB", []() { 
       g_wfdb.clear();
@@ -183,7 +186,7 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
       g_outputBuffer= (fmt % "Address" % "Sucesses" % "Failures" % "Note").str();
       for(const auto& s : siblings)
 	g_outputBuffer += (fmt % s->rem.toStringWithPort() % s->success % s->failures % (s->d_ignoreself ? "Self" : "") ).str();
-      
+
     });
 
 
@@ -196,7 +199,7 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
       return g_allow(&g_wfdb, lt); // no locking needed, we are in Lua here already!
     });
 
-  
+
   g_lua.writeFunction("countFailures", [](ComboAddress remote, int seconds) {
       return g_wfdb.countFailures(remote, seconds);
     });
@@ -214,6 +217,32 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
     });
 #endif
 
+  g_lua.writeFunction("newStringStatsDB", [](int window_size, int num_windows, const std::vector<pair<std::string, std::string>>& fmvec) {
+      FieldMap fm;
+      for(const auto& f : fmvec) {
+	fm.insert(std::make_pair(f.first, f.second));
+      }
+      auto sdb = TWStringStatsDBWrapper(window_size, num_windows);
+      sdb.setFields(fm);
+      return sdb;
+    });
+
+  g_lua.writeFunction("twSetFields", [](const std::vector<pair<std::string, std::string>>& fmvec) {
+      FieldMap fm;
+      for(const auto& f : fmvec) {
+        fm.insert(std::make_pair(f.first, f.second));
+      }
+      g_sdb.setFields(fm);
+    });
+   
+  g_lua.writeVariable("sdb", &g_sdb);
+   
+  g_lua.registerFunction("twAdd", &TWStringStatsDBWrapper::add);
+  g_lua.registerFunction("twSub", &TWStringStatsDBWrapper::sub);
+  g_lua.registerFunction("twGet", &TWStringStatsDBWrapper::get);
+  g_lua.registerFunction("twGetCurrent", &TWStringStatsDBWrapper::get_current);
+  g_lua.registerFunction("twGetWindows", &TWStringStatsDBWrapper::get_windows);
+
   g_lua.registerMember("t", &LoginTuple::t);
   g_lua.registerMember("remote", &LoginTuple::remote);
   g_lua.registerMember("login", &LoginTuple::login);
@@ -225,7 +254,7 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
 
   g_lua.registerFunction("tostring", &ComboAddress::toString);
   g_lua.writeFunction("newCA", [](string address) { return ComboAddress(address); } );
-  g_lua.registerFunction("countDiffFailuresAddress", static_cast<int (WForceDB::*)(const ComboAddress&, int) const>(&WForceDB::countDiffFailures));
+  g_lua.registerFunction("countDiffFailuresAddress", static_cast<int (WForceDB::*)(const ComboAddress&,  int) const>(&WForceDB::countDiffFailures));
   g_lua.registerFunction("countDiffFailuresAddressLogin", static_cast<int (WForceDB::*)(const ComboAddress&, string, int) const>(&WForceDB::countDiffFailures));
 
   g_lua.writeFunction("newNetmaskGroup", []() { return NetmaskGroup(); } );
@@ -235,42 +264,42 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
 
   g_lua.writeFunction("setAllow", [](allow_t func) { g_allow=func;});
 
-    g_lua.writeFunction("makeKey", []() {
+  g_lua.writeFunction("makeKey", []() {
       g_outputBuffer="setKey("+newKey()+")\n";
     });
   
   g_lua.writeFunction("setKey", [](const std::string& key) {
       if(B64Decode(key, g_key) < 0) {
-	  g_outputBuffer=string("Unable to decode ")+key+" as Base64";
-	  errlog("%s", g_outputBuffer);
-	}
+	g_outputBuffer=string("Unable to decode ")+key+" as Base64";
+	errlog("%s", g_outputBuffer);
+      }
     });
 
 
   g_lua.writeFunction("testCrypto", [](string testmsg)
-   {
-     try {
-       SodiumNonce sn, sn2;
-       sn.init();
-       sn2=sn;
-       string encrypted = sodEncryptSym(testmsg, g_key, sn);
-       string decrypted = sodDecryptSym(encrypted, g_key, sn2);
+		      {
+			try {
+			  SodiumNonce sn, sn2;
+			  sn.init();
+			  sn2=sn;
+			  string encrypted = sodEncryptSym(testmsg, g_key, sn);
+			  string decrypted = sodDecryptSym(encrypted, g_key, sn2);
        
-       sn.increment();
-       sn2.increment();
+			  sn.increment();
+			  sn2.increment();
 
-       encrypted = sodEncryptSym(testmsg, g_key, sn);
-       decrypted = sodDecryptSym(encrypted, g_key, sn2);
+			  encrypted = sodEncryptSym(testmsg, g_key, sn);
+			  decrypted = sodDecryptSym(encrypted, g_key, sn2);
 
-       if(testmsg == decrypted)
-	 g_outputBuffer="Everything is ok!\n";
-       else
-	 g_outputBuffer="Crypto failed..\n";
+			  if(testmsg == decrypted)
+			    g_outputBuffer="Everything is ok!\n";
+			  else
+			    g_outputBuffer="Crypto failed..\n";
        
-     }
-     catch(...) {
-       g_outputBuffer="Crypto failed..\n";
-     }});
+			}
+			catch(...) {
+			  g_outputBuffer="Crypto failed..\n";
+			}});
 
   
   std::ifstream ifs(config);

--- a/wforce.conf
+++ b/wforce.conf
@@ -9,11 +9,17 @@ siblingListener("0.0.0.0")
 
 
 bulkRetrievers = newNetmaskGroup()
-bulkRetrievers:addMask("130.161.0.0/16");
-bulkRetrievers:addMask("145.132.0.0/16");
+bulkRetrievers:addMask("130.161.0.0/16")
+bulkRetrievers:addMask("145.132.0.0/16")
+
+field_map = {}
+field_map["countLogins"] = "int"
+field_map["diffPasswords"] = "hll"
+field_map["diffIPs"] = "hll"
+twSetFields(field_map)
 
 -- Only initialize the GeoIPDB if you need it
---initGeoIPDB()
+initGeoIPDB()
 
 function allow(wfdb, lt)
 	if(bulkRetrievers:match(lt.remote))
@@ -22,10 +28,28 @@ function allow(wfdb, lt)
 	end
 
 	-- Example GeoIP lookup
-	--if (lookupCountry(lt.remote) ~= "GB")
-	--then
-	--	return -1
-	--end
+	if (lookupCountry(lt.remote) ~= "GB")
+	then
+		return -1
+	end
+
+	print("foo")
+
+	sdb:twAdd(wfdb.login, "countLogins", 1);
+	sdb:twAdd(wfdb.login, "diffPasswords", wfdb.pwhash);
+	sdb:twAdd(wfdb.login, "diffIPs", wfdb.remote);
+
+	if (sdb:twGet(wfdb.login, "diffPasswords") > 10)
+	then
+		print "too many different passwords"
+		return -1
+	end
+
+	if (sdb:twGet(wfdb.login, "diffIPs") > 10)
+	then
+		print "too many different remote IPs"
+		return -1
+	end
 
 	if(wfdb:countDiffFailuresAddress(lt.remote, 10) > 50)
 	then

--- a/wforce.conf
+++ b/wforce.conf
@@ -8,17 +8,11 @@ addSibling("192.168.1.54")
 siblingListener("0.0.0.0")
 
 bulkRetrievers = newNetmaskGroup()
-bulkRetrievers:addMask("130.161.0.0/16")
-bulkRetrievers:addMask("145.132.0.0/16")
-
-field_map = {}
-field_map["countLogins"] = "int"
-field_map["diffPasswords"] = "hll"
-field_map["diffIPs"] = "hll"
-twSetFields(field_map)
+--bulkRetrievers:addMask("130.161.0.0/16")
+--bulkRetrievers:addMask("145.132.0.0/16")
 
 -- Only initialize the GeoIPDB if you need it
---initGeoIPDB()
+-- initGeoIPDB()
 
 function allow(wfdb, lt)
 	if(bulkRetrievers:match(lt.remote))
@@ -31,22 +25,6 @@ function allow(wfdb, lt)
 	-- then
 	--	return -1
 	-- end
-
-	sdb:twAdd(lt.login, "countLogins", 1)
-	sdb:twAdd(lt.login, "diffPasswords", lt.pwhash)
-	sdb:twAdd(lt.login, "diffIPs", lt.remote)
-
-	if (sdb:twGet(lt.login, "diffPasswords") > 90)
-	then
-		print("too many different passwords")
-		return -1
-	end
-
-	if (sdb:twGet(lt.login, "diffIPs") > 10)
-	then
-		print("too many different remote IPs")
-		return -1
-	end
 
 	if(wfdb:countDiffFailuresAddress(lt.remote, 10) > 50)
 	then

--- a/wforce.conf
+++ b/wforce.conf
@@ -7,7 +7,6 @@ addSibling("192.168.1.30")
 addSibling("192.168.1.54")
 siblingListener("0.0.0.0")
 
-
 bulkRetrievers = newNetmaskGroup()
 bulkRetrievers:addMask("130.161.0.0/16")
 bulkRetrievers:addMask("145.132.0.0/16")
@@ -19,7 +18,7 @@ field_map["diffIPs"] = "hll"
 twSetFields(field_map)
 
 -- Only initialize the GeoIPDB if you need it
-initGeoIPDB()
+--initGeoIPDB()
 
 function allow(wfdb, lt)
 	if(bulkRetrievers:match(lt.remote))
@@ -28,26 +27,24 @@ function allow(wfdb, lt)
 	end
 
 	-- Example GeoIP lookup
-	if (lookupCountry(lt.remote) ~= "GB")
+	--	if (lookupCountry(lt.remote) ~= "GB")
+	-- then
+	--	return -1
+	-- end
+
+	sdb:twAdd(lt.login, "countLogins", 1)
+	sdb:twAdd(lt.login, "diffPasswords", lt.pwhash)
+	sdb:twAdd(lt.login, "diffIPs", lt.remote)
+
+	if (sdb:twGet(lt.login, "diffPasswords") > 90)
 	then
+		print("too many different passwords")
 		return -1
 	end
 
-	print("foo")
-
-	sdb:twAdd(wfdb.login, "countLogins", 1);
-	sdb:twAdd(wfdb.login, "diffPasswords", wfdb.pwhash);
-	sdb:twAdd(wfdb.login, "diffIPs", wfdb.remote);
-
-	if (sdb:twGet(wfdb.login, "diffPasswords") > 10)
+	if (sdb:twGet(lt.login, "diffIPs") > 10)
 	then
-		print "too many different passwords"
-		return -1
-	end
-
-	if (sdb:twGet(wfdb.login, "diffIPs") > 10)
-	then
-		print "too many different remote IPs"
+		print("too many different remote IPs")
 		return -1
 	end
 

--- a/wforce.conf.example
+++ b/wforce.conf.example
@@ -1,0 +1,91 @@
+webserver("0.0.0.0:8084", "super")
+setKey("Ay9KXgU3g4ygK+qWT0Ut4gH8PPz02gbtPeXWPdjD0HE=")
+controlSocket("0.0.0.0:4004")
+
+addSibling("192.168.1.79")
+addSibling("192.168.1.30")
+addSibling("192.168.1.54")
+siblingListener("0.0.0.0")
+
+bulkRetrievers = newNetmaskGroup()
+bulkRetrievers:addMask("130.161.0.0/16")
+bulkRetrievers:addMask("145.132.0.0/16")
+
+-- Field map contains as many different fields as you like
+-- Supported types are:
+--			 "int" - simple counter
+--			 "hll" - cardinality (count how many different things you put in the bucket)
+--			 "countmin" - like a multi-valued bloom filter. Counts how many of each type there are.
+field_map = {}
+field_map["countLogins"] = "int"
+field_map["diffPasswords"] = "hll"
+field_map["diffIPs"] = "hll"
+field_map["countryCount"] = "countmin"
+
+-- create a db for storing stats. 
+-- You can create multiple dbs with different window lengths for storing stats over different time windows
+-- This one is 6 windows of 10 minutes each, so an hour in total. Every 10 minutes the oldest window's data will expire
+sdb = newStringStatsDB(600,6,field_map)
+-- This one is 24 windows of 1 hour each, so 24 hours in total. Useful for tracking long-term stats.
+-- You can reuse field_map or create a different one
+sdb_day = newStringStatsDB(3600, 24, field_map)
+
+-- Only initialize the GeoIPDB if you need it
+initGeoIPDB()
+
+function allow(wfdb, lt)
+	if(bulkRetrievers:match(lt.remote))
+	then
+		return 0
+	end
+
+	-- Example GeoIP lookup
+	--	if (lookupCountry(lt.remote) ~= "GB")
+	-- then
+	--	return -1
+	-- end
+
+	cur_ct = lookupCountry(lt.remote) 
+
+	-- A note on keys: You can use strings or ComboAddresses. ComboAdddress will be converted to a string and then used as a key.
+	-- XXX - TODO - allow to specify a netmask when creating the DB, which will be used for all ComboAddress keys
+	-- twAdd() is the generic way to add things to the stats bucket. For integers it does addition
+	sdb:twAdd(lt.login, "countLogins", 1)
+	sdb:twAdd(lt.remote, "countLogins", 1)
+	sdb:twAdd(lt.login, "diffPasswords", lt.pwhash)
+	sdb:twAdd(lt.login, "diffIPs", lt.remote)
+	sdb_day:twAdd(lt.login, "countryCount", cur_ct)
+
+	-- twSub() can be used for the integer type. It does what you expect
+
+	-- twGet() returns the "sum" of all the values over all the time windows. 
+	-- For integer and countmin types, this is just a sum. For HLL, it's a union.
+	if (sdb:twGet(lt.login, "diffPasswords") > 90)
+	then
+		return -1
+	end
+
+	-- If user is logging in from multiple IPs and we haven't seen this country in the last 24 hours then reject
+	if ((sdb:twGet(lt.login, "diffIPs") > 5) and (sdb_day.twGet(lt.login, "countryCount", cur_ct) < 2))
+	then
+		return -1
+	end
+
+	-- We also have:
+	--		 twGetCurrent() which returns the value for the current window 
+	--		 twGetWindows() which returns a table with all window values (this is a bit weird because it's a circular buffer so the "current window" is almost certainly not the first value). XXX - Should probably sort it before returning so it's in order of time ([1] = now)
+
+	if(wfdb:countDiffFailuresAddress(lt.remote, 10) > 50)
+	then
+		return -1
+	end
+
+	if(wfdb:countDiffFailuresAddressLogin(lt.remote, lt.login, 10) > 3)
+	then
+		return -1
+	end
+
+	return 0
+end
+
+setAllow(allow)


### PR DESCRIPTION
This adds statistics functionality to Lua for tracking behavior of IPs/users over time.
The basic idea is that you define the set of things you want to track statistics for, using three (currently) types of stats counters: simple integer counters, hyperloglog for tracking cardinality, and countmin for tracking multisets. You then define one or more DBs to track these statistics over whatever time windows you like, using arbitrary strings or ComboAddresses as keys into the DB.

There is currently no expiration of entries in the DB, and it is entirely memory-based. I've also done no performance testing.

Really this is a first cut at looking how/if we could extend weakforce by moving a lot of the stats tracking logic from C++ into Lua, using efficient algorithms like hll and countmin to provide a lot of power (and hopefully eventually speed/efficiency). Thus making it possible for admins and implementors to write extremely powerful Lua-based anti-abuse scripts without having to ask for devs to write new functionality in C++.

There is deliberately no concept of saving data long-term. I do think this is something that is necessary (e.g. doing anomaly detection based on realtime behavior not matching long-term behavior), but could feed off the data stored in memory, e.g. by logging expired time windows. Alternatively some kind of lambda architecture where the same events are fed to a batch-processing system. Anyway, probably getting ahead of myself here...

TODO:
- Circular buffers probably not a good idea
- Need to expire old entries in a background thread or similar
- Support netmasks on ComboAddress keys so IP stats can be aggregated, not just /32 or /128
- Other types of statistics algorithms, e.g. bloomfilter for single-value sets
- Performance? Memory usage? etc.
