### PR TITLE
Blacklisting and Introspection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,7 @@ lt~obsolete.m4
 *.exe
 *.out
 *.app
+
+# Compressed files
+*.gz
+*.bz2

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,9 @@ before_script:
  - sed -i -e 's/]/}/g' ${HOME}/getdns/usr/lib/pkgconfig/getdns.pc
  - export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${HOME}/getdns/usr/lib/pkgconfig
  - export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${HOME}/getdns/usr/lib/x86_64-linux-gnu
- - wget http://ftp.de.debian.org/debian/pool/main/o/openssl/libssl1.0.2_1.0.2g-1_amd64.deb
- - dpkg-deb -x libssl1.0.2_1.0.2g-1_amd64.deb ${HOME}/libssl
- - rm libssl1.0.2_1.0.2g-1_amd64.deb
+ - wget http://ftp.de.debian.org/debian/pool/main/o/openssl/libssl1.0.2_1.0.2h-1_amd64.deb
+ - dpkg-deb -x libssl1.0.2_1.0.2h-1_amd64.deb ${HOME}/libssl
+ - rm libssl1.0.2_1.0.2h-1_amd64.deb
  - export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${HOME}/libssl/usr/lib/x86_64-linux-gnu
  - wget http://ftp.de.debian.org/debian/pool/main/u/unbound/libunbound2_1.5.8-1_amd64.deb
  - dpkg-deb -x libunbound2_1.5.8-1_amd64.deb ${HOME}/libunbound

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
   apt:
     packages:
       - libboost-dev
+      - libboost-date-time-dev
       - gcc-5
       - g++-5
       - libstdc++-5-dev

--- a/Makefile.am
+++ b/Makefile.am
@@ -26,7 +26,7 @@ wforce_SOURCES = \
 	ext/incbin/incbin.h \
 	ext/incbin/incbin.h \
 	ext/murmur3.cc \
-        ext/murmur3.h \ 
+        ext/murmur3.h \
 	ext/count_min_sketch.cpp \
 	ext/ctpl.h \
 	ext/hyperloglog.hpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -14,7 +14,8 @@ wforce_SOURCES = \
 	wforce-lua.cc \
 	wforce-web.cc \
 	wforce-geoip.cc \
-	twmap.cc \
+	twmap.cc twmap.hh \
+	blacklist.cc blacklist.hh \
 	dolog.hh \
 	iputils.cc iputils.hh \
 	misc.cc misc.hh \
@@ -52,6 +53,7 @@ noinst_HEADERS = \
 	sodcrypto.hh \
 	sstuff.hh \
 	twmap.hh \
+	blacklist.hh \
 	wforce-geoip.hh \
 	wforce.hh
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -39,7 +39,7 @@ wforce_LDFLAGS = \
 
 wforce_LDADD = \
 	-lreadline -ltermcap \
-	$(LUA_LIBS) $(YAHTTP_LIBS) ${libsodium_LIBS} $(GEOIP_LIBS) $(GETDNS_LIBS) $(LIBSYSTEMD_LIBS) $(JSON11_LIBS)
+	$(LUA_LIBS) $(YAHTTP_LIBS) ${libsodium_LIBS} $(GEOIP_LIBS) $(GETDNS_LIBS) $(LIBSYSTEMD_LIBS) $(JSON11_LIBS) $(BOOST_DATE_TIME_LIBS)
 
 noinst_HEADERS = \
 	base64.hh \

--- a/blacklist.cc
+++ b/blacklist.cc
@@ -81,12 +81,12 @@ bool BlackListDB::getEntry(const ComboAddress& ca, BlackListEntry& ret)
 
 bool BlackListDB::getEntry(const std::string& login, BlackListEntry& ret) 
 {
-  return _getEntry(login, ip_blacklist, ret);
+  return _getEntry(login, login_blacklist, ret);
 } 
 
 bool BlackListDB::getEntry(const ComboAddress& ca, const std::string& login, BlackListEntry& ret) 
 {
-  return _getEntry(ipLoginStr(ca, login), ip_blacklist, ret);
+  return _getEntry(ipLoginStr(ca, login), ip_login_blacklist, ret);
 } 
 
 bool BlackListDB::_getEntry(const std::string& key, blacklist_t& blacklist, BlackListEntry& ret_ble)
@@ -143,7 +143,7 @@ time_t BlackListDB::getExpiration(const ComboAddress& ca)
 
 time_t BlackListDB::getExpiration(const std::string& login)
 {
-  return _getExpiration(login, ip_blacklist);
+  return _getExpiration(login, login_blacklist);
 }
 
 time_t BlackListDB::getExpiration(const ComboAddress& ca, const std::string& login)
