### PR TITLE
Refactoring of twmap.hh 

### DIFF
--- a/docs/manpages/wforce.1.md
+++ b/docs/manpages/wforce.1.md
@@ -87,6 +87,15 @@ started with the -c option.
 		192.168.1.30:4001                   25        0              
 		192.168.1.54:4001                   0         0            Self
 
+* showStringStatsDB() - Returns information about configured stats
+  databases. For example:
+
+		> showStringStatsDB()
+		DB Name              Win Size/No Max Size  Cur Size  Field Name       Field Type
+		MyDB1                1/15        524288    0         countLogins      int
+		                                                     diffPasswords    hll
+		MyDB2                600/6       5000      2093      diffIPs          hll
+
 * showACL() - Returns the configured ACLs for the wforce server.
 
 		> showACL()

--- a/twmap-wrapper.cc
+++ b/twmap-wrapper.cc
@@ -53,6 +53,11 @@ void TWStringStatsDBWrapper::disableReplication()
   *replicated = false;
 }
 
+std::string TWStringStatsDBWrapper::getDBName()
+{
+  return sdbp->getDBName();
+}
+
 bool TWStringStatsDBWrapper::setFields(const std::vector<pair<std::string, std::string>>& fmvec)
 {
   FieldMap fm;
@@ -65,6 +70,11 @@ bool TWStringStatsDBWrapper::setFields(const std::vector<pair<std::string, std::
 bool TWStringStatsDBWrapper::setFields(const FieldMap& fm) 
 {
   return(sdbp->setFields(fm));
+}
+
+const FieldMap& TWStringStatsDBWrapper::getFields()
+{
+  return(sdbp->getFields());
 }
 
 void TWStringStatsDBWrapper::setv4Prefix(uint8_t bits)
@@ -279,4 +289,19 @@ unsigned int TWStringStatsDBWrapper::get_size()
 void TWStringStatsDBWrapper::set_size_soft(unsigned int size) 
 {
   sdbp->set_map_size_soft(size);
+}
+
+unsigned int TWStringStatsDBWrapper::get_max_size()
+{	
+  return sdbp->get_max_size();
+}
+
+int TWStringStatsDBWrapper::windowSize()
+{
+  return sdbp->windowSize();
+}
+
+int TWStringStatsDBWrapper::numWindows()
+{
+  return sdbp->numWindows();
 }

--- a/twmap-wrapper.hh
+++ b/twmap-wrapper.hh
@@ -40,8 +40,10 @@ public:
 
   void enableReplication();
   void disableReplication();
+  std::string getDBName();
   bool setFields(const std::vector<pair<std::string, std::string>>& fmvec);
   bool setFields(const FieldMap& fm);
+  const FieldMap& getFields();
   void setv4Prefix(uint8_t bits);
   void setv6Prefix(uint8_t bits);
   std::string getStringKey(const TWKeyType vkey);
@@ -56,7 +58,10 @@ public:
   void reset(const TWKeyType vkey);
   void resetInternal(const TWKeyType vkey, bool replicate=true);
   unsigned int get_size();
+  unsigned int get_max_size();
   void set_size_soft(unsigned int size);
+  int windowSize();
+  int numWindows();
 };
 
 extern std::mutex dbMap_mutx;

--- a/twmap.hh
+++ b/twmap.hh
@@ -27,6 +27,7 @@
 #include <map>
 #include <unordered_map>
 #include <ctime>
+#include <atomic>
 #include <mutex>
 #include <thread>
 #include <boost/variant.hpp>
@@ -40,9 +41,17 @@
 
 using std::thread;
 
+namespace wforce {
+  template<typename T, typename... Ts>
+  std::unique_ptr<T> make_unique(Ts&&... params)
+  {
+    return std::unique_ptr<T>(new T(std::forward<Ts>(params)...));
+  }
+}
+
 class TWStatsMember;
 
-typedef std::shared_ptr<TWStatsMember> TWStatsMemberP;
+typedef std::unique_ptr<TWStatsMember> TWStatsMemberP;
 typedef std::vector<std::pair<std::time_t, TWStatsMemberP>> TWStatsBuf;
 
 // Not all stats member subclasses will implement all of these methods in a useful way (e.g. add string is meaningless to an integer-based class)
@@ -66,6 +75,9 @@ public:
 class TWStatsMemberInt : public TWStatsMember
 {
 public:
+  TWStatsMemberInt() {}
+  TWStatsMemberInt(const TWStatsMemberInt&) = delete;
+  TWStatsMemberInt& operator=(const TWStatsMemberInt&) = delete;
   void add(int a) { i += a; }
   void add(const std::string& s) { int a = std::stoi(s); i += a; return; }
   void add(const std::string& s, int a) { return; }
@@ -79,9 +91,9 @@ public:
   int sum(const TWStatsBuf& vec)
   {
     int count = 0;
-    for (auto a : vec)
+    for (auto a=vec.begin(); a!=vec.end(); ++a)
       {
-        count += a.second->get();
+        count += a->second->get();
       }
     return count;
   }
@@ -97,10 +109,12 @@ class TWStatsMemberHLL : public TWStatsMember
 public:
   TWStatsMemberHLL()
   {
-    hllp = std::make_shared<hll::HyperLogLog>(HLL_NUM_REGISTER_BITS);
+    hllp = wforce::make_unique<hll::HyperLogLog>(HLL_NUM_REGISTER_BITS);
     cache_valid = false;
     cached_sum = 0;
   }
+  TWStatsMemberHLL(const TWStatsMemberHLL&) = delete;
+  TWStatsMemberHLL& operator=(const TWStatsMemberHLL&) = delete;
   void add(int a) { std::string str; str = std::to_string(a); hllp->add(str.c_str(), str.length()); cache_valid = false; return; }
   void add(const std::string& s) { hllp->add(s.c_str(), s.length()); cache_valid = false; return; }
   void add(const std::string& s, int a) { return; }
@@ -113,14 +127,13 @@ public:
   void erase() { hllp->clear(); cache_valid = false; }
   int sum(const TWStatsBuf& vec)
   {
-    if (cache_valid)
+    if (cache_valid == true)
       return cached_sum;
     hll::HyperLogLog hllsum(HLL_NUM_REGISTER_BITS);
-    for (auto a : vec)
+    for (auto a = vec.begin(); a != vec.end(); ++a)
       {
 	// XXX yes not massively pretty
-	std::shared_ptr<TWStatsMemberHLL> twp = std::dynamic_pointer_cast<TWStatsMemberHLL>(a.second);
-	hllsum.merge((*(twp->hllp)));
+	hllsum.merge(*((dynamic_cast<TWStatsMemberHLL&>(*(a->second))).hllp));
       }
     cached_sum = std::lround(hllsum.estimate());
     cache_valid = true;
@@ -128,7 +141,7 @@ public:
   }
   int sum(const std::string& s, const TWStatsBuf& vec) { return 0; }
 private:
-  std::shared_ptr<hll::HyperLogLog> hllp;
+  std::unique_ptr<hll::HyperLogLog> hllp;
   int cached_sum;
   bool cache_valid;
 };
@@ -141,8 +154,10 @@ class TWStatsMemberCountMin : public TWStatsMember
 public:
   TWStatsMemberCountMin()
   {
-    cm = std::make_shared<CountMinSketch>(COUNTMIN_EPS, COUNTMIN_GAMMA);
+    cm = wforce::make_unique<CountMinSketch>(COUNTMIN_EPS, COUNTMIN_GAMMA);
   }
+  TWStatsMemberCountMin(const TWStatsMemberCountMin&) = delete;
+  TWStatsMemberCountMin& operator=(const TWStatsMemberCountMin&) = delete;
   void add(int a) { return; }
   void add(const std::string& s) { cm->update(s.c_str(), 1); }
   void add(const std::string& s, int a) { cm->update(s.c_str(), a); }
@@ -156,26 +171,26 @@ public:
   int sum(const TWStatsBuf& vec)
   {
     int count = 0;
-    for (auto a : vec)
+    for (auto a=vec.begin(); a!=vec.end(); ++a)
       {
-	count += a.second->get();
+	count += a->second->get();
       }
     return count;
   }
   int sum(const std::string&s, const TWStatsBuf& vec)
   {
     int count = 0;
-    for (auto a : vec)
+    for (auto a=vec.begin(); a!=vec.end(); ++a)
       {
-	count += a.second->get(s);
+	count += a->second->get(s);
       }
     return count;
   }
 private:
-  std::shared_ptr<CountMinSketch> cm;
+  std::unique_ptr<CountMinSketch> cm;
 };
 
