### PR TITLE
Custom REST Endpoints

### DIFF
--- a/docs/swagger/wforce_api.7.yml
+++ b/docs/swagger/wforce_api.7.yml
@@ -230,7 +230,50 @@ paths:
           description: unexpected error
           schema:
             $ref: "#/definitions/Error"
+  /?command=customEndpoint:
+    post:
+      description: Extensible mechanism allows custom REST endpoints to be defined - this is an example
+      operationId: customEndpoint
+      produces:
+        - "application/json"
+      parameters:
+        - name: CustomFuncArgs
+          in: body
+          description: Arguments to custom REST endpoint
+          required: true
+          schema:
+            $ref: "#/definitions/CustomFuncArgs"
+      responses:
+        "200":
+          description: "custom endpoint response"
+          schema:
+            type: object
+            required:
+              - success
+              - r_attrs
+            properties:
+              success:
+                type: boolean
+              r_attrs:
+                type: object
+                properties:
+                  attr_name:
+                    type: string
+                example:
+                  two_factor_required: true
+        default:
+          description: unexpected error
+          schema:
+            $ref: "#/definitions/CustomError"
 definitions:
+  CustomFuncArgs:
+    required:
+      - attrs
+    example:
+      attrs: { "key"="value" }
+    properties:
+      attrs:
+        $ref: "#/definitions/LTAttrs" 
   LoginTupleReport:
     required:
       - login
@@ -318,6 +361,18 @@ definitions:
       ip: 127.0.0.1
       expire: 3600
       reason: “Too many bad passwords”
+  CustomError:
+    required:
+      - success
+      - reason
+    properties:
+      success:
+        type: boolean
+      reason:
+        type: string
+    example:
+      success: false
+      reason: Unauthorized
   Error:
     required:
       - status

--- a/regression-tests/test_Basics.py
+++ b/regression-tests/test_Basics.py
@@ -20,10 +20,14 @@ class TestBasics(ApiTestCase):
 
     def test_getBL(self):
         r = self.getBLFunc()
-        print r
         j = r.json()
         self.assertEquals(j['bl_entries'], [])
 
+    def test_customFunc(self):
+        r = self.customFunc("custom1")
+        j = r.json()
+        self.assertEquals(j['r_attrs']['login'], 'custom1')
+        
     def test_getDBStats(self):
         self.reportFunc('dbstats', '1.4.3.2', '1234', False); 
         r = self.getDBStatsLogin('dbstats')

--- a/regression-tests/test_GeoIP.py
+++ b/regression-tests/test_GeoIP.py
@@ -4,12 +4,9 @@ import time
 import json
 from test_helper import ApiTestCase
 
-configFile = "./wforce-tw.conf"
-
 class TestGeoIP(ApiTestCase):
 
     def test_geoIP(self):
-        self.writeFileToConsole(configFile)
         # don't allow IPs from Japan (arbitrary)
         r = self.allowFunc('baddie', '112.78.112.20', "1234")
         j = r.json()

--- a/regression-tests/test_helper.py
+++ b/regression-tests/test_helper.py
@@ -126,7 +126,16 @@ class ApiTestCase(unittest.TestCase):
                 self.url2("/?command=reset"),
                 data=json.dumps(payload),
                 headers={'Content-Type': 'application/json'})
-            
+
+    def customFunc(self, login):
+        attrs = dict()
+        attrs['login'] = login
+        payload = dict()
+        payload['attrs'] = attrs
+        return self.session.post(
+            self.url("/?command=custom"),
+            data=json.dumps(payload),
+            headers={'Content-Type': 'application/json'})
 
     def pingFunc(self):
         return self.session.get(self.url("/?command=ping"))

--- a/regression-tests/wforce-tw.conf
+++ b/regression-tests/wforce-tw.conf
@@ -142,3 +142,19 @@ setReport(twreport)
 setReset(reset)
 
 setCanonicalize(canonicalize)
+
+function custom(args)
+   login_name = "unknown"
+   for k,v in pairs(args.attrs) do
+      if (k == "login")
+      then
+	 login_name = v
+      end
+      infoLog("custom func argument attrs", { key=k, value=v });
+   end
+   -- return consists of a boolean, followed by { key-value pairs }
+   return true, { login=login_name }
+end
+
+-- Register a custom endpoint
+setCustomEndpoint("custom", custom)