@@ -153,7 +153,7 @@ time_t BlackListDB::getExpiration(const ComboAddress& ca, const std::string& log
 
 // to_time_t is missing in some versions of boost
 #if BOOST_VERSION < 105700
-time_t my_to_time_t(boost::posix_time::ptime pt)
+inline time_t my_to_time_t(boost::posix_time::ptime pt)
 {
   boost::posix_time::time_duration dur = pt - boost::posix_time::ptime(boost::gregorian::date(1970,1,1));
   return std::time_t(dur.total_seconds());
@@ -244,27 +244,30 @@ void BlackListDB::addEntryLog(BLType blt, const std::string& key, time_t seconds
 {
   std::ostringstream os;
   std::string bl_name = string(bl_names[blt]);
+  std::string key_name = string(key_names[blt]);
 
-  os << "addBLEntry " + bl_name + ": key=" + key + " expire_secs=" + std::to_string(seconds) + " reason=\"" + reason + "\"";
-  infolog(os.str().c_str());
+  os << "addBLEntry " + bl_name + ": " + key_name + "=" + key + " expire_secs=" + std::to_string(seconds) + " reason=\"" + reason + "\"";
+  warnlog(os.str().c_str());
 }
 
 void BlackListDB::deleteEntryLog(BLType blt, const std::string& key)
 {
   std::ostringstream os;
   std::string bl_name = string(bl_names[blt]);
+  std::string key_name = string(key_names[blt]);
 
-  os << "deleteBLEntry " + bl_name + ": key=" + key;
-  infolog(os.str().c_str());
+  os << "deleteBLEntry " + bl_name + ": " + key_name + "=" + key;
+  warnlog(os.str().c_str());
 }
 
 void BlackListDB::expireEntryLog(BLType blt, const std::string& key)
 {
   std::ostringstream os;
   std::string bl_name = string(bl_names[blt]);
+  std::string key_name = string(key_names[blt]);
 
-  os << "expireBLEntry " + bl_name + ": key=" + key;
-  infolog(os.str().c_str());
+  os << "expireBLEntry " + bl_name + ": " + key_name + "=" + key;
+  warnlog(os.str().c_str());
 }
 
 

--- a/blacklist.cc
+++ b/blacklist.cc
@@ -34,7 +34,7 @@ void BlackListDB::_addEntry(const std::string& key, time_t seconds, blacklist_t&
   std::lock_guard<std::mutex> lock(mutx);
 
   bl.key = key;
-  bl.expiration = boost::get_system_time() + boost::posix_time::seconds(seconds);
+  bl.expiration = boost::posix_time::from_time_t(time(NULL)) + boost::posix_time::seconds(seconds);
   bl.reason = reason;
 
   auto& keyindex = blacklist.get<KeyTag>();
@@ -191,7 +191,7 @@ void BlackListDB::_purgeEntries(BLType blt, blacklist_t& blacklist)
   }
 }
 
-std::vector<BlackListEntry> BlackListDB::getEntries()
+std::vector<BlackListEntry> BlackListDB::getIPEntries()
 {
   std::lock_guard<std::mutex> lock(mutx);
   std::vector<BlackListEntry> ret;
@@ -199,12 +199,26 @@ std::vector<BlackListEntry> BlackListDB::getEntries()
   auto& seqindex = ip_blacklist.get<SeqTag>();  
   for(const auto& a : seqindex)
     ret.push_back(a);
+  return ret;
+}
 
-  seqindex = login_blacklist.get<SeqTag>();  
+std::vector<BlackListEntry> BlackListDB::getLoginEntries()
+{
+  std::lock_guard<std::mutex> lock(mutx);
+  std::vector<BlackListEntry> ret;
+
+  auto& seqindex = login_blacklist.get<SeqTag>();  
   for(const auto& a : seqindex)
-    ret.push_back(a);
+    ret.push_back(a); 
+  return ret;
+}
 
-  seqindex = ip_login_blacklist.get<SeqTag>();  
+std::vector<BlackListEntry> BlackListDB::getIPLoginEntries()
+{
+  std::lock_guard<std::mutex> lock(mutx);
+  std::vector<BlackListEntry> ret;
+
+  auto& seqindex = ip_login_blacklist.get<SeqTag>();  
   for(const auto& a : seqindex)
     ret.push_back(a);
   return ret;

--- a/blacklist.cc
+++ b/blacklist.cc
@@ -1,0 +1,240 @@
+#include "blacklist.hh"
+
+BlackListDB bl_db;
+
+std::string BlackListDB::ipLoginStr(const ComboAddress& ca, const std::string& login)
+{
+  return ca.toString() + ":" + login;
+}
+
+void BlackListDB::addEntry(const ComboAddress& ca, time_t seconds, const std::string& reason)
+{
+  _addEntry(ca.toString(), seconds, ip_blacklist, reason);
+  addEntryLog(IP_BL, ca.toString(), seconds, reason);
+}
+
+void BlackListDB::addEntry(const std::string& login, time_t seconds, const std::string& reason)
+{
+  _addEntry(login, seconds, login_blacklist, reason);
+  addEntryLog(LOGIN_BL, login, seconds, reason);
+}
+
+void BlackListDB::addEntry(const ComboAddress& ca, const std::string& login, time_t seconds, const std::string& reason)
+{
+  std::string key = ipLoginStr(ca, login);
+  _addEntry(key, seconds, ip_login_blacklist, reason);
+  addEntryLog(IP_LOGIN_BL, key, seconds, reason);
+}
+
+
+void BlackListDB::_addEntry(const std::string& key, time_t seconds, blacklist_t& blacklist, const std::string& reason)
+{
+  BlackListEntry bl;
+
+  std::lock_guard<std::mutex> lock(mutx);
+
+  bl.key = key;
+  bl.expiration = boost::get_system_time() + boost::posix_time::seconds(seconds);
+  bl.reason = reason;
+
+  auto& keyindex = blacklist.get<KeyTag>();
+  keyindex.erase(key);
+
+  blacklist.insert(bl);
+}
+
+bool BlackListDB::checkEntry(const ComboAddress& ca)
+{
+  return _checkEntry(ca.toString(), ip_blacklist);
+}
+
+bool BlackListDB::checkEntry(const std::string& login)
+{
+  return _checkEntry(login, login_blacklist);
+}
+
+bool BlackListDB::checkEntry(const ComboAddress& ca, const std::string& login)
+{
+  return _checkEntry(ipLoginStr(ca, login), ip_login_blacklist);
+}
+
+bool BlackListDB::_checkEntry(const std::string& key, blacklist_t& blacklist)
+{
+  std::lock_guard<std::mutex> lock(mutx);
+  
+  auto& keyindex = blacklist.get<KeyTag>();
+  auto kit = keyindex.find(key);
+
+  if (kit != keyindex.end())
+    return true;
+  return false;
+}
+
+bool BlackListDB::getEntry(const ComboAddress& ca, BlackListEntry& ret) 
+{
+  return _getEntry(ca.toString(), ip_blacklist, ret);
+} 
+
+bool BlackListDB::getEntry(const std::string& login, BlackListEntry& ret) 
+{
+  return _getEntry(login, ip_blacklist, ret);
+} 
+
+bool BlackListDB::getEntry(const ComboAddress& ca, const std::string& login, BlackListEntry& ret) 
+{
+  return _getEntry(ipLoginStr(ca, login), ip_blacklist, ret);
+} 
+
+bool BlackListDB::_getEntry(const std::string& key, blacklist_t& blacklist, BlackListEntry& ret_ble)
+{
+  std::lock_guard<std::mutex> lock(mutx);
+
+  auto& keyindex = blacklist.get<KeyTag>();
+  auto kit = keyindex.find(key);
+
+  if (kit != keyindex.end()) {
+    ret_ble = *kit; // copy
+    return true;
+  }
+  return false;
+}
+
+bool BlackListDB::deleteEntry(const ComboAddress& ca)
+{
+  return _deleteEntry(ca.toString(), ip_blacklist);
+  deleteEntryLog(IP_BL, ca.toString());
+}
+
+bool BlackListDB::deleteEntry(const std::string& login)
+{
+  return _deleteEntry(login, login_blacklist);
+  deleteEntryLog(LOGIN_BL, login);
+}
+
+bool BlackListDB::deleteEntry(const ComboAddress& ca, const std::string& login)
+{
+  std::string key = ipLoginStr(ca, login);
+  return _deleteEntry(key, ip_login_blacklist);
+  deleteEntryLog(IP_LOGIN_BL, key);
+}
+
+bool BlackListDB::_deleteEntry(const std::string& key, blacklist_t& blacklist)
+{
+  std::lock_guard<std::mutex> lock(mutx);
+
+  auto& keyindex = blacklist.get<KeyTag>();
+  auto kit = keyindex.find(key);
+
+  if (kit != keyindex.end()) {
+    keyindex.erase(key);
+    return true;
+  }
+  return false;  
+}
+
+time_t BlackListDB::getExpiration(const ComboAddress& ca)
+{
+  return _getExpiration(ca.toString(), ip_blacklist);
+}
+
+time_t BlackListDB::getExpiration(const std::string& login)
+{
+  return _getExpiration(login, ip_blacklist);
+}
+
+time_t BlackListDB::getExpiration(const ComboAddress& ca, const std::string& login)
+{
+  return _getExpiration(ipLoginStr(ca, login), ip_login_blacklist);
+}
+
+time_t BlackListDB::_getExpiration(const std::string& key, blacklist_t& blacklist)
+{
+  std::lock_guard<std::mutex> lock(mutx);
+
+  auto& keyindex = blacklist.get<KeyTag>();
+  auto kit = keyindex.find(key);
+
+  if (kit != keyindex.end()) {
+    time_t expiration_secs = boost::posix_time::to_time_t(kit->expiration) - time(NULL);
+    if (expiration_secs >= 0)
+      return expiration_secs;
+    else
+      return -1; // expired already
+  }
+  return (time_t)-1; // not found
+}
+
+void BlackListDB::purgeEntries()
+{
+  while (true) {
+    sleep(1);
+    _purgeEntries(IP_BL, ip_blacklist);
+    _purgeEntries(LOGIN_BL, login_blacklist);
+    _purgeEntries(IP_LOGIN_BL, ip_login_blacklist);
+  }
+}
+
+void BlackListDB::_purgeEntries(BLType blt, blacklist_t& blacklist)
+{
+  std::lock_guard<std::mutex> lock(mutx);
+  boost::system_time now = boost::get_system_time();
+  
+  auto& timeindex = blacklist.get<TimeTag>();
+  
+  for (auto tit = timeindex.begin(); tit != timeindex.end(); ++tit) {
+    if (tit->expiration <= now) {
+      expireEntryLog(blt, tit->key);
+      timeindex.erase(tit);
+    }
+    else
+      break; // stop when we run out of entries to expire
+  }
+}
+
+std::vector<BlackListEntry> BlackListDB::getEntries()
+{
+  std::lock_guard<std::mutex> lock(mutx);
+  std::vector<BlackListEntry> ret;
+
+  auto& seqindex = ip_blacklist.get<SeqTag>();  
+  for(const auto& a : seqindex)
+    ret.push_back(a);
+
+  seqindex = login_blacklist.get<SeqTag>();  
+  for(const auto& a : seqindex)
+    ret.push_back(a);
+
+  seqindex = ip_login_blacklist.get<SeqTag>();  
+  for(const auto& a : seqindex)
+    ret.push_back(a);
+  return ret;
+}
+
+void BlackListDB::addEntryLog(BLType blt, const std::string& key, time_t seconds, const std::string& reason)
+{
+  std::ostringstream os;
+  std::string bl_name = string(bl_names[blt]);
+
+  os << "addBLEntry " + bl_name + ": key=" + key + " expire_secs=" + std::to_string(seconds) + " reason=\"" + reason + "\"";
+  infolog(os.str().c_str());
+}
+
+void BlackListDB::deleteEntryLog(BLType blt, const std::string& key)
+{
+  std::ostringstream os;
+  std::string bl_name = string(bl_names[blt]);
+
+  os << "deleteBLEntry " + bl_name + ": key=" + key;
+  infolog(os.str().c_str());
+}
+
+void BlackListDB::expireEntryLog(BLType blt, const std::string& key)
+{
+  std::ostringstream os;
+  std::string bl_name = string(bl_names[blt]);
+
+  os << "expireBLEntry " + bl_name + ": key=" + key;
+  infolog(os.str().c_str());
+}
+
+

--- a/blacklist.hh
+++ b/blacklist.hh
@@ -1,0 +1,97 @@
+#pragma once
+#include <time.h>
+#include "misc.hh"
+#include "iputils.hh"
+#include <atomic>
+#include <mutex>
+#include <thread>
+#include <random>
+#include "sholder.hh"
+#include "sstuff.hh"
+#include "dolog.hh"
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/hashed_index.hpp>
+#include <boost/thread/thread_time.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
+
+struct BlackListEntry {
+  std::string key;
+  std::string reason;
+  boost::system_time expiration;
+  bool operator<(const BlackListEntry& r) const
+  {
+    if (key < r.key) return true;
+    return false;
+  }
+};
+
+using namespace boost::multi_index;
+
+class BlackListDB {
+private:
+  struct TimeTag{};
+  struct KeyTag{};
+  struct SeqTag{};
+  typedef multi_index_container<
+    BlackListEntry,
+    indexed_by<
+      ordered_non_unique<
+	tag<TimeTag>,
+	member<BlackListEntry, boost::system_time, &BlackListEntry::expiration>	>,
+      hashed_unique<
+	tag<KeyTag>,
+	member<BlackListEntry, std::string, &BlackListEntry::key> >,
+      sequenced<tag<SeqTag>>
+    >
+    > blacklist_t;
+
+  enum BLType { IP_BL=0, LOGIN_BL=1, IP_LOGIN_BL=2 };
+  const char* bl_names[3] = { "ip_bl", "login_bl", "ip_login_bl" };
+  blacklist_t ip_blacklist;
+  blacklist_t login_blacklist;
+  blacklist_t ip_login_blacklist;
+  std::mutex mutx;
+
+  void _addEntry(const std::string& key, time_t seconds, blacklist_t& blacklist, const std::string& reason);
+  bool _checkEntry(const std::string& key, blacklist_t& blacklist);
+  bool _getEntry(const std::string& key, blacklist_t& blacklist, BlackListEntry& ret_ble);
+  bool _deleteEntry(const std::string& key, blacklist_t& blacklist);
+  time_t _getExpiration(const std::string& key, blacklist_t& blacklist); // returns number of seconds until expiration
+  void _purgeEntries(BLType blt, blacklist_t& blacklist);
+  void addEntryLog(BLType blt, const std::string& key, time_t seconds, const std::string& reason);
+  void deleteEntryLog(BLType blt, const std::string& key);
+  void expireEntryLog(BLType blt, const std::string& key);
+  std::string ipLoginStr(const ComboAddress& ca, const std::string& login);
+public:  
+  BlackListDB() {}
+  BlackListDB(const BlackListDB&) = delete;
+
+  void addEntry(const ComboAddress& ca, time_t seconds, const std::string& reason);
+  void addEntry(const std::string& login, time_t seconds, const std::string& reason);
+  void addEntry(const ComboAddress& ca, const std::string& login, time_t seconds, const std::string& reason);
+
+  bool checkEntry(const ComboAddress& ca);
+  bool checkEntry(const std::string& login);
+  bool checkEntry(const ComboAddress& ca, const std::string& login);
+
+  bool getEntry(const ComboAddress& ca, BlackListEntry& ret);
+  bool getEntry(const std::string& login, BlackListEntry& ret);
+  bool getEntry(const ComboAddress& ca, const std::string& login, BlackListEntry& ret);
+
+  bool deleteEntry(const ComboAddress& ca);
+  bool deleteEntry(const std::string& login);
+  bool deleteEntry(const ComboAddress& ca, const std::string& login);
+
+  time_t getExpiration(const ComboAddress& ca);
+  time_t getExpiration(const std::string& login);
+  time_t getExpiration(const ComboAddress& ca, const std::string& login);
+
+  void purgeEntries();
+  static void purgeEntriesThread(BlackListDB* bl_db)
+  {
+    bl_db->purgeEntries();
+  }
+  std::vector<BlackListEntry> getEntries();
+};
+
+extern BlackListDB bl_db;

--- a/blacklist.hh
+++ b/blacklist.hh
@@ -13,6 +13,7 @@
 #include <boost/multi_index/hashed_index.hpp>
 #include <boost/thread/thread_time.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/date_time/posix_time/posix_time_io.hpp>
 
 struct BlackListEntry {
   std::string key;
@@ -91,7 +92,9 @@ public:
   {
     bl_db->purgeEntries();
   }
-  std::vector<BlackListEntry> getEntries();
+  std::vector<BlackListEntry> getIPEntries();
+  std::vector<BlackListEntry> getLoginEntries();
+  std::vector<BlackListEntry> getIPLoginEntries();
 };
 
 extern BlackListDB bl_db;

--- a/blacklist.hh
+++ b/blacklist.hh
@@ -48,6 +48,7 @@ private:
 
   enum BLType { IP_BL=0, LOGIN_BL=1, IP_LOGIN_BL=2 };
   const char* bl_names[3] = { "ip_bl", "login_bl", "ip_login_bl" };
+  const char* key_names[3] = { "ip", "login", "ip_login" };
   blacklist_t ip_blacklist;
   blacklist_t login_blacklist;
   blacklist_t ip_login_blacklist;

--- a/configure.ac
+++ b/configure.ac
@@ -13,6 +13,7 @@ PKG_CHECK_MODULES([LIBSYSTEMD], [libsystemd], [AC_DEFINE([HAVE_LIBSYSTEMD], [1],
 AM_CONDITIONAL([LIBSYSTEMD],[test "$HAVE_LIBSYSTEMD" = "1"])
 AC_PROG_LIBTOOL
 BOOST_REQUIRE([1.35])
+BOOST_DATE_TIME
 BOOST_FOREACH
 AC_SUBST([YAHTTP_CFLAGS], ['-I$(top_srcdir)/ext/yahttp'])
 AC_SUBST([YAHTTP_LIBS], ['-L$(top_builddir)/ext/yahttp/yahttp -lyahttp'])

--- a/ext/count_min_sketch.cpp
+++ b/ext/count_min_sketch.cpp
@@ -123,6 +123,7 @@ void CountMinSketch::erase() {
       C[i][j] = 0;
     }
   }
+  total = 0; // zero the running total
 }
 
 // generates aj,bj from field Z_p for use in hashing

--- a/regression-tests/test_Blacklist.py
+++ b/regression-tests/test_Blacklist.py
@@ -1,0 +1,96 @@
+import requests
+import socket
+import time
+import json
+from test_helper import ApiTestCase
+
+class TestBlacklist(ApiTestCase):
+
+    def test_IPBlacklist(self):
+        r = self.allowFunc('goodie', '192.168.72.14', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], 0)
+        r.close()
+
+        r = self.allowFunc('goodie', '2001:503:ba3e::2:30', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], 0)
+        r.close()
+
+        self.writeCmdToConsole("ca4 = newCA(\"192.168.72.14\")")
+        self.writeCmdToConsole("ca6 = newCA(\"2001:503:ba3e::2:30\")")
+        self.writeCmdToConsole("blacklistIP(ca4, 10, \"test blacklist\")")
+        self.writeCmdToConsole("blacklistIP(ca6, 10, \"test blacklist\")")
+
+        r = self.allowFunc('goodie', '192.168.72.14', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], -1)
+        r.close()
+
+        r = self.allowFunc('goodie', '2001:503:ba3e::2:30', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], -1)
+        r.close()
+
+        time.sleep(11);
+
+        r = self.allowFunc('goodie', '192.168.72.14', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], 0)
+        r.close()
+        
+        r = self.allowFunc('goodie', '2001:503:ba3e::2:30', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], 0)
+        r.close()
+    
+    def test_LoginBlacklist(self):
+        r = self.allowFunc('goodie', '192.168.72.14', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], 0)
+        r.close()
+
+        self.writeCmdToConsole("blacklistLogin(\"goodie\", 10, \"test blacklist\")")
+
+        r = self.allowFunc('goodie', '192.168.72.14', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], -1)
+        r.close()
+
+        time.sleep(11);
+
+        r = self.allowFunc('goodie', '192.168.72.14', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], 0)
+        r.close()
+
+    def test_IPLoginBlacklist(self):
+        r = self.allowFunc('goodie', '192.168.72.14', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], 0)
+        r.close()
+
+        self.writeCmdToConsole("ca4 = newCA(\"192.168.72.14\")")
+        self.writeCmdToConsole("blacklistIPLogin(ca4, \"goodie\", 10, \"test blacklist\")")
+
+        r = self.allowFunc('goodie', '192.168.72.14', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], -1)
+        r.close()
+
+        r = self.allowFunc('goody', '192.168.72.14', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], 0)
+        r.close()
+
+        r = self.allowFunc('goodie', '192.168.72.15', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], 0)
+        r.close()
+
+        time.sleep(11);
+
+        r = self.allowFunc('goodie', '192.168.72.14', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], 0)
+        r.close()