-template<typename T> TWStatsMemberP createInstance() { return std::make_shared<T>(); }
+template<typename T> TWStatsMemberP createInstance() { return wforce::make_unique<T>(); }
 
 typedef std::map<std::string, TWStatsMemberP(*)()> map_type;
 
@@ -195,6 +210,8 @@ struct TWStatsTypeMap
 
 extern TWStatsTypeMap g_field_types;
 
+// this class is not protected by mutexes because it sits behind TWStatsDB which has a mutex
+// controlling all access
 class TWStatsEntry
 {
 public:
@@ -210,72 +227,67 @@ public:
       }
     }
   }
+
+  // prevent copies at compile time
+  TWStatsEntry(const TWStatsEntry&) = delete;
+  TWStatsEntry& operator=(const TWStatsEntry&) = delete;
+
   void add(int a) {
-    std::lock_guard<std::mutex> lock(mutx);
     clean_windows();
     int cur_window = current_window();
-    auto sm = stats_array[cur_window];
+    auto& sm = stats_array[cur_window];
     sm.second->add(a);
     update_write_timestamp(cur_window);
   }
   void add(const std::string& s) {
-    std::lock_guard<std::mutex> lock(mutx);
     clean_windows();
     int cur_window = current_window();
-    auto sm = stats_array[cur_window];
+    auto& sm = stats_array[cur_window];
     sm.second->add(s);
     update_write_timestamp(cur_window);
   }
   void add(const std::string& s, int a) {
-    std::lock_guard<std::mutex> lock(mutx);
     clean_windows();
     int cur_window = current_window();
-    auto sm = stats_array[cur_window];
+    auto& sm = stats_array[cur_window];
     sm.second->add(s, a);
     update_write_timestamp(cur_window);
   }
   void sub(int a) {
-    std::lock_guard<std::mutex> lock(mutx);
     clean_windows();
     int cur_window = current_window();
-    auto sm = stats_array[cur_window];
+    auto& sm = stats_array[cur_window];
     sm.second->sub(a);
     update_write_timestamp(cur_window);
   }
   void sub(const std::string& s) {
-    std::lock_guard<std::mutex> lock(mutx);
     clean_windows();
     int cur_window = current_window();
-    auto sm = stats_array[cur_window];
+    auto& sm = stats_array[cur_window];
     sm.second->sub(s);
     update_write_timestamp(cur_window);
   }
   int get() {
-    std::lock_guard<std::mutex> lock(mutx);
     clean_windows();
     int cur_window = current_window();
     return stats_array[cur_window].second->get();
   }
   int get(const std::string& s) {
-    std::lock_guard<std::mutex> lock(mutx);
     clean_windows();
     int cur_window = current_window();
     return stats_array[cur_window].second->get(s);
   }
   int get_current() { 
-    std::lock_guard<std::mutex> lock(mutx);
     clean_windows();
     int cur_window = current_window();
     return stats_array[cur_window].second->get();
   }
   int get_current(const std::string& s) {
-    std::lock_guard<std::mutex> lock(mutx);
     clean_windows();
     int cur_window = current_window();
     return stats_array[cur_window].second->get(s);    
   }
   void get_windows(std::vector<int>& ret_vec) {
-    std::lock_guard<std::mutex> lock(mutx);
     clean_windows();
     int cur_window = current_window();
     for (int i=cur_window+num_windows; i>cur_window; i--) {
@@ -284,7 +296,6 @@ public:
     }
   }
   void get_windows(const std::string& s, std::vector<int>& ret_vec) {
-    std::lock_guard<std::mutex> lock(mutx);
     clean_windows();
     int cur_window = current_window();
     for (int i=cur_window+num_windows; i>cur_window; i--) {
@@ -293,22 +304,18 @@ public:
     }
   }
   int sum() {
-    std::lock_guard<std::mutex> lock(mutx);
     clean_windows();
     int cur_window = current_window();
     return stats_array[cur_window].second->sum(stats_array);
   }
   int sum(const std::string& s) {
-    std::lock_guard<std::mutex> lock(mutx);
     clean_windows();
     int cur_window = current_window();
     return stats_array[cur_window].second->sum(s, stats_array);
   }
   void reset() {
-    std::lock_guard<std::mutex> lock(mutx);
     for (TWStatsBuf::iterator i = stats_array.begin(); i != stats_array.end(); ++i) {
-      auto sm = i->second;
-      sm->erase();
+      i->second->erase();
     }
   }
 protected:
