### PR TITLE
return correctly in parseAllowCmd

### DIFF
--- a/wforce-web.cc
+++ b/wforce-web.cc
@@ -494,6 +494,7 @@ void parseAllowCmd(const YaHTTP::Request& req, YaHTTP::Response& resp)
     
 	resp.status=200;
 	resp.body=msg.dump();
+	return;
       }
       catch(LuaContext::ExecutionErrorException& e) {
 	resp.status=500;


### PR DESCRIPTION
This fixes an issue where ret_attrs would not be set in the allow command response