--- a/sholder.hh
+++ b/sholder.hh
@@ -1,3 +1,4 @@
+#pragma once
 #include <memory>
 #include <atomic>
 #include <mutex>

--- a/twmap.cc
+++ b/twmap.cc
@@ -4,6 +4,7 @@
 
 TWStatsTypeMap g_field_types{};
 
+std::mutex dbMap_mutx;
 std::map<std::string, TWStringStatsDBWrapper> dbMap;
 
 #ifdef MAIN

--- a/twmap.hh
+++ b/twmap.hh
@@ -369,12 +369,13 @@ public:
   void add(const T& key, const std::string& field_name, const std::string& s, int a); 
   void sub(const T& key, const std::string& field_name, int a); 
   void sub(const T& key, const std::string& field_name, const std::string& s); 
-  int get(const T& key, const std::string& field_name); // gets all fields summed/combined over all windows
-  int get(const T& key, const std::string& field_name, const std::string& s); // gets all fields summed/combined over all windows for a particular value
+  int get(const T& key, const std::string& field_name); // gets all values summed/combined over all windows
+  int get(const T& key, const std::string& field_name, const std::string& s); // gets all values summed/combined over all windows for a particular value
   int get_current(const T& key, const std::string& field_name); // gets the value just for the current window
   int get_current(const T& key, const std::string& field_name, const std::string& s); // gets the value just for the current window for a particular value
   bool get_windows(const T& key, const std::string& field_name, std::vector<int>& ret_vec); // gets each window value returned in a vector
   bool get_windows(const T& key, const std::string& field_name, const std::string& s, std::vector<int>& ret_vec); // gets each window value returned in a vector for a particular value
