### PR TITLE
Refactor DNS Lookups mainly

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -42,6 +42,9 @@ wforce_LDADD = \
 	$(BOOST_REGEX_LIBS) $(LIBHIREDIS_LIBS) $(LIBCURL) $(LIBCRYPTO_LIBS) \
 	$(YAMLCPP_LIBS)
 
+EXTRA_wforce_DEPENDENCIES = \
+	$(EXT_LIBS) $(WFORCE_LIBS)
+
 noinst_HEADERS = \
 	blacklist.hh \
 	wforce.hh \

--- a/common/dns_lookup.hh
+++ b/common/dns_lookup.hh
@@ -27,6 +27,7 @@
 #include <vector>
 #include <memory>
 #include <mutex>
+#include <atomic>
 #include "iputils.hh"
 
 struct GetDNSContext {

--- a/configure.ac
+++ b/configure.ac
@@ -54,9 +54,9 @@ AC_SUBST([YAHTTP_LIBS], ['-L$(abs_top_builddir)/ext/yahttp/yahttp -lyahttp'])
 AC_SUBST([JSON11_CFLAGS], ['-I$(top_srcdir)/ext/json11'])
 AC_SUBST([JSON11_LIBS], ['-L$(abs_top_builddir)/ext/json11 -ljson11'])
 AC_SUBST([EXT_CFLAGS], ['-I$(top_srcdir)/ext'])
-AC_SUBST([EXT_LIBS], ['-L$(abs_top_builddir)/ext/ext -lext'])
+AC_SUBST([EXT_LIBS], ['$(abs_top_builddir)/ext/ext/libext.la'])
 AC_SUBST([WFORCE_CFLAGS], ['-I$(top_srcdir)'/common])
-AC_SUBST([WFORCE_LIBS], ['-L$(abs_top_builddir)/common -lweakforce'])
+AC_SUBST([WFORCE_LIBS], ['$(abs_top_builddir)/common/libweakforce.la'])
 # We need libcrypto for hash functions
 PDNS_CHECK_LIBCRYPTO
 # Check for LuaJIT first then Lua

--- a/docs/manpages/trackalert.conf.5.md
+++ b/docs/manpages/trackalert.conf.5.md
@@ -89,7 +89,7 @@ cannot be called inside the report or background functions:
   thread uses a separate Lua Context, the number of which is set with
   setNumLuaStates(). Defaults to 4 if not specified. For example:
   
-		setNumSiblingThreads(2)
+		setNumSchedulerThreads(2)
 
 * setNumWebHookThreads(\<num threads\>) - Set the number of threads in
   the pool used to send webhook events. Defaults to 4 if not
@@ -130,6 +130,18 @@ cannot be called inside the report or background functions:
   scheduleBackgroundFunc() function.
 
 		setBackground("mybg", backgroundFunc)
+
+* scheduleBackgroundFunc(\<cron string\>, \<background function
+  name\>) - Tells trackalert to run the specified function according
+  to the given cron schedule (note the
+  name given in setBackground() is used, *not* the actual function
+  name). Note that cron ranges are not currently supported - if you
+  want to schedule the same function to run for example on two
+  different days of the week, then you would use two different calls
+  to this function to achieve that. For example:
+
+		scheduleBackgroundFunc("0 0 1 * *", "mybg")
+		scheduleBackgroundFunc("0 0 6 * *", "mybg")
 
 * setCustomEndpoint(\<name of endpoint\>, \<custom lua function\>) -
   Create a new custom REST endpoint with the given name, which when
@@ -342,18 +354,6 @@ configuration or within the allow/report/reset functions:
 * GeoIPRecord.latitude - The latitude, e.g. 37.386001586914
 
 * GeoIPRecord.longitude - The longitude, e.g. -122.08380126953
-
-* scheduleBackgroundFunc(\<cron string\>, \<background function
-  name\>) - Tells trackalert to run the specified function according
-  to the given cron schedule (note the
-  name given in setBackground() is used, *not* the actual function
-  name). Note that cron ranges are not currently supported - if you
-  want to schedule the same function to run for example on two
-  different days of the week, then you would use two different calls
-  to this function to achieve that. For example:
-
-		scheduleBackgroundFunc("0 0 1 * *", "mybg")
-		scheduleBackgroundFunc("0 0 6 * *", "mybg")
 
 * CustomFuncArgs - The only parameter to custom functions
   is a CustomFuncArgs table. This table contains the following fields:

--- a/elasticqueries/login_fail_query.json
+++ b/elasticqueries/login_fail_query.json
@@ -12,36 +12,36 @@
     "aggs": {
 	"most_sig_ips": {
 	    "significant_terms": { 
-		"field": "remote.keyword",
+		"field": "remote",
 		"size": 6
 	    }
 	},
 	"most_sig_logins": {
 	    "significant_terms": { 
-		"field": "login.keyword",
+		"field": "login",
 		"size": 6
 	    }
 	},     
 	"most_sig_cc": {
 	    "significant_terms": { 
-		"field": "geoip.country_code2.keyword",
+		"field": "geoip.country_code2",
 		"size": 6
 	    }
 	},
 	"most_sig_browser": {
 	    "significant_terms": { 
-		"field": "device_attrs.browser.family.keyword",
+		"field": "device_attrs.browser.family",
 		"size": 6
 	    },
 	    "aggs": {
 		"os": {
 		    "terms": {
-			"field": "device_attrs.os.family.keyword"
+			"field": "device_attrs.os.family"
 		    },
 		    "aggs": {
 			"device": {
 			    "terms": {
-				"field": "device_attrs.device.family.keyword"
+				"field": "device_attrs.device.family"
 			    }
 			}
 		    }
@@ -50,36 +50,36 @@
 	},
 	"most_sig_imapc": {
 	    "significant_terms": { 
-		"field": "device_attrs.imapc.family.keyword",
+		"field": "device_attrs.imapc.family",
 		"size": 6
 	    },
 	    "aggs": {
 		"os": {
 		    "terms": {
-			"field": "device_attrs.os.family.keyword"
+			"field": "device_attrs.os.family"
 		    }
 		}
 	    }
 	},
 	"most_sig_mobileapp": {
             "significant_terms": {
-                "field": "device_attrs.app.name.keyword",
+                "field": "device_attrs.app.name",
                 "size": 6
             },
 	    "aggs": {
 		"brand": {
 		    "terms": {
-			"field": "device_attrs.app.brand.keyword"
+			"field": "device_attrs.app.brand"
 		    },
 		    "aggs": {
 			"os": {
 			    "terms": {
-				"field": "device_attrs.os.family.keyword"
+				"field": "device_attrs.os.family"
 			    },
 			    "aggs": {
 				"device": {
 				    "terms": {
-					"field": "device_attrs.device.family.keyword"
+					"field": "device_attrs.device.family"
 				    }
 				}
 			    }

--- a/trackalert/Makefile.am
+++ b/trackalert/Makefile.am
@@ -26,6 +26,9 @@ trackalert_LDADD = \
 	$(BOOST_REGEX_LIBS) $(LIBHIREDIS_LIBS) $(LIBCURL) $(LIBCRYPTO_LIBS) \
 	$(YAMLCPP_LIBS) $(GEOIP_LIBS)
 
+EXTRA_trackalert_DEPENDENCIES = \
+	$(EXT_LIBS) $(WFORCE_LIBS)
+
 noinst_HEADERS = \
 	trackalert.hh \
 	trackalert-luastate.hh \

--- a/trackalert/trackalert.cc
+++ b/trackalert/trackalert.cc
@@ -428,6 +428,8 @@ char* my_generator(const char* text, int state)
       "showCustomWebHooks()",
       "showPerfStats()",
       "showVersion()",
+      "showCustomEndpoints()",
+      "setCustomEndpoint(",
       "addWebHook(",
       "addCustomWebHook(",
       "setNumWebHookThreads("

--- a/trackalert/trackalert.conf
+++ b/trackalert/trackalert.conf
@@ -12,7 +12,7 @@ end
 setReport(report)
 
 function background()
-   print("foo")
+    infoLog("Ran background thread", {})
 end
 
 setBackground("background", background)


### PR DESCRIPTION
Also some nits, and an important dependency fix for in-tree libraries.

The DNS Lookup changes mainly involve:
- Thread-safety for some non-thread-safe member functions
- Refactoring the class to be non-copyable and using shared ptrs to reference it instead