@@ -343,9 +350,8 @@ protected:
 
     for (TWStatsBuf::iterator i = stats_array.begin(); i != stats_array.end(); ++i) {
       std::time_t last_write = i->first;
-      auto sm = i->second;
       if ((last_write != 0) && (now - last_write) >= expire_diff) {
-	sm->erase();
+	i->second->erase();
 	i->first = 0;
       }
     }
@@ -353,14 +359,13 @@ protected:
   }
 private:
   TWStatsBuf stats_array;
-  mutable std::mutex mutx;
   int num_windows;
   int window_size;
   std::time_t start_time;
   std::time_t last_cleaned;
 };
 
-typedef std::shared_ptr<TWStatsEntry> TWStatsEntryP;
+typedef std::unique_ptr<TWStatsEntry> TWStatsEntryP;
 
 // key is field name, value is field type
 typedef std::map<std::string, std::string> FieldMap;
@@ -380,7 +385,10 @@ public:
     map_size_soft = ctwstats_map_size_soft;
     db_name = name;
   }
-
+  // detect attempts to copy at compile time
+  TWStatsDB(const TWStatsDB&) = delete;
+  TWStatsDB& operator=(const TWStatsDB&) = delete;
+  
   std::string getDBName()
   {
     return db_name;
@@ -392,6 +400,9 @@ public:
   }	
   void expireEntries();
   bool setFields(const FieldMap& fields);