+  bool get_all_fields(const T& key,  std::vector<std::pair<std::string, int>>& ret_vec);
   void reset(const T&key); // Reset to zero all fields for a given key
   void set_map_size_soft(unsigned int size);
   unsigned int get_size();
@@ -662,6 +663,27 @@ bool TWStatsDB<T>::get_windows(const T& key, const std::string& field_name, cons
 }
 
 template <typename T>
+bool TWStatsDB<T>::get_all_fields(const T& key, std::vector<std::pair<std::string, int>>& ret_vec)
+{
+  std::lock_guard<std::mutex> lock(mutx);  
+
+  auto mysdb = stats_db.find(key);
+  if (mysdb == stats_db.end()) {
+    return false;
+  }
+  else {
+    auto myfm = mysdb->second.second;
+    // go through all the fields, get them and add to a vector
+    for (auto it = myfm.begin(); it != myfm.end(); ++it) {
+      std::string field_name = it->first;
+      auto stats_entryp = it->second;
+      ret_vec.push_back(make_pair(field_name, stats_entryp->sum()));
+    }
+  }
+  return true;
+}
+
+template <typename T>
 void TWStatsDB<T>::reset(const T& key)
 {
   std::lock_guard<std::mutex> lock(mutx);  
@@ -865,6 +887,12 @@ public:
       (void) sdbp->get_windows(key, field_name, retvec);
 
     return retvec; // copy
+  }
+
+  bool get_all_fields(const TWKeyType vkey, std::vector<std::pair<std::string, int>>& ret_vec)
+  {
+    std::string key = getStringKey(vkey);
+    return sdbp->get_all_fields(key, ret_vec);
   }
 
   void reset(const TWKeyType vkey)

