### PR TITLE
Enable GeoIP DBs to be reloaded

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -41,6 +41,8 @@ wforce_SOURCES = \
 	sholder.hh \
 	sodcrypto.cc sodcrypto.hh \
 	luastate.hh \
+	lock.hh \
+	pdnsexception.hh \
 	device_parser.hh device_parser.cc \
 	sstuff.hh ext/luawrapper/include/LuaContext.hpp \
 	ext/incbin/incbin.h \
@@ -88,7 +90,9 @@ noinst_HEADERS = \
 	wforce_exception.hh \
 	wforce_ns.hh \
 	luastate.hh \
-	device_parser.hh
+	device_parser.hh \
+	lock.hh \
+	pdnsexception.hh
 
 BUILT_SOURCES = replication.pb.cc replication.pb.h
 replication.pb.cc: replication.proto

--- a/lock.hh
+++ b/lock.hh
@@ -1,0 +1,205 @@
+/*
+ * This file is part of PowerDNS or dnsdist.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#ifndef LOCK_HH
+#define LOCK_HH
+
+#include <pthread.h>
+#include <errno.h>
+#include "misc.hh"
+#include "pdnsexception.hh"
+
+extern bool g_singleThreaded;
+
+class Lock
+{
+  pthread_mutex_t *d_lock;
+public:
+  Lock(const Lock& rhs) = delete;
+  Lock& operator=(const Lock& rhs) = delete;
+
+  Lock(pthread_mutex_t *lock) : d_lock(lock)
+  {
+    if(g_singleThreaded)
+      return;
+    if((errno=pthread_mutex_lock(d_lock)))
+      throw PDNSException("error acquiring lock: "+stringerror());
+  }
+  ~Lock()
+  {
+    if(g_singleThreaded)
+      return;
+
+    pthread_mutex_unlock(d_lock);
+  }
+};
+
+class WriteLock
+{
+  pthread_rwlock_t *d_lock;
+public:
+
+  WriteLock(pthread_rwlock_t *lock) : d_lock(lock)
+  {
+    if(g_singleThreaded)
+      return;
+
+    if((errno=pthread_rwlock_wrlock(d_lock))) {
+      throw PDNSException("error acquiring rwlock wrlock: "+stringerror());
+    }
+  }
+  ~WriteLock()
+  {
+    if(g_singleThreaded)
+      return;
+    if(d_lock) // might have been moved
+      pthread_rwlock_unlock(d_lock);
+  }
+
+  WriteLock(WriteLock&& rhs)
+  {
+    d_lock = rhs.d_lock;
+    rhs.d_lock=0;
+  }
+  WriteLock(const WriteLock& rhs) = delete;
+  WriteLock& operator=(const WriteLock& rhs) = delete;
+
+
+};
+
+class TryWriteLock
+{
+  pthread_rwlock_t *d_lock;
+  bool d_havelock;
+public:
+  TryWriteLock(const TryWriteLock& rhs) = delete;
+  TryWriteLock& operator=(const TryWriteLock& rhs) = delete;
+
+  TryWriteLock(pthread_rwlock_t *lock) : d_lock(lock)
+  {
+    if(g_singleThreaded) {
+      d_havelock=true;
+      return;
+    }
+
+    d_havelock=false;
+    if((errno=pthread_rwlock_trywrlock(d_lock)) && errno!=EBUSY)
+      throw PDNSException("error acquiring rwlock tryrwlock: "+stringerror());
+    d_havelock=(errno==0);
+  }
+
+  TryWriteLock(TryWriteLock&& rhs)
+  {
+    d_lock = rhs.d_lock;
+    rhs.d_lock=0;
+  }
+
+  
+  ~TryWriteLock()
+  {
+    if(g_singleThreaded)
+      return;
+
+    if(d_havelock && d_lock) // we might be moved
+      pthread_rwlock_unlock(d_lock);
+  }
+  bool gotIt()
+  {
+    if(g_singleThreaded)
+      return true;
+
+    return d_havelock;
+  }
+};
+
+class TryReadLock
+{
+  pthread_rwlock_t *d_lock;
+  bool d_havelock;
+public:
+  TryReadLock(const TryReadLock& rhs) = delete;
+  TryReadLock& operator=(const TryReadLock& rhs) = delete;
+
+  TryReadLock(pthread_rwlock_t *lock) : d_lock(lock)
+  {
+    if(g_singleThreaded) {
+      d_havelock=true;
+      return;
+    }
+
+    if((errno=pthread_rwlock_tryrdlock(d_lock)) && errno!=EBUSY)
+      throw PDNSException("error acquiring rwlock tryrdlock: "+stringerror());
+    d_havelock=(errno==0);
+  }
+  TryReadLock(TryReadLock&& rhs)
+  {
+    d_lock = rhs.d_lock;
+    rhs.d_lock=0;
+  }
+
+  ~TryReadLock()
+  {
+    if(g_singleThreaded)
+      return;
+
+    if(d_havelock && d_lock)
+      pthread_rwlock_unlock(d_lock);
+  }
+  bool gotIt()
+  {
+    if(g_singleThreaded)
+      return true;
+
+    return d_havelock;
+  }
+};
+
+
+class ReadLock
+{
+  pthread_rwlock_t *d_lock;
+public:
+
+  ReadLock(pthread_rwlock_t *lock) : d_lock(lock)
+  {
+    if(g_singleThreaded)
+      return;
+
+    if((errno=pthread_rwlock_rdlock(d_lock)))
+      throw PDNSException("error acquiring rwlock readlock: "+stringerror());
+  }
+  ~ReadLock()
+  {
+    if(g_singleThreaded)
+      return;
+    if(d_lock) // may have been moved
+      pthread_rwlock_unlock(d_lock);
+  }
+
+  ReadLock(ReadLock&& rhs)
+  {
+    d_lock = rhs.d_lock;
+    rhs.d_lock=0;
+  }
+  ReadLock(const ReadLock& rhs) = delete;
+  ReadLock& operator=(const ReadLock& rhs) = delete;
+};
+#endif

--- a/pdnsexception.hh
+++ b/pdnsexception.hh
@@ -1,0 +1,1 @@
+wforce_exception.hh

--- a/wforce-geoip.hh
+++ b/wforce-geoip.hh
@@ -24,6 +24,7 @@
 #include <string>
 #include <GeoIP.h>
 #include <GeoIPCity.h>
+#include "lock.hh"
 #include "iputils.hh"
 
 enum class WFGeoIPDBType : uint32_t { GEOIP_NONE=0x00, GEOIP_COUNTRY=0x01, GEOIP_CITY=0x02, GEOIP_ISP=0x04, GEOIP_COUNTRY_V6=0x08, GEOIP_CITY_V6=0x10, GEOIP_ISP_V6=0x20 };
@@ -84,6 +85,7 @@ public:
   std::string lookupCountry(const ComboAddress& address) const;
   std::string lookupISP(const ComboAddress& address) const;
   WFGeoIPRecord lookupCity(const ComboAddress& address) const;
+  void reload(); // Reload any opened DBs from original files
 protected:
   GeoIP* openGeoIPDB(GeoIPDBTypes db_type, const std::string& name);
 private:
@@ -94,6 +96,7 @@ private:
   GeoIP *gi_city_v6 = NULL;
   GeoIP *gi_isp_v4 = NULL;
   GeoIP *gi_isp_v6 = NULL;
+  mutable pthread_rwlock_t gi_rwlock = PTHREAD_RWLOCK_INITIALIZER;
 };
 
 extern WFGeoIPDB g_wfgeodb;

--- a/wforce-lua.cc
+++ b/wforce-lua.cc
@@ -420,6 +420,22 @@ vector<std::function<void(void)>> setupLua(bool client, bool allow_report, LuaCo
   else {
     c_lua.writeFunction("initGeoIPDB", []() { });
   }
+  if (!allow_report) {
+    c_lua.writeFunction("reloadGeoIPDBs", []() {
+	try {
+	  g_wfgeodb.reload();
+	}
+	catch (const WforceException& e) {
+	  boost::format fmt("%s (%s)\n");
+	  errlog("reloadGeoIPDBs(): Error reloading GeoIP (%s)", e.what());
+	  g_outputBuffer += (fmt % "reloadGeoIPDBs(): Error reloading GeoIP" % e.what()).str();
+	}
+	g_outputBuffer += "reloadGeoIPDBs() successful\n";
+      });
+  }
+  else {
+    c_lua.writeFunction("reloadGeoIPDBs", []() { });
+  }
   c_lua.writeFunction("lookupCountry", [](ComboAddress address) {
       return g_wfgeodb.lookupCountry(address);
     });

--- a/wforce.cc
+++ b/wforce.cc
@@ -39,6 +39,7 @@
 #include "perf-stats.hh"
 #include "luastate.hh"
 #include "webhook.hh"
+#include "lock.hh"
 
 #include <getopt.h>
 #ifdef HAVE_LIBSYSTEMD
@@ -717,7 +718,8 @@ char* my_generator(const char* text, int state)
       "blacklistPersistReplicated()",
       "blacklistIP",
       "blacklistLogin",
-      "blacklistIPLogin"
+      "blacklistIPLogin",
+      "reloadGeoIPDBs()"
       };
   static int s_counter=0;
   int counter=0;
@@ -881,6 +883,8 @@ try
   argc-=optind;
   argv+=optind;
 
+  g_singleThreaded = false;
+  
   if (!g_cmdLine.beClient) {
     checkUaRegexFile(g_cmdLine.regexes);
     vinfolog("Will read UserAgent regexes from %s", g_cmdLine.regexes);


### PR DESCRIPTION
Previously the GeoIP DB would be loaded and new changes would be ignored.
This behaviour is very fast and thread safe, but meant that changes to the
GeoIP DB were ignored, which is non-optimal.
This commit adds the GEOIP_CACHE_CHECK flag to the DB open function, which
means that the DB will be reloaded if it changes on disk. However this change
now means that lookups are no longer thread-safe, so a mutex has been added
to protect all lookups.