+  const FieldMap& getFields() {
+    return field_map;
+  }
   void incr(const T& key, const std::string& field_name);
   void decr(const T& key, const std::string& field_name);
   void add(const T& key, const std::string& field_name, int a); 
@@ -409,13 +420,21 @@ public:
   void reset(const T&key); // Reset to zero all fields for a given key
   void set_map_size_soft(unsigned int size);
   unsigned int get_size();
+  unsigned int get_max_size();
   uint8_t getv4Prefix() { return v4_prefix; }
   uint8_t getv6Prefix() { return v6_prefix; }
   void setv4Prefix(uint8_t prefix) { v4_prefix = prefix; }
   void setv6Prefix(uint8_t prefix) { v6_prefix = prefix; }
+  int windowSize() { return window_size; }
+  int numWindows() { return num_windows; }
 protected:
-  bool find_create_key_field(const T& key, const std::string& field_name, TWStatsEntryP& tp, typename TWKeyTrackerType::iterator* ktp, bool create=1);
-  bool find_key_field(const T& key, const std::string& field_name, TWStatsEntryP& tp);  
+  template<typename Fn>
+  bool find_create_key_field(const T& key, const std::string& field_name,
+					   Fn fn, bool create=true);
+  template<typename Fn>
+  bool find_key_field(const T& key, const std::string& field_name,
+					   Fn fn);
+
   void update_write_timestamp(typename TWKeyTrackerType::iterator& kt)
   {
     // this is always called from a mutex lock (or should be)
@@ -424,8 +443,6 @@ protected:
 		       key_tracker,
 		       kt);
   }
-  int windowSize() { return window_size; }
-  int numWindows() { return num_windows; }
 private:
   TWKeyTrackerType key_tracker;
   typedef std::unordered_map<T, std::pair<typename TWKeyTrackerType::iterator, std::map<std::string, TWStatsEntryP>>> TWStatsDBMap;
@@ -473,7 +490,7 @@ void TWStatsDB<T>::expireEntries()
       unsigned int num_expire = stats_db.size() - map_size_soft;
       unsigned int num_expired = num_expire;
 
-      infolog("About to expire %d entries from stats db", num_expire);
+      infolog("About to expire %d entries from stats db %s", num_expire, db_name);
 
       // this just uses the front of the key tracker list, which always contains the Least Recently Modified keys
       while (num_expire--) {
@@ -483,22 +500,29 @@ void TWStatsDB<T>::expireEntries()
 	  key_tracker.pop_front();
 	}
       }
-      infolog("Finished expiring %d entries from stats db", num_expired);
+      infolog("Finished expiring %d entries from stats db %s", num_expired, db_name);
     }
   }
 }
 
 template <typename T>
-bool TWStatsDB<T>::find_key_field(const T& key, const std::string& field_name, TWStatsEntryP& tp)
+template <typename Fn>
+bool TWStatsDB<T>::find_key_field(const T& key, const std::string& field_name, Fn fn)
 {
-  return find_create_key_field(key, field_name, tp, NULL, false);
+  std::lock_guard<std::mutex> lock(mutx);
+  return find_create_key_field(key, field_name, fn, false);
 }
 
 template <typename T>
