### PR TITLE
Backport: Support for GeoIP City and ISP DBs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,10 @@ before_script:
  - dig @208.67.222.222 a.root-servers.net
  - cpanm --quiet --installdeps --notest Template
  - cpanm --quiet --installdeps --notest Swagger2::Markdown
+ - sudo wget -N -O /usr/share/GeoIP/GeoIPCityv6.dat.gz http://geolite.maxmind.com/download/geoip/database/GeoLiteCityv6-beta/GeoLiteCityv6.dat.gz
+ - sudo gunzip /usr/share/GeoIP/GeoIPCityv6.dat.gz
+ - sudo wget -N -O /usr/share/GeoIP/GeoIPCity.dat.gz http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz
+ - sudo gunzip /usr/share/GeoIP/GeoIPCity.dat.gz
 script:
  - autoreconf -i
  - ./configure

--- a/README.md
+++ b/README.md
@@ -325,4 +325,48 @@ Address                             Sucesses  Failures     Note
 
 
 With this setup, several wforces are all kept in sync, and can be load
-balanced behind for example haproxy, which incidentally can also offer SSL.
+balanced behind (for example) haproxy, which incidentally can also offer SSL.
+
+GeoIP Support
+-------------
+
+GeoIP support is provided using the legacy Maxmind APIs and
+Databases (i.e. for DBs ending in .dat not .mmdb).
+
+Three types of GeoIP lookup are supported:
+
+* Country lookups - Initialized with initGeoIPDB() and looked up
+    with lookupCountry()
+* ISP Lookups - Initialized with initGeoIPISPDB() and looked up with
+  lookupISP()
+* City Lookup - Initialized with initGeoIPCityDB() and looked up
+  with lookupCity()
+
+The Country and ISP lookups return a string, while lookupCity()
+returns a Lua map consisting of the following keys:
+* country_code
+* country_name
+* region
+* city
+* postal_code
+* continent_code
+* latitude
+* longitude
+
+For example:
+	local geoip_data = lookupCity(newCA("128.243.21.16"))
+	print(geoip_data.city)
+
+When a DB is initialized, wforce attempts to open both v4 and v6
+versions of the database. If either is not found an error is thrown,
+so make sure both ipv4 and v6 versions of each DB are
+installed.
+
+Additionally, when using the free/lite versions of the
+databases, you may see errors such as "initGeoIPCityDB(): Error
+initialising GeoIP (No geoip v6 city db available)". This is usually
+because the filenames for the "lite" DBs are not the same as the
+expected filenames for the full DBs, specifically all files must
+start with GeoIP rather than GeoLite. Creating symbolic links to the
+expected filenames will fix this problem, for example:
+	ln -s GeoLiteCityv6.dat GeoIPCityv6.dat

--- a/docs/manpages/wforce.conf.5.md
+++ b/docs/manpages/wforce.conf.5.md
@@ -95,6 +95,21 @@ cannot be called inside the allow/report/reset functions:
   
 		initGeoIPDB()
 
+* initGeoIPCityDB() - Initializes the city-level IPv4 and IPv6 GeoIP
+  databases. If either of these databases is not installed, this
+  command will fail and wforce will not start. Ensure these databases
+  have the right names if you're using the free/lite DBs - you may
+  need to create symbolic links e.g. GeoIPCityv6.dat ->
+  GeoLiteCityv6.dat. For example: 
+  
+		initGeoIPCityDB()
+
+* initGeoIPISPDB() - Initializes the ISP-level IPv4 and IPv6 GeoIP
+  databases. If either of these databases is not installed, this
+  command will fail and wforce will not start. For example:
+  
+		initGeoIPISPDB()
+
 * newDNSResolver(\<resolver name\>) - Create a new DNS resolver object with the
   specified name. Note this does not return the resolver object - that
   is achieved with the getDNSResolver() function. For example:
@@ -137,6 +152,21 @@ configuration or within the allow/report/reset functions:
   ComboAddress object can be created with the newCA() function. For example:
   
 		my_country = lookupCountry(my_ca)
+
+* lookupISP(\<ComboAddress\>) - Returns the name of the ISP hosting
+  the IP address. A ComboAddress object can be created with the
+  newCA() function. For example:
+
+		local my_isp = lookupCountry(newCA("128.243.16.21"))
+
+* lookupCity(\<ComboAddress\>) - Returns a map containing information
+  about the IP address, such as the city name and latitude and
+  longitude. See GeoIPRecord below for the full list of fields. For
+  example:
+
+		local gip_record = lookupCity(lt.remote)
+		local my_city = gip_record.city
+		local my_latitude = gip_record.latitude
 
 * newCA(\<IP[:port]\>) - Create and return an object representing an IP
   address (v4 or v6) and optional port. The object is called a
