### PR TITLE
Persistent Blacklists in Redis regression

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: required
 dist: trusty
 compiler:
   - gcc
+services:
+  - redis-server
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ addons:
       - protobuf-compiler
       - libhiredis-dev
       - libcurl4-openssl-dev
+      - redis-server
 before_script:
  - sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install systemd-services libsystemd-daemon-dev libsystemd-daemon0
  - wget http://http.us.debian.org/debian/pool/main/libs/libsodium/libsodium-dev_1.0.0-1_amd64.deb http://http.us.debian.org/debian/pool/main/libs/libsodium/libsodium13_1.0.0-1_amd64.deb

--- a/blacklist.cc
+++ b/blacklist.cc
@@ -441,7 +441,6 @@ void BlackListDB::makePersistent(const std::string& host, unsigned int port=6379
 bool BlackListDB::addPersistEntry(const std::string& key, time_t seconds, BLType bl_type, const std::string& reason)
 {
   bool retval = false;
-  std::lock_guard<std::mutex> lock(mutx);
   if (checkSetupContext()) {
     std::stringstream redis_key_s;
     std::stringstream redis_value_s;
@@ -466,8 +465,6 @@ bool BlackListDB::addPersistEntry(const std::string& key, time_t seconds, BLType
 bool BlackListDB::deletePersistEntry(const std::string& key, BLType bl_type, blacklist_t& blacklist)
 {
   bool retval = false;
-  std::lock_guard<std::mutex> lock(mutx);
-
   if (checkSetupContext()) {
     BlackListEntry ble;
     std::stringstream redis_key_s;

--- a/regression-tests/test_Blacklist.py
+++ b/regression-tests/test_Blacklist.py
@@ -1,5 +1,7 @@
 import requests
 import socket
+import subprocess
+import sys
 import time
 import json
 from test_helper import ApiTestCase
@@ -17,11 +19,11 @@ class TestBlacklist(ApiTestCase):
         self.assertEquals(j['status'], 0)
         r.close()
 
-        r = self.addBLEntryIP("192.168.72.14", 10, "test blacklist");
+        r = self.addBLEntryIP("192.168.72.14", 10, "test blacklist")
         j = r.json()
         self.assertEquals(j['status'], 'ok')
 
-        r = self.addBLEntryIP("2001:503:ba3e::2:30", 10, "test blacklist");
+        r = self.addBLEntryIP("2001:503:ba3e::2:30", 10, "test blacklist")
         j = r.json()
         self.assertEquals(j['status'], 'ok')
         
@@ -53,7 +55,7 @@ class TestBlacklist(ApiTestCase):
         self.assertEquals(j['status'], 0)
         r.close()
 
-        r = self.addBLEntryLogin("goodie", 10, "test blacklist");
+        r = self.addBLEntryLogin("goodie", 10, "test blacklist")
         j = r.json()
         self.assertEquals(j['status'], 'ok')
         
@@ -75,7 +77,7 @@ class TestBlacklist(ApiTestCase):
         self.assertEquals(j['status'], 0)
         r.close()
 
-        r = self.addBLEntryIPLogin("192.168.72.14", "goodie", 10, "test blacklist");
+        r = self.addBLEntryIPLogin("192.168.72.14", "goodie", 10, "test blacklist")
         j = r.json()
         self.assertEquals(j['status'], 'ok')
         
@@ -100,3 +102,28 @@ class TestBlacklist(ApiTestCase):
         j = r.json()
         self.assertEquals(j['status'], 0)
         r.close()
+
+    def test_PersistBlacklist(self):
+        cmd3 = ("../wforce -C ./wforce3.conf").split()
+        proc3 = subprocess.Popen(cmd3, close_fds=True)
+        time.sleep(1)
+        
+        r = self.addBLEntryIPPersist("99.99.99.99", 10, "test blacklist")
+        j = r.json()
+        self.assertEquals(j['status'], 'ok')
+
+        print "Killing process"
+        proc3.terminate()
+        print "Waiting for process"
+        proc3.wait()
+
+        proc3 = subprocess.Popen(cmd3, close_fds=True)
+
+        time.sleep(1)
+        
+        r = self.getBLFuncPersist()
+        j = r.json()
+        self.assertNotEqual(str.find(json.dumps(j),'99.99.99.99'), -1)
+
+        proc3.terminate()
+        proc3.wait()

--- a/regression-tests/test_helper.py
+++ b/regression-tests/test_helper.py
@@ -18,6 +18,8 @@ class ApiTestCase(unittest.TestCase):
         self.server1_url = 'http://%s:%s/' % (self.server_address, self.server1_port)
         self.server2_port = 8085
         self.server2_url = 'http://%s:%s/' % (self.server_address, self.server2_port)
+        self.server3_port = 8086
+        self.server3_url = 'http://%s:%s/' % (self.server_address, self.server3_port)
         self.session = requests.Session()
         self.session.auth = ('foo', os.environ.get('APIKEY', 'super'))
         #self.session.keep_alive = False
@@ -135,6 +137,9 @@ class ApiTestCase(unittest.TestCase):
     def getBLFuncReplica(self):
         return self.session.get(self.url2("/?command=getBL"))
 
+    def getBLFuncPersist(self):
+        return self.session.get(self.url3("/?command=getBL"))
+    
     def addBLEntryIPLogin(self, ip, login, expire_secs, reason):
         payload = dict()
         payload['login'] = login
@@ -156,6 +161,16 @@ class ApiTestCase(unittest.TestCase):
             data=json.dumps(payload),
             headers={'Content-Type': 'application/json'}) 
 
+    def addBLEntryIPPersist(self, ip, expire_secs, reason):
+        payload = dict()
+        payload['ip'] = ip
+        payload['expire_secs'] = expire_secs
+        payload['reason'] = reason
+        return self.session.post(
+            self.url3("/?command=addBLEntry"),
+            data=json.dumps(payload),
+            headers={'Content-Type': 'application/json'}) 
+    
     def addBLEntryLogin(self, login, expire_secs, reason):
         payload = dict()
         payload['login'] = login
@@ -221,7 +236,10 @@ class ApiTestCase(unittest.TestCase):
 
     def url2(self, relative_url):
         return urlparse.urljoin(self.server2_url, relative_url)
-    
+
+    def url3(self, relative_url):
+        return urlparse.urljoin(self.server3_url, relative_url)
+        
     def assert_success_json(self, result):
         try:
             result.raise_for_status()

--- a/regression-tests/wforce3.conf
+++ b/regression-tests/wforce3.conf
@@ -1,0 +1,7 @@
+webserver("0.0.0.0:8086", "super")
+setKey("Ay9KXgU3g4ygK+qWT0Ut4gH8PPz02gbtPeXWPdjD0HE=")
+controlSocket("0.0.0.0:4006")
+
+blacklistPersistDB("127.0.0.1", 6379)
+
+dofile("./wforce-tw.conf")

--- a/wforce.conf.example
+++ b/wforce.conf.example
@@ -54,6 +54,14 @@ field_map["countryCount"] = "countmin"
 -- You can create multiple dbs with different window lengths for storing stats over different time windows
 -- This one is 6 windows of 10 minutes each, so an hour in total. Every 10 minutes the oldest windows data will expire
 newStringStatsDB("OneHourDB",600,6,field_map)
+
+-- Persist the blacklist entries in the specified redis DB
+-- blacklistPersistDB("127.0.0.1", 6379)
+
+-- Only set this option if every wforce server is using a separate redis DB
+-- Do not set when there is a central redis DB used by all wforce servers
+-- blacklistPersistReplicated()
+
 -- This one is 24 windows of 1 hour each, so 24 hours in total. Useful for tracking long-term stats.
 -- You can reuse field_map or create a different one
 newStringStatsDB("24HourDB",3600, 24, field_map)


### PR DESCRIPTION
Regressions for persistent blacklists in Redis. Store a key, stop wforce, restart, check the key is still there.