### PR TITLE
Remove PrivateDevices from wforce.service

### DIFF
--- a/wforce.service.in
+++ b/wforce.service.in
@@ -10,7 +10,6 @@ ExecStart=@bindir@/wforce -s
 Restart=on-failure
 StartLimitInterval=0
 PrivateTmp=true
-PrivateDevices=true
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 NoNewPrivileges=true
 ProtectSystem=full


### PR DESCRIPTION
Remove PrivateDevices as there is a bug affecting older versions of systemd that prevents journalctl from functioning