@@ -358,7 +388,33 @@ configuration or within the allow/report/reset functions:
   about the login, e.g. information about the user from LDAP.
   		
 * LoginTuple.attrs_mv - Additional array of (multi-valued)
-  attributes about the login.
+  attributes about the login. For example:
+
+		 for k, v in pairs(lt.attrs_mv) do
+			 for i, vi in ipairs(v) do
+				 if ((k == "xxx") and (vi == "yyy"))
+				 then
+					 -- do something
+				 end
+			 end
+		 end
+
+* GeoIPRecord - The type returned by the lookupCity() function. See
+  below for fields:
+
+* GeoIPRecord.country_code - The two-letter country code e.g. "US".
+
+* GeoIPRecord.country_name - The country name, e.g. "United States"
+
+* GeoIPRecord.region - The region, e.g. "CA"
+
+* GeoIPRecord.city - The city name, e.g. "Mountain View"
+
+* GeoIPRecord.postal_code - The postal code, e.g. "93102" or "BA216AS"
+
+* GeoIPRecord.latitude - The latitude, e.g. 37.386001586914
+
+* GeoIPRecord.longitude - The longitude, e.g. -122.08380126953
 
 # FILES
 */etc/wforce.conf*

--- a/regression-tests/test_GeoIP.py
+++ b/regression-tests/test_GeoIP.py
@@ -16,5 +16,9 @@ class TestGeoIP(ApiTestCase):
         self.assertEquals(j['status'], -1)
         r.close()
 
-
-        
+    def test_geoIPCity(self):
+        # Don't allow IPs from Nottingham (I went to college there)
+        r = self.allowFunc('baddie', '128.243.21.16', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], -1)
+        r.close()

--- a/regression-tests/wforce-tw.conf
+++ b/regression-tests/wforce-tw.conf
@@ -19,6 +19,7 @@ sdb_small = getStringStatsDB("15SecondsSmallDB")
 sdb_small:twSetMaxSize(10)
 
 initGeoIPDB()
+initGeoIPCityDB()
 
 function twreport(lt)
 	sdb = getStringStatsDB("15SecondsFirstDB")
@@ -63,6 +64,12 @@ function twallow(lt)
 	if (cur_ct == "JP")
        	then
 		return -1, "", "", {}
+	end
+
+	gip_record = lookupCity(lt.remote)
+	if (gip_record.city == "Nottingham")
+	then
+	   return -1, "Nottingham is blocked", "Nottingham is blocked", {}
 	end
 
 	if (sdb:twGet(lt.login, "diffPasswords") > 20)

--- a/wforce-geoip.cc
+++ b/wforce-geoip.cc
@@ -5,51 +5,116 @@
 
 WFGeoIPDB g_wfgeodb;
 