-bool TWStatsDB<T>::find_create_key_field(const T& key, const std::string& field_name, TWStatsEntryP& tp, 
-					 typename TWKeyTrackerType::iterator* keytrack, bool create)
+template <typename Fn>
+bool TWStatsDB<T>::find_create_key_field(const T& key, const std::string& field_name,
+					 Fn fn, bool create)
 {
   TWStatsBuf myrv;
+  bool retval = false;
+
+  if (create == true)
+    std::lock_guard<std::mutex> lock(mutx);
 
   // first check if the field name is in the field map - if not we throw the query out straight away
   auto myfield = field_map.find(field_name);
@@ -516,41 +540,32 @@ bool TWStatsDB<T>::find_create_key_field(const T& key, const std::string& field_
     // the key already exists let's look for the field
     auto myfm = mysdb->second.second.find(field_name);
     if (myfm != mysdb->second.second.end()) {
-      // awesome this key/field combination has already been created
-      tp = myfm->second;
-      if (keytrack)
-	*keytrack = mysdb->second.first;
-      return(true);
+      // awesome this key/field combination has already been created so call the supplied lambda
+      fn(myfm, mysdb->second.first);
+      retval = true;
     }
     else {
       if (create) {
 	// if we get here it means the key exists, but not the field so we need to add it
-	auto field_type = mytype->first;
-	tp = std::make_shared<TWStatsEntry>(num_windows, window_size, start_time, field_type);
-	mysdb->second.second.insert(std::pair<std::string, TWStatsEntryP>(field_name, tp));
-	if (keytrack)
-	  *keytrack = mysdb->second.first;
-	return(true);
+	mysdb->second.second.emplace(std::make_pair(field_name, wforce::make_unique<TWStatsEntry>(num_windows, window_size, start_time, mytype->first)));
+	retval = find_create_key_field(key, field_name, fn, false);
       }
     }
   }
   else {
     if (create) {
       // if we get here, we have no key and no field
-      auto field_type = mytype->first;
-      tp = std::make_shared<TWStatsEntry>(num_windows, window_size, start_time, field_type);      
-      std::map<std::string, TWStatsEntryP> myfm;
-      myfm.insert(std::make_pair(field_name, tp));
       // add the key at the end of the key tracker list
       typename TWKeyTrackerType::iterator kit = key_tracker.insert(key_tracker.end(), key);
-      stats_db.insert(std::make_pair(key, std::make_pair(kit, myfm)));
-      if (keytrack)
-	*keytrack = kit;
-      return(true);
+      std::map<std::string, TWStatsEntryP> myfm;
+      myfm.emplace(std::make_pair(field_name, wforce::make_unique<TWStatsEntry>(num_windows, window_size, start_time, mytype->first)));
+      stats_db.emplace(std::make_pair(key, std::make_pair(kit, std::move(myfm))));
+      retval = find_create_key_field(key, field_name, fn, false);
     }
   }
-  return(false);
+  return(retval);
 }
+
 
 template <typename T>
 void TWStatsDB<T>::incr(const T& key, const std::string& field_name)