--- a/twmap.hh
+++ b/twmap.hh
@@ -913,4 +913,5 @@ public:
 
 };
 
+extern std::mutex dbMap_mutx;
 extern std::map<std::string, TWStringStatsDBWrapper> dbMap;

--- a/wforce-lua.cc
+++ b/wforce-lua.cc
@@ -326,6 +326,7 @@ vector<std::function<void(void)>> setupLua(bool client, bool allow_report, LuaCo
     c_lua.writeFunction("newStringStatsDB", [](const std::string& name, int window_size, int num_windows, const std::vector<pair<std::string, std::string>>& fmvec) {
 	auto twsdbw = TWStringStatsDBWrapper(name, window_size, num_windows, fmvec);
 	// register this statsDB in a map for retrieval later
+	std::lock_guard<std::mutex> lock(dbMap_mutx);
 	dbMap.insert(std::pair<std::string, TWStringStatsDBWrapper>(name, twsdbw));
       });
   }
@@ -334,6 +335,7 @@ vector<std::function<void(void)>> setupLua(bool client, bool allow_report, LuaCo
   }
 
   c_lua.writeFunction("getStringStatsDB", [](const std::string& name) {
+      std::lock_guard<std::mutex> lock(dbMap_mutx);
       auto it = dbMap.find(name);
       if (it != dbMap.end())
 	return it->second; // copy

--- a/wforce-lua.cc
+++ b/wforce-lua.cc
@@ -5,6 +5,7 @@
 #include "sodcrypto.hh"
 #include "base64.hh"
 #include "twmap.hh"
+#include "blacklist.hh"
 #include <fstream>
 
 #ifdef HAVE_GEOIP
@@ -358,6 +359,18 @@ vector<std::function<void(void)>> setupLua(bool client, bool allow_report, LuaCo
 	os << i.first << "="<< "\"" << i.second << "\"" << " ";
       }
       infolog(os.str().c_str());
+    });
+
+  c_lua.writeFunction("blacklistIP", [](const ComboAddress& ca, unsigned int seconds, const std::string& reason) {
+      bl_db.addEntry(ca, seconds, reason);
+    });
+
+  c_lua.writeFunction("blacklistLogin", [](const std::string& login, unsigned int seconds, const std::string& reason) {
+      bl_db.addEntry(login, seconds, reason);
+    });
+
+  c_lua.writeFunction("blacklistIPLogin", [](const ComboAddress& ca, const std::string& login, unsigned int seconds, const std::string& reason) {
+      bl_db.addEntry(ca, login, seconds, reason);
     });
 
   c_lua.registerMember("t", &LoginTuple::t);