-void WFGeoIPDB::initGeoIPDB()
-  {
-    if (gi_v4)
-      return;
-    if (GeoIP_db_avail(GEOIP_COUNTRY_EDITION)) {
-      gi_v4 = GeoIP_open_type(GEOIP_COUNTRY_EDITION, GEOIP_MEMORY_CACHE);
-      if (!gi_v4) {
-	errlog("Unable to open geoip v4 country db");
-	throw std::runtime_error("Unable to open geoip v4 country db");
+void WFGeoIPDB::initGeoIPDB(WFGeoIPDBType db_types)
+{
+  if (db_types & WFGeoIPDBType::GEOIP_COUNTRY) {
+    if (!gi_v4)
+      gi_v4 = openGeoIPDB(GEOIP_COUNTRY_EDITION, "v4 country");
+  }
+  if (db_types & WFGeoIPDBType::GEOIP_COUNTRY_V6) {
+    if (!gi_v6)
+      gi_v6 = openGeoIPDB(GEOIP_COUNTRY_EDITION_V6, "v6 country");
+  }
+  if (db_types & WFGeoIPDBType::GEOIP_CITY) {
+    if (!gi_city_v4)
+      gi_city_v4 = openGeoIPDB(GEOIP_CITY_EDITION_REV1, "v4 city");
+  }
+  if (db_types & WFGeoIPDBType::GEOIP_CITY_V6) {
+    if (!gi_city_v6)
+      gi_city_v6 = openGeoIPDB(GEOIP_CITY_EDITION_REV1_V6, "v6 city");
+  }
+  if (db_types & WFGeoIPDBType::GEOIP_ISP) {
+    if (!gi_isp_v4)
+      gi_isp_v4 = openGeoIPDB(GEOIP_ISP_EDITION, "v4 isp");
+  }
+  if (db_types & WFGeoIPDBType::GEOIP_ISP_V6) {
+    if (!gi_isp_v6)
+      gi_isp_v6 = openGeoIPDB(GEOIP_ISP_EDITION_V6, "v6 isp");
+  }
+}
+
+GeoIP* WFGeoIPDB::openGeoIPDB(GeoIPDBTypes db_type, const std::string& name)
+{
+  GeoIP* gip=NULL;
+  if (GeoIP_db_avail(db_type)) {
+      gip = GeoIP_open_type(db_type, GEOIP_MEMORY_CACHE);
+      if (!gip) {
+	std::string myerr = "Unable to open geoip " + name + " db";
+	errlog(myerr.c_str());
+	throw std::runtime_error(myerr);
       }
     }
     else {
-      errlog("No geoip v4 country db available");
-      throw std::runtime_error("No geoip v4 country db available");
+      std::string myerr = "No geoip " + name + " db available";
+      errlog(myerr.c_str());
+      throw std::runtime_error(myerr);
     }
-    if (gi_v6)
-      return;
-    if (GeoIP_db_avail(GEOIP_COUNTRY_EDITION_V6)) {
-      gi_v6 = GeoIP_open_type(GEOIP_COUNTRY_EDITION_V6, GEOIP_MEMORY_CACHE);
-      if (!gi_v6) {
-	errlog("Unable to open geoip v6 country db");
-	throw std::runtime_error("Unable to open geoip v6 country db");
-      }
-    }
-    else {
-      errlog("No geoip v6 country db available");
-      throw std::runtime_error("No geoip v6 country db available");
-    }
-  }
+  return gip;
+}
 
-std::string const WFGeoIPDB::lookupCountry(const ComboAddress& address)
-  {
-    GeoIPLookup gl;
-    const char* retstr=NULL;
-    std::string ret="";
+std::string WFGeoIPDB::lookupCountry(const ComboAddress& address) const
+{
+  GeoIPLookup gl;
+  const char* retstr=NULL;
+  std::string ret="";
 
-    if (address.sin4.sin_family == AF_INET && gi_v4 != NULL) {
-      retstr = GeoIP_country_code_by_ipnum_gl(gi_v4, ntohl(address.sin4.sin_addr.s_addr), &gl);
-    }
-    else if (gi_v6 != NULL) { // it's a v6 address (included mapped v4 of course)
-      retstr = GeoIP_country_code_by_ipnum_v6_gl(gi_v6, address.sin6.sin6_addr, &gl);
-    }
-    if (retstr)
-      ret = retstr;
-    return ret;
+  if (address.sin4.sin_family == AF_INET && gi_v4 != NULL) {
+    retstr = GeoIP_country_code_by_ipnum_gl(gi_v4, ntohl(address.sin4.sin_addr.s_addr), &gl);
   }
+  else if (gi_v6 != NULL) { // it's a v6 address (included mapped v4 of course)
+    retstr = GeoIP_country_code_by_ipnum_v6_gl(gi_v6, address.sin6.sin6_addr, &gl);
+  }
+  if (retstr)
+    ret = retstr;
+  return ret;
+}
+
+std::string WFGeoIPDB::lookupISP(const ComboAddress& address) const
+{
+  GeoIPLookup gl;
+  const char* retstr=NULL;
+  std::string ret="";
+
+  if (address.sin4.sin_family == AF_INET && gi_isp_v4 != NULL) {
+    retstr = GeoIP_name_by_ipnum_gl(gi_isp_v4, ntohl(address.sin4.sin_addr.s_addr), &gl);
+  }
+  else if (gi_isp_v6 != NULL) { // v6 address
+    retstr = GeoIP_name_by_ipnum_v6_gl(gi_isp_v6, address.sin6.sin6_addr, &gl);
+  }
+  if (retstr)
+    ret = retstr;
+  return ret;
+}
+
+WFGeoIPRecord WFGeoIPDB::lookupCity(const ComboAddress& address) const
+{
+  GeoIPRecord* gir=NULL;
+  WFGeoIPRecord ret_wfgir = {};
+
+  if (address.sin4.sin_family == AF_INET && gi_city_v4 != NULL) {
+    gir = GeoIP_record_by_ipnum(gi_city_v4, ntohl(address.sin4.sin_addr.s_addr));
+  }
+  else if (gi_city_v6 != NULL) { // v6 address
+    gir = GeoIP_record_by_ipnum_v6(gi_city_v6, address.sin6.sin6_addr);
+  }
+  if (gir) {
+    if (gir->country_code != NULL)
+      ret_wfgir.country_code = gir->country_code;
+    if (gir->country_name != NULL)
+      ret_wfgir.country_name = gir->country_name;
+    if (gir->region != NULL)
+      ret_wfgir.region = gir->region;
+    if (gir->city != NULL)
+      ret_wfgir.city = gir->city;
+    if (gir->postal_code != NULL)
+      ret_wfgir.postal_code = gir->postal_code;
+    if (gir->continent_code != NULL)
+      ret_wfgir.continent_code = gir->continent_code;
+    ret_wfgir.latitude = gir->latitude;
+    ret_wfgir.longitude = gir->longitude;
+  }
+  return ret_wfgir;
+}
+
 
 #endif // HAVE_GEOIP

--- a/wforce-geoip.hh
+++ b/wforce-geoip.hh
@@ -1,14 +1,37 @@
 #pragma once
 #include <string>
 #include <GeoIP.h>
-#include "wforce.hh"
+#include <GeoIPCity.h>
+#include "iputils.hh"
+
+enum class WFGeoIPDBType : uint32_t { GEOIP_NONE=0x00, GEOIP_COUNTRY=0x01, GEOIP_CITY=0x02, GEOIP_ISP=0x04, GEOIP_COUNTRY_V6=0x08, GEOIP_CITY_V6=0x10, GEOIP_ISP_V6=0x20 };
+
+constexpr enum WFGeoIPDBType operator |( const enum WFGeoIPDBType selfValue, const enum WFGeoIPDBType inValue )
+{
+    return (enum WFGeoIPDBType)(uint32_t(selfValue) | uint32_t(inValue));
+}
+
+constexpr bool operator &( const enum WFGeoIPDBType selfValue, const enum WFGeoIPDBType inValue )
+{
+    return (uint32_t(selfValue) & uint32_t(inValue));
+}
+
+struct WFGeoIPRecord {
+  std::string country_code;
+  std::string country_name;
+  std::string region;
+  std::string city;
+  std::string postal_code;
+  std::string continent_code;
+  float	      latitude;
+  float	      longitude;
+};
 
 class WFGeoIPDB
 {
 public:
   WFGeoIPDB()
   {
-    gi_v4 = gi_v6 = NULL;
   }
 
   ~WFGeoIPDB()
@@ -19,17 +42,36 @@ public:
     if (gi_v6) {
       GeoIP_delete(gi_v6);
     }
+    if (gi_city_v4) {
+      GeoIP_delete(gi_city_v4);
+    }
+    if (gi_city_v6) {
+      GeoIP_delete(gi_city_v6);
+    }
+    if (gi_isp_v4) {
+      GeoIP_delete(gi_isp_v4);
+    }
+    if (gi_isp_v6) {
+      GeoIP_delete(gi_isp_v6);
+    }
   }
 
   // Only load it if someone wants to use GeoIP, otherwise it's a waste of RAM
-  void initGeoIPDB();
+  void initGeoIPDB(WFGeoIPDBType db_types); // pass these as flags
   // This will lookup in either the v4 or v6 GeoIP DB, depending on what address is
-  std::string const lookupCountry(const ComboAddress& address);
-
+  std::string lookupCountry(const ComboAddress& address) const;
+  std::string lookupISP(const ComboAddress& address) const;
+  WFGeoIPRecord lookupCity(const ComboAddress& address) const;
+protected:
+  GeoIP* openGeoIPDB(GeoIPDBTypes db_type, const std::string& name);
 private:
   // GeoIPDB seems to have different DBs for v4 and v6 addresses, hence two DBs
-  GeoIP *gi_v4;
-  GeoIP *gi_v6;
+  GeoIP *gi_v4 = NULL;
+  GeoIP *gi_v6 = NULL;
+  GeoIP *gi_city_v4 = NULL;
+  GeoIP *gi_city_v6 = NULL;
+  GeoIP *gi_isp_v4 = NULL;
+  GeoIP *gi_isp_v6 = NULL;
 };
 
 extern WFGeoIPDB g_wfgeodb;

--- a/wforce-lua.cc
+++ b/wforce-lua.cc
@@ -248,15 +248,61 @@ vector<std::function<void(void)>> setupLua(bool client, bool allow_report, LuaCo
 
 #ifdef HAVE_GEOIP
   if (!allow_report) {
-    c_lua.writeFunction("initGeoIPDB", []() {
-	g_wfgeodb.initGeoIPDB();
-      });
+      c_lua.writeFunction("initGeoIPDB", []() {
+	  try {
+	    g_wfgeodb.initGeoIPDB(WFGeoIPDBType::GEOIP_COUNTRY|WFGeoIPDBType::GEOIP_COUNTRY_V6);
+	  }
+	  catch (const std::runtime_error& e) {
+	    errlog("initGeoIPDB(): Error initialising GeoIP (%s)", e.what());
+	  }
+	});
   }
   else {
     c_lua.writeFunction("initGeoIPDB", []() { });
   }
   c_lua.writeFunction("lookupCountry", [](ComboAddress address) {
       return g_wfgeodb.lookupCountry(address);
+    });
+  if (!allow_report) {
+      c_lua.writeFunction("initGeoIPCityDB", []() {
+	  try {
+	    g_wfgeodb.initGeoIPDB(WFGeoIPDBType::GEOIP_CITY|WFGeoIPDBType::GEOIP_CITY_V6);
+	  }
+	  catch (const std::runtime_error& e) {
+	    errlog("initGeoIPCityDB(): Error initialising GeoIP (%s)", e.what());
+	  }
+	});
+
+  }
+  else {
+    c_lua.writeFunction("initGeoIPCityDB", []() { });
+  }
+  c_lua.writeFunction("lookupCity", [](ComboAddress address) {
+      return g_wfgeodb.lookupCity(address);
+    });
+  c_lua.registerMember("country_code", &WFGeoIPRecord::country_code);
+  c_lua.registerMember("country_name", &WFGeoIPRecord::country_name);
+  c_lua.registerMember("region", &WFGeoIPRecord::region);
+  c_lua.registerMember("city", &WFGeoIPRecord::city);
+  c_lua.registerMember("postal_code", &WFGeoIPRecord::postal_code);
+  c_lua.registerMember("continent_code", &WFGeoIPRecord::continent_code);
+  c_lua.registerMember("latitude", &WFGeoIPRecord::latitude);
+  c_lua.registerMember("longitude", &WFGeoIPRecord::longitude);
+  if (!allow_report) {
+    c_lua.writeFunction("initGeoIPISPDB", []() {
+	try {
+	  g_wfgeodb.initGeoIPDB(WFGeoIPDBType::GEOIP_ISP|WFGeoIPDBType::GEOIP_ISP_V6);
+	}
+	catch (const std::runtime_error& e) {
+	  errlog("initGeoIPISPDB(): Error initialising GeoIP (%s)", e.what());
+	}
+      });
+  }
+  else {
+    c_lua.writeFunction("initGeoIPISPDB", []() { });
+  }
+  c_lua.writeFunction("lookupISP", [](ComboAddress address) {
+      return g_wfgeodb.lookupISP(address);
     });
 #endif // HAVE_GEOIP
 

--- a/wforce.conf.example
+++ b/wforce.conf.example
@@ -48,8 +48,13 @@ newStringStatsDB("OneHourDB",600,6,field_map)
 -- You can reuse field_map or create a different one
 newStringStatsDB("24HourDB",3600, 24, field_map)
 
--- Only initialize the GeoIPDB if you need it
+-- Only initialize the GeoIPDB if you need it - this initializes the "country"
+-- GeoIP DBs (ipv4 and ipv6)
 initGeoIPDB()
+-- You can also initialize the "city" and "ISP" databases (ensure you have
+-- downloaded them, again you need both ipv4 and ipv6 DBs)
+-- initGeoIPCityDB()
+-- initGeoIPISPDB()
 
 -- The report function is used to store custom stats
 -- The allow and report functions cannot access any lua variables defined outside, hence the get... functions
@@ -117,6 +122,11 @@ function allow(lt)
 	then
 		return -1, "country blocked", "country blocked", { remoteCountry="XX" }
 	end
+	-- You can also lookup ISP names:
+	  -- lookupISP(lt.remote)
+	-- And more detailed information like city/lat/long:
+	  -- gip_record = lookupCity(lt.remote)
+	  -- local my_city = gip_record.city
 
 	-- Example DNS lookups
 	dnames = resolv:lookupNameByAddr(lt.remote)


### PR DESCRIPTION
(cherry picked from commit 44a122d2b81c86d241381fe58f811cde361fbef7)
(cherry picked from commit 00c84da851c590444019e52060109dec394bad35)
(cherry picked from commit 6db15c34ed027deb952bd3b23c2dc02a0e89e230)
(cherry picked from commit 6c9cd3236f9b3a705a11695ddc8e3a765ea4e59e)
(cherry picked from commit 1d27cf0d5f8798999381d9e126b0e1f9038e6bfa)
(cherry picked from commit cae19b6465d7ba09b3d19f51b3a97240605b98ef)
Change WforceException->std:runtime_error
Remove return val tests in GeoIP regression backport as 1.0 doesn't support