### PR TITLE
Time window netmask keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://travis-ci.org/neilcook/weakforced.svg)](https://travis-ci.org/neilcook/weakforced)
 Weakforced
 ----------
 The goal of 'wforced' is to detect brute forcing of passwords across many

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Build Status](https://travis-ci.org/neilcook/weakforced.svg)](https://travis-ci.org/neilcook/weakforced)
 Weakforced
 ----------
 The goal of 'wforced' is to detect brute forcing of passwords across many

--- a/regression-tests/test_TimeWindows.py
+++ b/regression-tests/test_TimeWindows.py
@@ -91,4 +91,45 @@ class TestTimeWindows(ApiTestCase):
         r = self.allowFunc('subbaddie', '127.0.0.1', "1234")
         j = r.json()
         self.assertEquals(j['status'], 0)
-        
+
+    def test_countMinPrefixv4(self):
+        self.writeFileToConsole(configFile)
+        r = self.allowFunc('ipv4baddie', '114.31.192.200', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], 0)
+        r.close()
+
+        for i in range(12):
+            r = self.reportFunc('ipv4baddie%s' % i, "114.31.192.%s" % i, "1234", 'true')
+            r.json()
+
+        r = self.allowFunc('ipv4baddie', '114.31.192.200', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], -1)
+
+        # Wait for the time windows to clear and then check again
+        time.sleep(15)
+        r = self.allowFunc('ipv4baddie', '114.31.192.200', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], 0)
+
+    def test_countMinPrefixv6(self):
+        self.writeFileToConsole(configFile)
+        r = self.allowFunc('ipv6baddie', '2001:c78::1000', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], 0)
+        r.close()
+
+        for i in range(12):
+            r = self.reportFunc('ipv6baddie%s' % i, "2001:c78::%s" % i, "1234", 'true')
+            r.json()
+
+        r = self.allowFunc('ipv6baddie', '2001:c78::1000', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], -1)
+
+        # Wait for the time windows to clear and then check again
+        time.sleep(15)
+        r = self.allowFunc('ipv6baddie', '2001:c78::1000', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], 0)

--- a/regression-tests/wforce-tw.conf
+++ b/regression-tests/wforce-tw.conf
@@ -1,7 +1,3 @@
-webserver("0.0.0.0:8084", "super")
-setKey("Ay9KXgU3g4ygK+qWT0Ut4gH8PPz02gbtPeXWPdjD0HE=")
-controlSocket("0.0.0.0:4004")
-
 field_map = {}
 field_map["countLogins"] = "int"
 field_map["failedLogins"] = "int"
@@ -11,6 +7,10 @@ field_map["diffIPs"] = "hll"
 field_map["countryCount"] = "countmin"
 
 sdb = newStringStatsDB(1,15,field_map)
+
+sdb_prefix = newStringStatsDB(1,15,field_map)
+sdb_prefix:twSetv4Prefix(24)
+sdb_prefix:twSetv6Prefix(64)
 
 initGeoIPDB()
 
@@ -25,11 +25,13 @@ function twreport(wfdb, lt)
 	sdb:twSub(lt.login, "subTest", 1)
 	sdb:twAdd(lt.login, "diffPasswords", lt.pwhash)
 	sdb:twAdd(lt.login, "diffIPs", lt.remote)
+	sdb_prefix:twAdd(lt.remote, "countryCount", cur_ct)
 end
 
 function twallow(wfdb, lt)
 	print("twallow")
-       	if (lookupCountry(lt.remote) == "JP")
+       	cur_ct = lookupCountry(lt.remote)
+	if (cur_ct == "JP")
        	then
 		return -1
 	end
@@ -50,6 +52,11 @@ function twallow(wfdb, lt)
 	end
 
 	if (sdb:twGet(lt.login, "subTest") < -40)
+	then
+		return -1
+	end
+
+	if (sdb_prefix:twGet(lt.remote, "countryCount", "AU") > 10)
 	then
 		return -1
 	end

--- a/wforce-lua.cc
+++ b/wforce-lua.cc
@@ -225,6 +225,8 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
   g_lua.registerFunction("twGet", &TWStringStatsDBWrapper::get);
   g_lua.registerFunction("twGetCurrent", &TWStringStatsDBWrapper::get_current);
   g_lua.registerFunction("twGetWindows", &TWStringStatsDBWrapper::get_windows);
+  g_lua.registerFunction("twSetv4Prefix", &TWStringStatsDBWrapper::setv4Prefix);
+  g_lua.registerFunction("twSetv6Prefix", &TWStringStatsDBWrapper::setv6Prefix);
 
   g_lua.registerMember("t", &LoginTuple::t);
   g_lua.registerMember("remote", &LoginTuple::remote);


### PR DESCRIPTION
ComboAddress keys for time window operations will now respect the prefix specified by:
twSetv4Prefix() and twSetv6Prefix() for each tw db. This allows aggregation of stats keyed on IP address.

For example:
sdb:twSetv4Prefix(24)

will ensure that all stats with an IP address key will be aggregated as a Class C.

I also created regression tests for this for v4 and v6, using the countmin type, which thus also has a regression test.