--- a/wforce-web.cc
+++ b/wforce-web.cc
@@ -392,15 +392,18 @@ void parseGetStatsCmd(const YaHTTP::Request& req, YaHTTP::Response& resp)
     } 
     else {
       Json::object js_db_stats;
-      for (auto i = dbMap.begin(); i != dbMap.end(); ++i) {
-	std::string dbName = i->first;
-	std::vector<std::pair<std::string, int>> db_fields;
-	if (i->second.get_all_fields(lookup_key, db_fields)) {
-	  Json::object js_db_fields;
-	  for (auto j = db_fields.begin(); j != db_fields.end(); ++j) {
-	    js_db_fields.insert(make_pair(j->first, j->second));
+      {
+	std::lock_guard<std::mutex> lock(dbMap_mutx);
+	for (auto i = dbMap.begin(); i != dbMap.end(); ++i) {
+	  std::string dbName = i->first;
+	  std::vector<std::pair<std::string, int>> db_fields;
+	  if (i->second.get_all_fields(lookup_key, db_fields)) {
+	    Json::object js_db_fields;
+	    for (auto j = db_fields.begin(); j != db_fields.end(); ++j) {
+	      js_db_fields.insert(make_pair(j->first, j->second));
+	    }
+	    js_db_stats.insert(make_pair(dbName, js_db_fields));
 	  }
-	  js_db_stats.insert(make_pair(dbName, js_db_fields));
 	}
       }
       Json ret_json = Json::object {

--- a/wforce.cc
+++ b/wforce.cc
@@ -194,7 +194,7 @@ try
   int sock;
   warnlog("Accepting control connections on %s", local.toStringWithPort());
   while((sock=SAccept(fd, client)) >= 0) {
-    warnlog("Got control connection from %s", client.toStringWithPort());
+    infolog("Got control connection from %s", client.toStringWithPort());
     thread t(controlClientThread, sock, client);
     t.detach();
   }

--- a/wforce.cc
+++ b/wforce.cc
@@ -33,6 +33,7 @@
 #include "ext/json11/json11.hpp"
 #include <unistd.h>
 #include "sodcrypto.hh"
+#include "blacklist.hh"
 #include <getopt.h>
 #ifdef HAVE_LIBSYSTEMD
 #include <systemd/sd-daemon.h>
@@ -788,6 +789,10 @@ try
     thread t1(tcpAcceptorThread, cs);
     t1.detach();
   }
+
+  // setup blacklist_db purge thread
+  thread t1(BlackListDB::purgeEntriesThread, &bl_db);
+  t1.detach();
 
 #ifdef HAVE_LIBSYSTEMD
   sd_notify(0, "READY=1");

--- a/wforce.conf
+++ b/wforce.conf
@@ -15,7 +15,7 @@ function twreport(lt)
 	then
 	   sdb = getStringStatsDB("OneHourDB")
 	   sdb:twAdd(lt.remote, "diffFailedPasswords", lt.pwhash)
-	   addrlogin = lt.remote:tostring() .. lt.login
+	   addrlogin = lt.remote:tostring() .. ":" .. lt.login
 	   sdb:twAdd(addrlogin, "diffFailedPasswords", lt.pwhash)
 	end
 end
@@ -36,7 +36,7 @@ function allow(lt)
 		return -1, "", "too many different failed password attempts by IP", { attempts=50 }
 	end
 
-	addrlogin = lt.remote:tostring() .. lt.login
+	addrlogin = lt.remote:tostring() .. ":" .. lt.login
 	
 	if(sdb:twGet(addrlogin, "diffFailedPasswords") > 3)
 	then

--- a/wforce.conf.example
+++ b/wforce.conf.example
@@ -55,7 +55,7 @@ function report(lt)
 	sdb_day = getStringStatsDB("24HourDB")
 	cur_ct = lookupCountry(lt.remote) 
 
-	-- A note on keys: You can use strings or ComboAddresses. ComboAdddress will be converted to a string and then used as a key.
+	-- A note on keys: You can use strings or ComboAddresses.
 	-- You can specify a separate ipv4 and v6 netmasks for the DB, which will be used for all ComboAddress keys, thus allowing aggregation of IP stats
 	-- Example for IPv4 addresses: sdb:twSetv4Prefix(24) 
 	-- Example for IPv6 addresses: sdb:twSetv6Prefix(64)


### PR DESCRIPTION
The following features are added:

- Blacklisting support 
    - You can add IPs/Logins/IP:Login Tuples to a blacklist from Lua with an individual expiry for each entry added
    - When an allow command is received the blacklist is checked and if on the blacklist, -1 is returned and Lua is not called.
    - Full regression for blacklisting
    - New HTTP command "getBL" to retrieve the current contents of the blacklist in a json object
- Introspection Support
    - New command to retrieve "everything" known about a given IP/Login or IP:Login tuple
    - Returns all fields from all DBs registered as well as whether blacklisted in a json object
 