--- a/wforce-lua.cc
+++ b/wforce-lua.cc
@@ -521,6 +521,9 @@ vector<std::function<void(void)>> setupLua(bool client, bool allow_report, LuaCo
     c_lua.writeFunction("setCanonicalize", [](canonicalize_t func) { });
   }
 
+  c_lua.registerMember("attrs", &CustomFuncArgs::attrs);
+  c_lua.registerMember("attrs_mv", &CustomFuncArgs::attrs_mv);
+
   c_lua.writeFunction("setCustomEndpoint", [&custom_func_map, allow_report, client](const std::string& f_name, custom_func_t func) {
       custom_func_map.insert(std::make_pair(f_name, func));
       if (!allow_report && !client) {

--- a/wforce-lua.cc
+++ b/wforce-lua.cc
@@ -53,6 +53,7 @@ vector<std::function<void(void)>> setupLua(bool client, bool allow_report, LuaCo
 					   report_t& report_func,
 					   reset_t& reset_func,
 					   canonicalize_t& canon_func,
+					   CustomFuncMap& custom_func_map,
 					   const std::string& config)
 {
   g_launchWork= new vector<std::function<void(void)>>();
@@ -520,6 +521,26 @@ vector<std::function<void(void)>> setupLua(bool client, bool allow_report, LuaCo
     c_lua.writeFunction("setCanonicalize", [](canonicalize_t func) { });
   }
 
+  c_lua.writeFunction("setCustomEndpoint", [&custom_func_map, allow_report, client](const std::string& f_name, custom_func_t func) {
+      custom_func_map.insert(std::make_pair(f_name, func));
+      if (!allow_report && !client) {
+	noticelog("Registering custom endpoint [%s]", f_name);
+      }
+    });
+
+  if (!allow_report) {
+    c_lua.writeFunction("showCustomEndpoints", []() {
+	g_outputBuffer = "Custom Endpoint\n";
+	for (const auto& i : g_custom_func_map) {
+	  g_outputBuffer += i.first;
+	  g_outputBuffer += "\n";
+	}
+      });
+  }
+  else {
+    c_lua.writeFunction("showCustomEndpoints", []() { });
+  }
+  
   if (!allow_report) {
     c_lua.writeFunction("setNumWebHookThreads", [](unsigned int num_threads) { g_webhook_runner.setNumThreads(num_threads); });
   }

--- a/wforce.cc
+++ b/wforce.cc
@@ -601,6 +601,7 @@ allow_t g_allow{defaultAllowTuple};
 report_t g_report{defaultReportTuple};
 reset_t g_reset{defaultReset};
 canonicalize_t g_canon{defaultCanonicalize};
+CustomFuncMap g_custom_func_map;
 
 /**** CARGO CULT CODE AHEAD ****/
 extern "C" {
@@ -756,13 +757,13 @@ try
 
 
   if(g_cmdLine.beClient || !g_cmdLine.command.empty()) {
-    setupLua(true, false, g_lua, g_allow, g_report, g_reset, g_canon, g_cmdLine.config);
+    setupLua(true, false, g_lua, g_allow, g_report, g_reset, g_canon, g_custom_func_map, g_cmdLine.config);
     doClient(g_serverControl, g_cmdLine.command);
     exit(EXIT_SUCCESS);
   }
 
   // this sets up the global lua state used for config and setup
-  auto todo=setupLua(false, false, g_lua, g_allow, g_report, g_reset, g_canon, g_cmdLine.config);
+  auto todo=setupLua(false, false, g_lua, g_allow, g_report, g_reset, g_canon, g_custom_func_map, g_cmdLine.config);
 
   // now we setup the allow/report lua states
   g_luamultip = std::make_shared<LuaMultiThread>(g_num_luastates);
@@ -778,6 +779,7 @@ try
 	     it->report_func,
 	     it->reset_func,
 	     it->canon_func,
+	     it->custom_func_map,
 	     g_cmdLine.config);
   }
 

--- a/wforce.conf.example
+++ b/wforce.conf.example
@@ -208,6 +208,8 @@ setReset(reset)
 function custom(args)
 	 attrs = args.attrs
 	 attrs_mv = args.attrs_mv
+	 -- return consists of a boolean, followed by { key-value pairs }
+	 return true, { foo=1 }
 end
 
 -- Register a custom endpoint

--- a/wforce.conf.example
+++ b/wforce.conf.example
@@ -204,3 +204,11 @@ end
 setReport(report)
 setAllow(allow)
 setReset(reset)
+
+function custom(args)
+	 attrs = args.attrs
+	 attrs_mv = args.attrs_mv
+end
+
+-- Register a custom endpoint
+setCustomEndpoint("custom", custom)

--- a/wforce.conf.example
+++ b/wforce.conf.example
@@ -206,10 +206,11 @@ setAllow(allow)
 setReset(reset)
 
 function custom(args)
-	 attrs = args.attrs
-	 attrs_mv = args.attrs_mv
-	 -- return consists of a boolean, followed by { key-value pairs }
-	 return true, { foo=1 }
+   for k,v in pairs(args.attrs) do
+      infoLog("custom func argument attrs", { key=k, value=v });
+   end
+   -- return consists of a boolean, followed by { key-value pairs }
+   return true, { key=value }
 end
 
 -- Register a custom endpoint

--- a/wforce.hh
+++ b/wforce.hh
@@ -124,10 +124,17 @@ struct LoginTuple
   }
 };
 
+struct CustomFuncArgs {
+  std::map<std::string, std::string> attrs; // additional attributes
+  std::map<std::string, std::vector<std::string>> attrs_mv; // additional multi-valued attributes
+};
+typedef std::vector<std::pair<std::string, std::string>> KeyValVector;
+
 extern GlobalStateHolder<vector<shared_ptr<Sibling>>> g_report_sinks;
 void sendReportSink(const LoginTuple& lt);
 
-typedef std::tuple<int, std::string, std::string, std::vector<pair<std::string, std::string>>> AllowReturn;
+typedef std::tuple<int, std::string, std::string, KeyValVector> AllowReturn;
+typedef std::tuple<int, KeyValVector> CustomFuncReturn;
 
 typedef std::function<AllowReturn(const LoginTuple&)> allow_t;
 extern allow_t g_allow;
@@ -136,8 +143,11 @@ extern report_t g_report;
 typedef std::function<bool(const std::string&, const std::string&, const ComboAddress&)> reset_t;
 extern reset_t g_reset;
 typedef std::function<std::string(const std::string&)> canonicalize_t;
+typedef std::function<CustomFuncReturn(const CustomFuncArgs&)> custom_func_t;
+typedef std::map<std::string, custom_func_t> CustomFuncMap;
+extern CustomFuncMap g_custom_func_map;
 
-vector<std::function<void(void)>> setupLua(bool client, bool allow_report, LuaContext& c_lua, allow_t& allow_func, report_t& report_func, reset_t& reset_func, canonicalize_t& canon_func, const std::string& config);
+vector<std::function<void(void)>> setupLua(bool client, bool allow_report, LuaContext& c_lua, allow_t& allow_func, report_t& report_func, reset_t& reset_func, canonicalize_t& canon_func, CustomFuncMap& custom_func_map, const std::string& config);
 
 struct LuaThreadContext {
   std::shared_ptr<LuaContext> lua_contextp;
@@ -146,6 +156,7 @@ struct LuaThreadContext {
   report_t report_func;
   reset_t reset_func;
   canonicalize_t canon_func;
+  CustomFuncMap custom_func_map;
 };
 
 #define NUM_LUA_STATES 6

--- a/wforce.hh
+++ b/wforce.hh
@@ -228,7 +228,7 @@ public:
     auto lt_context = getLuaState();
     // lock the lua state mutex
     std::lock_guard<std::mutex> lock(*(lt_context.lua_mutexp));
-    // call the allow function
+    // call the custom function
     for (const auto& i : lt_context.custom_func_map) {
       if (command.compare(i.first) == 0)
 	return i.second(cfa);


### PR DESCRIPTION
Custom REST Endpoints which call custom Lua functions:

In wforce.conf:

function custom(args)
   for k,v in pairs(args.attrs) do
      infoLog("custom func argument attrs", { key=k, value=v });
   end
   -- return consists of a boolean, followed by { key-value pairs }
   return true, { key=value }
end

setCustomEndpoint("endpointName", myfunction)

% curl -v -X POST -H "Content-Type: application/json" --data '{"attrs":{"login1":"ahu", "remote": "127.0.0.1",  "pwhash":"1234"}}'   http://127.0.0.1:8084/?command=endpointName  -u wforce:super

{"r_attrs": { "key"="value"}, "success": true}
%