### PR TITLE
Performance

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,7 @@ SUBDIRS=ext docs
 
 EXTRA_DIST= wforce.conf README.md wforce.service.in wforce.conf.example replication.proto
 
-CLEANFILES = replication.pb.cc replication.pb.h
+CLEANFILES = replication.pb.cc replication.pb.h wforce.service.in
 
 sysconf_DATA= wforce.conf wforce.conf.example
 bin_PROGRAMS = wforce

--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,7 @@ SUBDIRS=ext docs
 
 EXTRA_DIST= wforce.conf README.md wforce.service.in wforce.conf.example replication.proto
 
-CLEANFILES = replication.pb.cc replication.pb.h wforce.service.in
+CLEANFILES = replication.pb.cc replication.pb.h wforce.service
 
 sysconf_DATA= wforce.conf wforce.conf.example
 bin_PROGRAMS = wforce

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Installing
 From GitHub:
 
 ```
-$ git clone git@github.com:ahupowerdns/weakforced.git
+$ git clone https://github.com/PowerDNS/weakforced.git
 $ cd weakforced
 $ autoreconf -i
 $ ./configure

--- a/docs/swagger/wforce_api.7.yml
+++ b/docs/swagger/wforce_api.7.yml
@@ -1,6 +1,6 @@
 swagger: "2.0"
 info:
-  version: "2.0"
+  version: "1.2"
   title: "Dovecot Anti-Abuse Shield"
   description: "An API to the Dovecot Anti-Abuse Shield to prevent brute-force and abuse of mail systems"
   contact:

--- a/wforce-web.cc
+++ b/wforce-web.cc
@@ -106,7 +106,7 @@ void reportLog(const LoginTuple& lt)
   os << "policy_reject=\"" << lt.policy_reject << "\" ";
   os << "pwhash=\"" << std::hex << std::uppercase << lt.pwhash << "\" ";
   os << LtAttrsToString(lt);
-  infolog(os.str().c_str());
+  vinfolog(os.str().c_str());
 }
 
 void allowLog(int retval, const std::string& msg, const LoginTuple& lt, const std::vector<pair<std::string, std::string>>& kvs) 
@@ -123,8 +123,9 @@ void allowLog(int retval, const std::string& msg, const LoginTuple& lt, const st
   }
   os << "}";
   // only log at notice if login was rejected or tarpitted
-  if (retval == 0)
-    infolog(os.str().c_str());
+  if (retval == 0) {
+    vinfolog(os.str().c_str());
+  }
   else
     noticelog(os.str().c_str());
 }
@@ -674,7 +675,7 @@ static void connectionThread(int id, std::shared_ptr<WFConnection> wfc)
   auto i_millis = std::chrono::duration_cast<std::chrono::milliseconds>(wait_time);
   addWTWStat(i_millis.count());
 
-  infolog("Webserver handling request from %s on fd=%d", wfc->remote.toStringWithPort(), wfc->fd);
+  vinfolog("Webserver handling request from %s on fd=%d", wfc->remote.toStringWithPort(), wfc->fd);
 
   YaHTTP::AsyncRequestLoader yarl;
   yarl.initialize(&req);

--- a/wforce.cc
+++ b/wforce.cc
@@ -46,7 +46,7 @@
 
 using std::atomic;
 using std::thread;
-bool g_verbose;
+bool g_verbose=false;
 
 struct WForceStats g_stats;
 bool g_console;


### PR DESCRIPTION
Change logging for  "allow=0" and "report" to only log when verbose is enabled (-v flag). Doing it everytime causes a big performance impact, particularly under systemd, which duplicates all logging (syslogd and journald). 

Also some small doc cleanup and add wforce.service to clean target in Makefile.am