### PR TITLE
Support mapped v4 addresses inside v6 addresses

### DIFF
--- a/common/login_tuple.cc
+++ b/common/login_tuple.cc
@@ -67,8 +67,12 @@ void LoginTuple::from_json(const Json& msg, const std::shared_ptr<UserAgentParse
   pwhash=msg["pwhash"].string_value();
   t=msg["t"].number_value();
   success=msg["success"].bool_value();
-  if (msg["remote"].is_string())
+  if (msg["remote"].is_string()) {
     remote=ComboAddress(msg["remote"].string_value());
+    if (remote.isMappedIPv4()) {
+      remote = remote.mapToIPv4();
+    }
+  }
   setLtAttrs(msg);
   setDeviceAttrs(msg, uap);
   device_id=msg["device_id"].string_value();

--- a/regression-tests/test_Basics.py
+++ b/regression-tests/test_Basics.py
@@ -48,7 +48,7 @@ class TestBasics(ApiTestCase):
         self.assertRegexpMatches(json.dumps(j), "countLogins")
         r = self.getDBStatsIP('1.4.3.2')
         j = r.json();
-        self.assertRegexpMatches(json.dumps(j), "countryCount")
+        self.assertRegexpMatches(json.dumps(j), "countLogins")
 
     def chunkGen(self):
         payload = dict()

--- a/regression-tests/test_Replication.py
+++ b/regression-tests/test_Replication.py
@@ -113,6 +113,27 @@ class TestTimeWindowsReplication(ApiTestCase):
         j = r.json()
         self.assertEquals(j['status'], 0)
 
+    def test_PrefixMappedv4(self):
+        r = self.allowFunc('mappedipv4baddiereplication', '::ffff:114.31.193.200', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], 0)
+        r.close()
+
+        for i in range(50):
+            r = self.reportFunc('mappedipv4baddiereplication%s' % i, "::ffff:%s.31.193.200" % i, "1234", 'true')
+            r.json()
+
+        time.sleep(1)
+        r = self.allowFuncReplica('mappedipv4baddiereplication', '::ffff:114.31.193.200', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], 0)
+
+        # Wait for the time windows to clear and then check again
+        time.sleep(16)
+        r = self.allowFuncReplica('mappedipv4baddiereplication', '::ffff:114.31.193.200', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], 0)
+
     def test_Prefixv6(self):
         r = self.allowFunc('ipv6baddiereplication', '2001:c78::1000', "1234")
         j = r.json()

--- a/regression-tests/test_Replication.py
+++ b/regression-tests/test_Replication.py
@@ -92,13 +92,13 @@ class TestTimeWindowsReplication(ApiTestCase):
         j = r.json()
         self.assertEquals(j['status'], 0)
 
-    def test_countMinPrefixv4(self):
+    def test_Prefixv4(self):
         r = self.allowFunc('ipv4baddiereplication', '114.31.193.200', "1234")
         j = r.json()
         self.assertEquals(j['status'], 0)
         r.close()
 
-        for i in range(12):
+        for i in range(50):
             r = self.reportFunc('ipv4baddiereplication%s' % i, "114.31.193.%s" % i, "1234", 'true')
             r.json()
 
@@ -113,13 +113,13 @@ class TestTimeWindowsReplication(ApiTestCase):
         j = r.json()
         self.assertEquals(j['status'], 0)
 
-    def test_countMinPrefixv6(self):
+    def test_Prefixv6(self):
         r = self.allowFunc('ipv6baddiereplication', '2001:c78::1000', "1234")
         j = r.json()
         self.assertEquals(j['status'], 0)
         r.close()
 
-        for i in range(12):
+        for i in range(50):
             r = self.reportFunc('ipv6baddiereplication%s' % i, "2001:c78::%s" % i, "1234", 'true')
             r.json()
 

--- a/regression-tests/test_TimeWindows.py
+++ b/regression-tests/test_TimeWindows.py
@@ -89,7 +89,7 @@ class TestTimeWindows(ApiTestCase):
         j = r.json()
         self.assertEquals(j['status'], 0)
 
-    def test_countMinPrefixv4(self):
+    def test_Prefixv4(self):
         r = self.allowFunc('ipv4baddie', '114.31.192.200', "1234")
         j = r.json()
         self.assertEquals(j['status'], 0)
@@ -109,7 +109,7 @@ class TestTimeWindows(ApiTestCase):
         j = r.json()
         self.assertEquals(j['status'], 0)
 
-    def test_countMinPrefixv6(self):
+    def test_Prefixv6(self):
         r = self.allowFunc('ipv6baddie', '2001:c78::1000', "1234")
         j = r.json()
         self.assertEquals(j['status'], 0)

--- a/regression-tests/test_TimeWindows.py
+++ b/regression-tests/test_TimeWindows.py
@@ -109,6 +109,26 @@ class TestTimeWindows(ApiTestCase):
         j = r.json()
         self.assertEquals(j['status'], 0)
 
+    def test_PrefixMappedv4(self):
+        r = self.allowFunc('mappedipv4baddie', '::ffff:114.31.192.200', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], 0)
+        r.close()
+
+        for i in range(50):
+            r = self.reportFunc('mappedipv4baddie%s' % i, "::ffff:%s.31.192.200" % i, "1234", 'true')
+            r.json()
+
+        r = self.allowFunc('mappedipv4baddie', '::ffff:114.31.192.200', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], 0)
+
+        # Wait for the time windows to clear and then check again
+        time.sleep(16)
+        r = self.allowFunc('mappedipv4baddie', '::ffff:114.31.192.200', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], 0)
+
     def test_Prefixv6(self):
         r = self.allowFunc('ipv6baddie', '2001:c78::1000', "1234")
         j = r.json()

--- a/regression-tests/wforce-tw.conf
+++ b/regression-tests/wforce-tw.conf
@@ -53,7 +53,7 @@ function twreport(lt)
 	sdb:twSub(lt.login, "subTest", 1)
 	sdb:twAdd(lt.login, "diffPasswords", lt.pwhash)
 	sdb:twAdd(lt.login, "diffIPs", lt.remote)
-	sdb_prefix:twAdd(lt.remote, "countryCount", cur_ct)
+	sdb_prefix:twAdd(lt.remote, "countLogins", 1)
 	if (string.find(lt.login, "expirebaddie"))
 	then
 	    sdb_small:twAdd(lt.login, "countLogins", 1)
@@ -113,9 +113,9 @@ function twallow(lt)
 		return -1, "subTest", "subTest", {}
 	end
 
-	if (sdb_prefix:twGet(lt.remote, "countryCount", "AU") > 10)
+	if (sdb_prefix:twGet(lt.remote, "countLogins") > 45)
 	then
-		return -1, "Australia countryCount", "Australia countryCount", {}
+		return -1, "Too many logins (prefix)", "Too many logins (prefix)", {}
 	end
 
 	if (sdb_small:twGetSize() > 10)


### PR DESCRIPTION
Convert mapped v4 addresses inside v6 addresses into actual v4 addresses so that StatsDB prefixes work correctly.