### PR TITLE
TimeWindow object mutexes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,9 @@ before_script:
  - dpkg-deb -x libssl1.0.2_1.0.2e-1_amd64.deb ${HOME}/libssl
  - rm libssl1.0.2_1.0.2e-1_amd64.deb
  - export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${HOME}/libssl/usr/lib/x86_64-linux-gnu
- - wget http://ftp.de.debian.org/debian/pool/main/u/unbound/libunbound2_1.5.6-1_amd64.deb
- - dpkg-deb -x libunbound2_1.5.6-1_amd64.deb ${HOME}/libunbound
- - rm libunbound2_1.5.6-1_amd64.deb
+ - wget http://ftp.de.debian.org/debian/pool/main/u/unbound/libunbound2_1.5.7-1_amd64.deb
+ - dpkg-deb -x libunbound2_1.5.7-1_amd64.deb ${HOME}/libunbound
+ - rm libunbound2_1.5.7-1_amd64.deb
  - export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${HOME}/libunbound/usr/lib/pkgconfig
  - export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${HOME}/libunbound/usr/lib/x86_64-linux-gnu
  - dig @208.67.222.222 a.root-servers.net

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,9 @@ before_script:
  - sed -i -e 's/]/}/g' ${HOME}/getdns/usr/lib/pkgconfig/getdns.pc
  - export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${HOME}/getdns/usr/lib/pkgconfig
  - export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${HOME}/getdns/usr/lib/x86_64-linux-gnu
- - wget http://ftp.de.debian.org/debian/pool/main/o/openssl/libssl1.0.2_1.0.2d-3_amd64.deb
- - dpkg-deb -x libssl1.0.2_1.0.2d-3_amd64.deb ${HOME}/libssl
- - rm libssl1.0.2_1.0.2d-3_amd64.deb
+ - wget http://ftp.de.debian.org/debian/pool/main/o/openssl/libssl1.0.2_1.0.2e-1_amd64.deb
+ - dpkg-deb -x libssl1.0.2_1.0.2e-1_amd64.deb ${HOME}/libssl
+ - rm libssl1.0.2_1.0.2e-1_amd64.deb
  - export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${HOME}/libssl/usr/lib/x86_64-linux-gnu
  - wget http://ftp.de.debian.org/debian/pool/main/u/unbound/libunbound2_1.5.6-1_amd64.deb
  - dpkg-deb -x libunbound2_1.5.6-1_amd64.deb ${HOME}/libunbound

--- a/regression-tests/test_Attrs.py
+++ b/regression-tests/test_Attrs.py
@@ -1,0 +1,36 @@
+import requests
+import socket
+import time
+import json
+from test_helper import ApiTestCase
+
+configFile = "./wforce-tw.conf"
+
+class TestAttrs(ApiTestCase):
+
+    def test_Attrs(self):
+        self.writeFileToConsole(configFile)
+        attrs = dict()
+        attrs['accountStatus'] = "normal"
+        r = self.allowFuncAttrs('fredbloggs', '127.0.0.1', "1234",  attrs)
+        j = r.json()
+        self.assertEquals(j['status'], 0)
+        r.close()
+
+        attrs['accountStatus'] = "blocked"        
+        r = self.allowFuncAttrs('fredbloggs', '127.0.0.1', "1234", attrs)
+        j = r.json()
+        self.assertEquals(j['status'], -1)
+
+        attrs['accountStatus'] = "normal"        
+        attrs['countryList'] = [ "UK", "US" ]
+        r = self.allowFuncAttrs('fredbloggs', '127.0.0.1', "1234", attrs)
+        j = r.json()
+        self.assertEquals(j['status'], 0)
+        r.close()
+
+        attrs['countryList'] = [ "UK", "US", "Blockmestan" ]
+        r = self.allowFuncAttrs('fredbloggs', '127.0.0.1', "1234", attrs)
+        j = r.json()
+        self.assertEquals(j['status'], -1)
+

--- a/twmap.cc
+++ b/twmap.cc
@@ -7,7 +7,7 @@ TWStatsTypeMap g_field_types{};
 #ifdef MAIN
 #include <string.h>
 