@@ -567,144 +582,124 @@ void TWStatsDB<T>::decr(const T& key, const std::string& field_name)
 template <typename T>
 void TWStatsDB<T>::add(const T& key, const std::string& field_name, int a)
 {
-  std::lock_guard<std::mutex> lock(mutx);
-  typename TWKeyTrackerType::iterator kt;
-  TWStatsEntryP tp;
-
-  if (find_create_key_field(key, field_name, tp, &kt) != true) {
-    return;
-  }
-  tp->add(a);
-  update_write_timestamp(kt);
+  find_create_key_field(key, field_name, [a, this](std::map<std::string, TWStatsEntryP>::iterator it, typename TWKeyTrackerType::iterator& kt)
+			    {
+			      it->second->add(a);
+			      this->update_write_timestamp(kt);
+			    });
 }
 
 template <typename T>
 void TWStatsDB<T>::add(const T& key, const std::string& field_name, const std::string& s)
 {
-  std::lock_guard<std::mutex> lock(mutx);
-  typename TWKeyTrackerType::iterator kt;
-  TWStatsEntryP tp;
-
-  if (find_create_key_field(key, field_name, tp, &kt) != true) {
-    return;
-  }
-  tp->add(s);
-  update_write_timestamp(kt);
+  find_create_key_field(key, field_name, [s, this](std::map<std::string, TWStatsEntryP>::iterator it, typename TWKeyTrackerType::iterator& kt)
+			{
+			  it->second->add(s);
+			  this->update_write_timestamp(kt);
+			});
 }
 
 template <typename T>
 void TWStatsDB<T>::add(const T& key, const std::string& field_name, const std::string& s, int a)
 {
-  std::lock_guard<std::mutex> lock(mutx);
-  typename TWKeyTrackerType::iterator kt;
-  TWStatsEntryP tp;
-
-  if (find_create_key_field(key, field_name, tp, &kt) != true) {
-    return;
-  }
-  tp->add(s, a);
-  update_write_timestamp(kt);
+  find_create_key_field(key, field_name, [&s, a, this](std::map<std::string, TWStatsEntryP>::iterator it, typename TWKeyTrackerType::iterator& kt)
+			{
+			  it->second->add(s, a);
+			  this->update_write_timestamp(kt);
+			});
 }
 
 template <typename T>
 void TWStatsDB<T>::sub(const T& key, const std::string& field_name, int a)
 {
-  std::lock_guard<std::mutex> lock(mutx);
-  typename TWKeyTrackerType::iterator kt;
-  TWStatsEntryP tp;
-
-  if (find_create_key_field(key, field_name, tp, &kt) != true) {
-    return;
-  }
-  tp->sub(a);
-  update_write_timestamp(kt);
+  find_create_key_field(key, field_name, [a, this](std::map<std::string, TWStatsEntryP>::iterator it, typename TWKeyTrackerType::iterator& kt)
+			{
+			  it->second->sub(a);
+			  update_write_timestamp(kt);
+			});
 }
 
 template <typename T>
 void TWStatsDB<T>::sub(const T& key, const std::string& field_name, const std::string& s)
 {
-  std::lock_guard<std::mutex> lock(mutx);
-  typename TWKeyTrackerType::iterator kt;
-  TWStatsEntryP tp;
-
-  if (find_create_key_field(key, field_name, tp, &kt) != true) {
-    return;
-  }
-  tp->sub(s);
-  update_write_timestamp(kt);
+  find_create_key_field(key, field_name, [s, this](std::map<std::string, TWStatsEntryP>::iterator it, typename TWKeyTrackerType::iterator& kt)
+			{
+			  it->second->sub(s);
+			  update_write_timestamp(kt);
+			});
 }
 
 template <typename T>
 int TWStatsDB<T>::get(const T& key, const std::string& field_name)
 {
-  std::lock_guard<std::mutex> lock(mutx);
-  TWStatsEntryP tp;
-
-  if (find_key_field(key, field_name, tp) != true) {
-    return 0;
-  }
-  return tp->sum();
+  int retval=0;
+  
+  find_key_field(key, field_name, [&retval](std::map<std::string, TWStatsEntryP>::iterator it, typename TWKeyTrackerType::iterator& kt)
+		 {
+		   retval = it->second->sum();
+		 });
+  return retval;
 }
 
 template <typename T>
 int TWStatsDB<T>::get(const T& key, const std::string& field_name, const std::string& s)
 {
-  std::lock_guard<std::mutex> lock(mutx);
-  TWStatsEntryP tp;
-  if (find_key_field(key, field_name, tp) != true) {
-    return 0;
-  }
-  return tp->sum(s);
+  int retval=0;
+  
+  find_key_field(key, field_name, [&retval, s](std::map<std::string, TWStatsEntryP>::iterator it, typename TWKeyTrackerType::iterator& kt)
+		 {
+		   retval = it->second->sum(s);
+		 });
+  return retval;
 }
 
 template <typename T>
 int TWStatsDB<T>::get_current(const T& key, const std::string& field_name)
 {
-  std::lock_guard<std::mutex> lock(mutx);
-  TWStatsEntryP tp;
-  if (find_key_field(key, field_name, tp) != true) {
-    return 0;
-  }
-  return tp->get();
+  int retval=0;
+  
+  find_key_field(key, field_name, [&retval](std::map<std::string, TWStatsEntryP>::iterator it, typename TWKeyTrackerType::iterator& kt)
+		 {
+		   retval = it->second->get();
+		 });
+  return retval;
 }
 
 template <typename T>
 int TWStatsDB<T>::get_current(const T& key, const std::string& field_name, const std::string& val)
 {
-  std::lock_guard<std::mutex> lock(mutx);
-  TWStatsEntryP tp;
-
-  if (find_key_field(key, field_name, tp) != true) {
-    return 0;
-  }
-  return tp->get(val);
+  int retval=0;
+  
+  find_key_field(key, field_name, [&retval, val](std::map<std::string, TWStatsEntryP>::iterator it, typename TWKeyTrackerType::iterator& kt)
+		 {
+		   retval = it->second->get(val);
+		 });
+  return retval;
 }
 
 
 template <typename T>
 bool TWStatsDB<T>::get_windows(const T& key, const std::string& field_name, std::vector<int>& ret_vec)
 {
-  std::lock_guard<std::mutex> lock(mutx);
-  TWStatsEntryP tp;
-
-  if (find_key_field(key, field_name, tp) != true) {
-    return false;
-  }
-  tp->get_windows(ret_vec);
-  return(true);
+  bool retval=false;
+  
+  retval = find_key_field(key, field_name, [&ret_vec](std::map<std::string, TWStatsEntryP>::iterator it, typename TWKeyTrackerType::iterator& kt)
+		 {
+		   it->second->get_windows(ret_vec);
+		 });
+  return(retval);
 }
 
 template <typename T>
 bool TWStatsDB<T>::get_windows(const T& key, const std::string& field_name, const std::string& val, std::vector<int>& ret_vec)
 {
-  std::lock_guard<std::mutex> lock(mutx);
-  TWStatsEntryP tp;
-
-  if (find_key_field(key, field_name, tp) != true) {
-    return false;
-  }
-  tp->get_windows(val, ret_vec);
-  return(true);
+  bool retval=false;
+  
+  retval = find_key_field(key, field_name, [&val, &ret_vec](std::map<std::string, TWStatsEntryP>::iterator it, typename TWKeyTrackerType::iterator& kt)
+		 {
+		   it->second->get_windows(val, ret_vec);
+		 });
+  return(retval);
 }
 
 template <typename T>
