### PR TITLE
StatsDB Memleak

### DIFF
--- a/common/minicurl.cc
+++ b/common/minicurl.cc
@@ -149,7 +149,7 @@ void MiniCurl::setPostData(const std::string& url,
                            const MiniCurlHeaders& headers)
 {
   if (d_curl) {
-    d_post_body = std::stringstream(post_body);
+    d_post_body = std::istringstream(post_body);
     clearCurlHeaders();
         
     curl_easy_setopt(d_curl, CURLOPT_URL, url.c_str());

--- a/common/minicurl.cc
+++ b/common/minicurl.cc
@@ -232,7 +232,9 @@ void MiniCurlMulti::initMCurl()
 #else
   curl_multi_setopt(d_mcurl, CURLMOPT_PIPELINING, 1L);  
 #endif
+#ifdef CURLMOPT_MAX_HOST_CONNECTIONS
   curl_multi_setopt(d_mcurl, CURLMOPT_MAX_HOST_CONNECTIONS, d_ccs.size());
+#endif
   d_current = d_ccs.begin();
 }
 

--- a/common/minicurl.hh
+++ b/common/minicurl.hh
@@ -64,7 +64,7 @@ private:
   static size_t write_callback(char *ptr, size_t size, size_t nmemb, void *userdata);
   static size_t read_callback(char *buffer, size_t size, size_t nitems, void *userdata);
   std::string d_data;
-  std::stringstream d_post_body;
+  std::istringstream d_post_body;
   struct curl_slist* d_header_list = nullptr;
   char d_error_buf[CURL_ERROR_SIZE];
   unsigned int d_id;

--- a/common/twmap.hh
+++ b/common/twmap.hh
@@ -51,6 +51,7 @@ typedef std::vector<std::pair<std::time_t, TWStatsMemberP>> TWStatsBuf;
 class TWStatsMember
 {
 public:
+  virtual ~TWStatsMember() = default;
   virtual void add(int a) = 0; // add an integer to the stored value
   virtual void add(const std::string& s) = 0; // add a string to the stored window (this has different semantics for each subclass)
   virtual void add(const std::string& s, int a) = 0; // add a string/integer combo to the stored window (only applies to some stats types)

--- a/common/twmap.hh
+++ b/common/twmap.hh
@@ -71,6 +71,8 @@ public:
   TWStatsMemberInt() {}
   TWStatsMemberInt(const TWStatsMemberInt&) = delete;
   TWStatsMemberInt& operator=(const TWStatsMemberInt&) = delete;
+  TWStatsMemberInt(TWStatsMemberInt&&) = delete; // move construct
+  TWStatsMemberInt& operator=(TWStatsMemberInt &&) = delete; // move assign
   void add(int a) { i += a; }
   void add(const std::string& s) { int a = std::stoi(s); i += a; return; }
   void add(const std::string& s, int a) { return; }
@@ -106,6 +108,8 @@ public:
   }
   TWStatsMemberHLL(const TWStatsMemberHLL&) = delete;
   TWStatsMemberHLL& operator=(const TWStatsMemberHLL&) = delete;
+  TWStatsMemberHLL(TWStatsMemberHLL&&) = delete; // move construct
+  TWStatsMemberHLL& operator=(TWStatsMemberHLL &&) = delete; // move assign
   void add(int a) { std::string str; str = std::to_string(a); hllp->add(str.c_str(), str.length()); return; }
   void add(const std::string& s) { hllp->add(s.c_str(), s.length()); }
   void add(const std::string& s, int a) { return; }
@@ -143,6 +147,8 @@ public:
   }
   TWStatsMemberCountMin(const TWStatsMemberCountMin&) = delete;
   TWStatsMemberCountMin& operator=(const TWStatsMemberCountMin&) = delete;
+  TWStatsMemberCountMin(TWStatsMemberCountMin&&) = delete; // move construct
+  TWStatsMemberCountMin& operator=(TWStatsMemberCountMin &&) = delete; // move assign
   void add(int a) { return; }
   void add(const std::string& s) { cm->update(s.c_str(), 1); }
   void add(const std::string& s, int a) { cm->update(s.c_str(), a); }


### PR DESCRIPTION
- Fix Memory Leak in StatsDB - no virtual destructor in base class.
- Fix curl compilation when curl is 7.29 or lower
- Only use input string stream if you don't need output in minicurl.cc