-main (int argc, char** argv)
+int main (int argc, char** argv)
 {
   FieldMap field_map;
 

--- a/twmap.hh
+++ b/twmap.hh
@@ -543,8 +543,9 @@ bool TWStatsDB<T>::get_windows(const T& key, const std::string& field_name, std:
   if (find_key_field(key, field_name, myvec) != true) {
     return false;
   }
-  for (auto sm : (*myvec)) {
-    ret_vec.push_back(sm.second->get());
+  for (int i=cur_window+num_windows; i>cur_window; i--) {
+    int index = i % num_windows;
+    ret_vec.push_back((*myvec)[index].second->get());
   }
 
   return(true);

--- a/twmap.hh
+++ b/twmap.hh
@@ -170,79 +170,110 @@ public:
     start_time = st;
     window_size = ws;
     auto it = g_field_types.type_map.find(field_type);
-    for (int i=0; i< num_windows; i++) {
-      stats_array.push_back(std::pair<std::time_t, TWStatsMemberP>((std::time_t)0, it->second()));
+    if (it == g_field_types.type_map.end()) {
+      for (int i=0; i< num_windows; i++) {
+	stats_array.push_back(std::pair<std::time_t, TWStatsMemberP>((std::time_t)0, it->second()));
+      }
     }
   }
-  int add(int a, int cur_window) {
+  int add(int a) {
     std::lock_guard<std::mutex> lock(mutx);
-
+    clean_windows();
+    int cur_window = current_window();
     auto sm = stats_array[cur_window];
     sm.second->add(a);
     update_write_timestamp(cur_window);
     return sm.second->sum(stats_array);
   }
-  int add(const std::string& s, int cur_window) {
+  int add(const std::string& s) {
     std::lock_guard<std::mutex> lock(mutx);
-
+    clean_windows();
+    int cur_window = current_window();
     auto sm = stats_array[cur_window];
     sm.second->add(s);
     update_write_timestamp(cur_window);
     return sm.second->sum(stats_array);    
   }
-  int add(const std::string& s, int a, int cur_window) {
+  int add(const std::string& s, int a) {
     std::lock_guard<std::mutex> lock(mutx);
-
+    clean_windows();
+    int cur_window = current_window();
     auto sm = stats_array[cur_window];
     sm.second->add(s, a);
     update_write_timestamp(cur_window);
     return sm.second->sum(stats_array);        
   }
-  int sub(int a, int cur_window) {
+  int sub(int a) {
     std::lock_guard<std::mutex> lock(mutx);
-
+    clean_windows();
+    int cur_window = current_window();
     auto sm = stats_array[cur_window];
     sm.second->sub(a);
     update_write_timestamp(cur_window);
     return sm.second->sum(stats_array);
   }
-  int sub(const std::string& s, int cur_window) {
+  int sub(const std::string& s) {
     std::lock_guard<std::mutex> lock(mutx);
-
+    clean_windows();
+    int cur_window = current_window();
     auto sm = stats_array[cur_window];
     sm.second->sub(s);
     update_write_timestamp(cur_window);
     return sm.second->sum(stats_array);
   }
-  int get(int cur_window) {
+  int get() {
     std::lock_guard<std::mutex> lock(mutx);
+    clean_windows();
+    int cur_window = current_window();
     return stats_array[cur_window].second->sum(stats_array);
   }
-  int get(const std::string& s, int cur_window) {
+  int get(const std::string& s) {
     std::lock_guard<std::mutex> lock(mutx);
+    clean_windows();
+    int cur_window = current_window();
     return stats_array[cur_window].second->sum(s, stats_array);
   }
-  int get_current(int cur_window) { 
+  int get_current() { 
     std::lock_guard<std::mutex> lock(mutx);
+    clean_windows();
+    int cur_window = current_window();
     return stats_array[cur_window].second->get();
   }
-  int get_current(const std::string& s, int cur_window) {
+  int get_current(const std::string& s) {
     std::lock_guard<std::mutex> lock(mutx);
+    clean_windows();
+    int cur_window = current_window();
     return stats_array[cur_window].second->get(s);    
   }
-  void get_windows(int cur_window, std::vector<int>& ret_vec) {
+  void get_windows(std::vector<int>& ret_vec) {
     std::lock_guard<std::mutex> lock(mutx);
+    clean_windows();
+    int cur_window = current_window();
     for (int i=cur_window+num_windows; i>cur_window; i--) {
       int index = i % num_windows;
       ret_vec.push_back(stats_array[index].second->get());
     }
   }
-  void get_windows(const std::string& s, int cur_window, std::vector<int>& ret_vec) {
+  void get_windows(const std::string& s, std::vector<int>& ret_vec) {
     std::lock_guard<std::mutex> lock(mutx);
+    clean_windows();
+    int cur_window = current_window();
     for (int i=cur_window+num_windows; i>cur_window; i--) {
       int index = i % num_windows;
       ret_vec.push_back(stats_array[index].second->get(s));
     }
+  }
+  int sum() {
+    std::lock_guard<std::mutex> lock(mutx);
+    clean_windows();
+    int cur_window = current_window();
+    return stats_array[cur_window].second->sum(stats_array);
+  }
+  int sum(const std::string& s) {
+    std::lock_guard<std::mutex> lock(mutx);
+    clean_windows();
+    int cur_window = current_window();
+    return stats_array[cur_window].second->sum(s, stats_array);
   }
 protected:
   void update_write_timestamp(int cur_window)
@@ -253,6 +284,30 @@ protected:
     if (stats_array[cur_window].first == 0) {
       write_time = now - ((now - start_time) % window_size);
       stats_array[cur_window].first = write_time;
+    }
+  }
+  int current_window() {
+    std::time_t now, diff;
+    std::time(&now);
+    diff = now - start_time;
+    int cw = (diff/window_size) % num_windows;
+    return cw;
+  }
+  void clean_windows()
+  {
+    // this function checks the time difference since each array member was first written
+    // and expires (zeros) any windows as necessary. This needs to be done before any data is read or written
+    std::time_t now, expire_diff;
+    std::time(&now);
+    expire_diff = window_size * num_windows;
+
+    for (TWStatsBuf::iterator i = stats_array.begin(); i != stats_array.end(); ++i) {
+      std::time_t last_write = i->first;
+      auto sm = i->second;
+      if ((last_write != 0) && (now - last_write) >= expire_diff) {
+	sm->erase();
+	i->first = 0;
+      }
     }
   }
 private:
@@ -305,24 +360,10 @@ public:
   void set_map_size_soft(unsigned int size);
   unsigned int get_size();
 protected:
-  bool find_create_key_field(const T& key, const std::string& field_name, TWStatsBuf*& ret_vec, typename TWKeyTrackerType::iterator* ktp, bool create=1);
-  bool find_key_field(const T& key, const std::string& field_name, TWStatsBuf*& ret_vec);  
-  int current_window() {
-    std::time_t now, diff;
-    std::time(&now);
-    diff = now - start_time;
-    int cw = (diff/window_size) % num_windows;
-    return cw;
-  }
-  void update_write_timestamp(std::pair<std::time_t, TWStatsMemberP>& vec, typename TWKeyTrackerType::iterator& kt)
+  bool find_create_key_field(const T& key, const std::string& field_name, TWStatsEntryP& tp, typename TWKeyTrackerType::iterator* ktp, bool create=1);
+  bool find_key_field(const T& key, const std::string& field_name, TWStatsEntryP& tp);  
+  void update_write_timestamp(typename TWKeyTrackerType::iterator& kt)
   {
-    std::time_t now, write_time;
-    std::time(&now);
-    // only do this if the window first mod time is 0
-    if (vec.first == 0) {
-      write_time = now - ((now - start_time) % window_size);
-      vec.first = write_time;
-    }
     // move this key to the end of the key tracker list
     key_tracker.splice(key_tracker.end(),
 		       key_tracker,
@@ -330,15 +371,13 @@ protected:
   }
   int windowSize() { return window_size; }
   int numWindows() { return num_windows; }
-  void clean_windows(TWStatsBuf& twsbuf);
 private:
   TWKeyTrackerType key_tracker;
-  typedef std::unordered_map<T, std::pair<typename TWKeyTrackerType::iterator, std::map<std::string, TWStatsBuf>>> TWStatsDBMap;
+  typedef std::unordered_map<T, std::pair<typename TWKeyTrackerType::iterator, std::map<std::string, TWStatsEntryP>>> TWStatsDBMap;
   TWStatsDBMap stats_db;
   FieldMap field_map;
   int window_size;
   int num_windows;
-  int cur_window = 0;
   unsigned int map_size_soft;
   std::time_t start_time;
   mutable std::mutex mutx;
@@ -387,40 +426,19 @@ void TWStatsDB<T>::expireEntries()
   }
 }
 
-// XXX this function probably needs to move into a background thread housekeeping task
-// XXX Since I use a circular buffer, it should run at least every window_size seconds
-// XXX If the class was changed to one which just pushed new windows onto the front, we could expire
-// XXX windows off the back in our own time rather than have the restriction of window_size
 template <typename T>
-void TWStatsDB<T>::clean_windows(TWStatsBuf& twsb)
+bool TWStatsDB<T>::find_key_field(const T& key, const std::string& field_name, TWStatsEntryP& tp)
 {
-  // this function checks the time difference since each array member was first written
-  // and expires (zeros) any windows as necessary. This needs to be done before any data is read or written
-  std::time_t now, expire_diff;
-  std::time(&now);
-  expire_diff = window_size * num_windows;
-
-  for (TWStatsBuf::iterator i = twsb.begin(); i != twsb.end(); ++i) {
-    std::time_t last_write = i->first;
-    auto sm = i->second;
-    if ((last_write != 0) && (now - last_write) >= expire_diff) {
-      sm->erase();
-      i->first = 0;
-    }
-  }
+  return find_create_key_field(key, field_name, tp, NULL, false);
 }
 
 template <typename T>
-bool TWStatsDB<T>::find_key_field(const T& key, const std::string& field_name, TWStatsBuf*& ret_vec)
-{
-  return find_create_key_field(key, field_name, ret_vec, NULL, false);
-}
-
-template <typename T>
-bool TWStatsDB<T>::find_create_key_field(const T& key, const std::string& field_name, TWStatsBuf*& ret_vec, 
+bool TWStatsDB<T>::find_create_key_field(const T& key, const std::string& field_name, TWStatsEntryP& tp, 
 					 typename TWKeyTrackerType::iterator* keytrack, bool create)
 {
   TWStatsBuf myrv;
+  std::lock_guard<std::mutex> lock(mutx);
+
   // first check if the field name is in the field map - if not we throw the query out straight away
   auto myfield = field_map.find(field_name);
   if (myfield == field_map.end())
@@ -438,46 +456,35 @@ bool TWStatsDB<T>::find_create_key_field(const T& key, const std::string& field_
     auto myfm = mysdb->second.second.find(field_name);
     if (myfm != mysdb->second.second.end()) {
       // awesome this key/field combination has already been created
-      ret_vec = &(myfm->second);
+      tp = myfm->second;
       if (keytrack)
 	*keytrack = mysdb->second.first;
-      // whenever we retrieve a set of windows, we clean them to remove expired windows
-      clean_windows(myfm->second);
-      cur_window = current_window();
       return(true);
     }
     else {
       if (create) {
 	// if we get here it means the key exists, but not the field so we need to add it
-	auto mystat = mytype->second;
-	for (int i=0; i< num_windows; i++) {
-	  myrv.push_back(std::pair<std::time_t, TWStatsMemberP>((std::time_t)0, mystat()));
-	}
-	mysdb->second.second.insert(std::pair<std::string, TWStatsBuf>(field_name, myrv));
+	auto field_type = mytype->first;
+	tp = std::make_shared<TWStatsEntry>(num_windows, window_size, start_time, field_type);
+	mysdb->second.second.insert(std::pair<std::string, TWStatsEntryP>(field_name, tp));
+	return(true);
       }
     }
   }
   else {
     if (create) {
       // if we get here, we have no key and no field
-      auto mystat = mytype->second;
-      for (int i=0; i< num_windows; i++) {
-	myrv.push_back(std::pair<std::time_t, TWStatsMemberP>((std::time_t)0, mystat()));
-      }
-      std::map<std::string, TWStatsBuf> myfm;
-      myfm.insert(std::make_pair(field_name, myrv));
+      auto field_type = mytype->first;
+      tp = std::make_shared<TWStatsEntry>(num_windows, window_size, start_time, field_type);      
+      std::map<std::string, TWStatsEntryP> myfm;
+      myfm.insert(std::make_pair(field_name, tp));
       // add the key at the end of the key tracker list
       typename TWKeyTrackerType::iterator kit = key_tracker.insert(key_tracker.end(), key);
       stats_db.insert(std::make_pair(key, std::make_pair(kit, myfm)));
+      return(true);
     }
   }
-  // update the current window
-  cur_window = current_window();
-  // we created the field, now just look it up again so we get the actual pointer not a copy
-  if (create)
-    return (find_create_key_field(key, field_name, ret_vec, keytrack, false));
-  else
-    return(false);
+  return(false);
 }
 
 template <typename T>
@@ -495,176 +502,137 @@ int TWStatsDB<T>::decr(const T& key, const std::string& field_name)
 template <typename T>
 int TWStatsDB<T>::add(const T& key, const std::string& field_name, int a)
 {
-  TWStatsBuf* myvec;
-  std::lock_guard<std::mutex> lock(mutx);
   typename TWKeyTrackerType::iterator kt;
+  TWStatsEntryP tp;
 
-  if (find_create_key_field(key, field_name, myvec, &kt) != true) {
+  if (find_create_key_field(key, field_name, tp, &kt) != true) {
     return 0;
   }
-  auto sm = (*myvec)[cur_window];
-
-  sm.second->add(a);
-  update_write_timestamp((*myvec)[cur_window], kt);
-  return sm.second->sum(*myvec);
+  tp->add(a);
+  update_write_timestamp(kt);
+  return tp->sum();
 }
 
 template <typename T>
 int TWStatsDB<T>::add(const T& key, const std::string& field_name, const std::string& s)
 {
-  TWStatsBuf* myvec;
   typename TWKeyTrackerType::iterator kt;
-  std::lock_guard<std::mutex> lock(mutx);
+  TWStatsEntryP tp;
 
-  if (find_create_key_field(key, field_name, myvec, &kt) != true) {
+  if (find_create_key_field(key, field_name, tp, &kt) != true) {
     return 0;
   }
-  auto sm = (*myvec)[cur_window];
-
-  sm.second->add(s);
-  update_write_timestamp((*myvec)[cur_window], kt);
-  return sm.second->sum(*myvec);
+  tp->add(s);
+  update_write_timestamp(kt);
+  return tp->sum();
 }
 
 template <typename T>
 int TWStatsDB<T>::add(const T& key, const std::string& field_name, const std::string& s, int a)
 {
-  TWStatsBuf* myvec;
   typename TWKeyTrackerType::iterator kt;
-  std::lock_guard<std::mutex> lock(mutx);
+  TWStatsEntryP tp;
 
-  if (find_create_key_field(key, field_name, myvec, &kt) != true) {
+  if (find_create_key_field(key, field_name, tp, &kt) != true) {
     return 0;
   }
-  auto sm = (*myvec)[cur_window];
-
-  sm.second->add(s, a);
-  update_write_timestamp((*myvec)[cur_window], kt);
-  return sm.second->sum(s, *myvec);
+  tp->add(s, a);
+  update_write_timestamp(kt);
+  return tp->sum(s);
 }
 
 template <typename T>
 int TWStatsDB<T>::sub(const T& key, const std::string& field_name, int a)
 {
-  TWStatsBuf* myvec;
   typename TWKeyTrackerType::iterator kt;
-  std::lock_guard<std::mutex> lock(mutx);
+  TWStatsEntryP tp;
 
-  if (find_create_key_field(key, field_name, myvec, &kt) != true) {
+  if (find_create_key_field(key, field_name, tp, &kt) != true) {
     return 0;
   }
-  auto sm = (*myvec)[cur_window];
-
-  sm.second->sub(a);
-  update_write_timestamp((*myvec)[cur_window], kt);
-  return sm.second->sum(*myvec);
+  tp->sub(a);
+  update_write_timestamp(kt);
+  return tp->sum();
 }
 
 template <typename T>
 int TWStatsDB<T>::sub(const T& key, const std::string& field_name, const std::string& s)
 {
-  TWStatsBuf* myvec;
   typename TWKeyTrackerType::iterator kt;
-  std::lock_guard<std::mutex> lock(mutx);
+  TWStatsEntryP tp;
 
-  if (find_create_key_field(key, field_name, myvec, &kt) != true) {
+  if (find_create_key_field(key, field_name, tp, &kt) != true) {
     return 0;
   }
-  auto sm = (*myvec)[cur_window];
-
-  sm.second->sub(s);
-  update_write_timestamp((*myvec)[cur_window], kt);
-  return sm.second->sum(*myvec);
+  tp->sub(s);
+  update_write_timestamp(kt);
+  return tp->sum();
 }
 
 template <typename T>
 int TWStatsDB<T>::get(const T& key, const std::string& field_name)
 {
-  TWStatsBuf* myvec;
-  std::lock_guard<std::mutex> lock(mutx);
+  TWStatsEntryP tp;
 
-  if (find_key_field(key, field_name, myvec) != true) {
+  if (find_key_field(key, field_name, tp) != true) {
     return 0;
   }
-  auto sm = (*myvec)[cur_window];
-
-  return sm.second->sum(*myvec);
+  return tp->sum();
 }
 
 template <typename T>
 int TWStatsDB<T>::get(const T& key, const std::string& field_name, const std::string& s)
 {
-  TWStatsBuf* myvec;
-  std::lock_guard<std::mutex> lock(mutx);
-
-  if (find_key_field(key, field_name, myvec) != true) {
+  TWStatsEntryP tp;
+  if (find_key_field(key, field_name, tp) != true) {
     return 0;
   }
-  auto sm = (*myvec)[cur_window];
-
-  return sm.second->sum(s, *myvec);
+  return tp->sum(s);
 }
-
 
 template <typename T>
 int TWStatsDB<T>::get_current(const T& key, const std::string& field_name)
 {
-  TWStatsBuf* myvec;
-  std::lock_guard<std::mutex> lock(mutx);
-
-  if (find_key_field(key, field_name, myvec) != true) {
+  TWStatsEntryP tp;
+  if (find_key_field(key, field_name, tp) != true) {
     return 0;
   }
-  auto sm = (*myvec)[cur_window];
-
-  return sm.second->get();
+  return tp->get();
 }
 
 template <typename T>
 int TWStatsDB<T>::get_current(const T& key, const std::string& field_name, const std::string& val)
 {
-  TWStatsBuf* myvec;
-  std::lock_guard<std::mutex> lock(mutx);
+  TWStatsEntryP tp;
 
-  if (find_key_field(key, field_name, myvec) != true) {
+  if (find_key_field(key, field_name, tp) != true) {
     return 0;
   }
-  auto sm = (*myvec)[cur_window];
-
-  return sm.second->get(val);
+  return tp->get(val);
 }
 
 
 template <typename T>
 bool TWStatsDB<T>::get_windows(const T& key, const std::string& field_name, std::vector<int>& ret_vec)
 {
-  TWStatsBuf* myvec;
-  std::lock_guard<std::mutex> lock(mutx);
+  TWStatsEntryP tp;
 
-  if (find_key_field(key, field_name, myvec) != true) {
+  if (find_key_field(key, field_name, tp) != true) {
     return false;
   }
-  for (int i=cur_window+num_windows; i>cur_window; i--) {
-    int index = i % num_windows;
-    ret_vec.push_back((*myvec)[index].second->get());
-  }
-
+  tp->get_windows(ret_vec);
   return(true);
 }
 
 template <typename T>
 bool TWStatsDB<T>::get_windows(const T& key, const std::string& field_name, const std::string& val, std::vector<int>& ret_vec)
 {
-  TWStatsBuf* myvec;
-  std::lock_guard<std::mutex> lock(mutx);
+  TWStatsEntryP tp;
 
-  if (find_key_field(key, field_name, myvec) != true) {
+  if (find_key_field(key, field_name, tp) != true) {
     return false;
   }
-  for (auto sm : (*myvec)) {
-    ret_vec.push_back(sm.second->get(val));
-  }
-
+  tp->get_windows(val, ret_vec);
   return(true);
 }
 

--- a/twmap.hh
+++ b/twmap.hh
@@ -169,6 +169,7 @@ public:
     num_windows = nw;
     start_time = st;
     window_size = ws;
+    last_cleaned = 0;
     auto it = g_field_types.type_map.find(field_type);
     if (it != g_field_types.type_map.end()) {
       for (int i=0; i< num_windows; i++) {
@@ -301,6 +302,10 @@ protected:
     std::time(&now);
     expire_diff = window_size * num_windows;
 
+    // optimization - only clean windows if they need cleaning
+    if ((now-last_cleaned) < window_size)
+      return;
+
     for (TWStatsBuf::iterator i = stats_array.begin(); i != stats_array.end(); ++i) {
       std::time_t last_write = i->first;
       auto sm = i->second;
@@ -309,6 +314,7 @@ protected:
 	i->first = 0;
       }
     }
+    last_cleaned = now;
   }
 private:
   TWStatsBuf stats_array;
@@ -316,6 +322,7 @@ private:
   int num_windows;
   int window_size;
   std::time_t start_time;
+  std::time_t last_cleaned;
 };
 
 typedef std::shared_ptr<TWStatsEntry> TWStatsEntryP;

--- a/twmap.hh
+++ b/twmap.hh
@@ -170,7 +170,7 @@ public:
     start_time = st;
     window_size = ws;
     auto it = g_field_types.type_map.find(field_type);
-    if (it == g_field_types.type_map.end()) {
+    if (it != g_field_types.type_map.end()) {
       for (int i=0; i< num_windows; i++) {
 	stats_array.push_back(std::pair<std::time_t, TWStatsMemberP>((std::time_t)0, it->second()));
       }
@@ -467,6 +467,8 @@ bool TWStatsDB<T>::find_create_key_field(const T& key, const std::string& field_
 	auto field_type = mytype->first;
 	tp = std::make_shared<TWStatsEntry>(num_windows, window_size, start_time, field_type);
 	mysdb->second.second.insert(std::pair<std::string, TWStatsEntryP>(field_name, tp));
+	if (keytrack)
+	  *keytrack = mysdb->second.first;
 	return(true);
       }
     }
@@ -481,6 +483,8 @@ bool TWStatsDB<T>::find_create_key_field(const T& key, const std::string& field_
       // add the key at the end of the key tracker list
       typename TWKeyTrackerType::iterator kit = key_tracker.insert(key_tracker.end(), key);
       stats_db.insert(std::make_pair(key, std::make_pair(kit, myfm)));
+      if (keytrack)
+	*keytrack = kit;
       return(true);
     }
   }

--- a/wforce-lua.cc
+++ b/wforce-lua.cc
@@ -264,6 +264,28 @@ vector<std::function<void(void)>> setupLua(bool client, const std::string& confi
   g_lua.registerFunction("twGetSize", &TWStringStatsDBWrapper::get_size);
   g_lua.registerFunction("twSetMaxSize", &TWStringStatsDBWrapper::set_size_soft);
 
+  g_lua.writeFunction("infolog", [](const std::string& msg, const std::vector<pair<std::string, std::string>>& kvs) {
+      std::ostringstream os;
+      os << msg << ": ";
+      for (const auto& i : kvs) {
+	os << i.first << "="<< "\"" << i.second << "\"" << " ";
+      }
+      infolog(os.str().c_str());
+    });
+
+  g_lua.writeFunction("allowLog", [](int retval, const std::string& msg, const LoginTuple& lt, const std::vector<pair<std::string, std::string>>& kvs) {
+      std::ostringstream os;
+      os << msg << ": ";
+      os << "allow=\"" << retval << "\" ";
+      os << "remote=\"" << lt.remote.toString() << "\" ";
+      os << "login=\"" << lt.login << "\" ";
+      os << "success=\"" << lt.success << "\" ";
+      for (const auto& i : kvs) {
+	os << i.first << "="<< "\"" << i.second << "\"" << " ";
+      }
+      infolog(os.str().c_str());
+    });
+
   g_lua.registerMember("t", &LoginTuple::t);
   g_lua.registerMember("remote", &LoginTuple::remote);
   g_lua.registerMember("login", &LoginTuple::login);

--- a/wforce.conf.example
+++ b/wforce.conf.example
@@ -62,29 +62,33 @@ rblresolv:addResolver("127.0.0.1", 5353)
 function allow(wfdb, lt)
 	if(bulkRetrievers:match(lt.remote))
 	then
+		allowLog(0, "bulkRetrievers", lt, { foo=1 })
 		return 0
 	end
 
-	// check optional attrs for things that indicate badness
+	-- check optional attrs for things that indicate badness
         for k, v in pairs(lt.attrs) do
              if ((k == "accountStatus") and (v == "blocked"))
              then
+	     	allowLog(-1, "account blocked", lt, { accountStatus="blocked" })
                 return -1
              end
         end
-	// attrs can be multi-valued, in which case they will appear in attrs_mv automagically
+	-- attrs can be multi-valued, in which case they will appear in attrs_mv automagically
         for k, v in pairs(lt.attrs_mv) do
              for i, vi in ipairs(v) do
                   if ((k == "countryList") and (vi == "Blockmestan"))
                   then
+			allowLog(-1, "blocked", lt, { countryList="Blockmestan" })
                         return -1
                   end
               end
         end
-
+	
 	-- Example GeoIP lookup
-	if (lookupCountry(lt.remote) ~= "GB")
+	if (lookupCountry(lt.remote) == "XX")
 	then
+		allowLog(-1, "country blocked", lt, { remoteCountry="XX" })
 		return -1
 	end
 
@@ -93,6 +97,7 @@ function allow(wfdb, lt)
 	for i, dname in ipairs(dnames) do
 	    if (string.match(dname, "XXX"))
 	    then
+	    	allowLog(-1, "Reverse IP", lt, { ptrContains="XXX" })
 		return -1
 	    end
 	end
@@ -101,6 +106,7 @@ function allow(wfdb, lt)
 	for i, dname in ipairs(dnames) do
 	    if (string.match(dname, "127.0.0.2"))
 	    then
+	    	allowLog(5, "RBL", lt, { spamhaus=1 })
 		-- tarpit the connection
 		return 5
 	    end
@@ -110,6 +116,7 @@ function allow(wfdb, lt)
 	-- For integer and countmin types, this is just a sum. For HLL, it's a union.
 	if (sdb:twGet(lt.login, "diffPasswords") > 90)
 	then
+		allowLog(-1, "diffPasswords", lt, { diffPasswords=90 })
 		return -1
 	end
 
@@ -117,23 +124,27 @@ function allow(wfdb, lt)
 	cur_ct = lookupCountry(lt.remote) 
 	if ((sdb:twGet(lt.login, "diffIPs") > 5) and (sdb_day.twGet(lt.login, "countryCount", cur_ct) < 2))
 	then
+		allowLog(-1, "diffIPs", lt, { diffIPs=5 })
 		return -1
 	end
 
 	-- We also have:
 	--		 twGetCurrent() which returns the value for the current window 
-	--		 twGetWindows() which returns a table with all window values (this is a bit weird because it's a circular buffer so the "current window" is almost certainly not the first value). XXX - Should probably sort it before returning so it's in order of time ([1] = now)
+	--		 twGetWindows() which returns a table with all window values - the first item in the list is the "current" window. The last is the "oldest" window.
 
 	if(wfdb:countDiffFailuresAddress(lt.remote, 10) > 50)
 	then
+		allowLog(-1, "countDiffFailures", lt, { countDiffFailuresAddr=50 })
 		return -1
 	end
 
 	if(wfdb:countDiffFailuresAddressLogin(lt.remote, lt.login, 10) > 3)
 	then
+		allowLog(-1, "countDiffFailures", lt, { countDiffFailuresAddLogin=3 })
 		return -1
 	end
 
+	allowLog(0, "allowed", lt, { foo=1 })
 	return 0
 end
 


### PR DESCRIPTION
Each entry in the time window stats DB is now represented by a class TWStatsEntry. Each class has its own mutex. Thus, the DB mutex is locked when finding/creating entries, and the per-class mutex is locked when accessing the data in the entry.

Entries are stored with a shared_ptr, thus even if they are expired, any threads which are using those objects will still be able to access them, and the memory will only be deleted once they are finished.

This refactoring also makes key creation more efficient by removing the need for recursion.