@@ -717,12 +712,10 @@ bool TWStatsDB<T>::get_all_fields(const T& key, std::vector<std::pair<std::strin
     return false;
   }
   else {
-    auto myfm = mysdb->second.second;
+    auto& myfm = mysdb->second.second;
     // go through all the fields, get them and add to a vector
     for (auto it = myfm.begin(); it != myfm.end(); ++it) {
-      std::string field_name = it->first;
-      auto stats_entryp = it->second;
-      ret_vec.push_back(make_pair(field_name, stats_entryp->sum()));
+      ret_vec.push_back(make_pair(it->first, it->second->sum()));
     }
   }
   return true;
@@ -735,11 +728,10 @@ void TWStatsDB<T>::reset(const T& key)
 
   auto mysdb = stats_db.find(key);
   if (mysdb != stats_db.end()) {
-    auto myfm = mysdb->second.second;
+    auto& myfm = mysdb->second.second;
     // go through all the fields and reset them
     for (auto it = myfm.begin(); it != myfm.end(); ++it) {
-      auto stats_entryp = it->second;
-      stats_entryp->reset();
+      it->second->reset();
     }
   }
 }
@@ -759,5 +751,13 @@ unsigned int TWStatsDB<T>::get_size()
   std::lock_guard<std::mutex> lock(mutx);
 
   return stats_db.size();
+}
+
+template <typename T>
+unsigned int TWStatsDB<T>::get_max_size()
+{
+  std::lock_guard<std::mutex> lock(mutx);
+
+  return map_size_soft;
 }
 

--- a/wforce.cc
+++ b/wforce.cc
@@ -84,7 +84,7 @@ catch(...) {
 
 std::mutex g_luamutex;
 LuaContext g_lua;
-int g_num_luastates=10;
+int g_num_luastates=NUM_LUA_STATES;
 std::shared_ptr<LuaMultiThread> g_luamultip;
 
 static void daemonize(void)


### PR DESCRIPTION
- replace shared ptrs with unique ptrs to reduce memory footprint
- move from using returning shared_ptr, to using lambda functions - also cut down on code duplication
- remove unnecessary mutexes from TWStatsEntry
- Add console showStringStatsDB() function and documented
- get rid of unnecessary copies, use emplace and std::move in places