### PR TITLE
Synchronization of DBs for newly started wforce instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Add sibling received success/fail stats to sibling() command
 - New custom stats framework
 - New stats for all commands, including custom commands
-- GeoIP2 support
+- GeoIP2 support (MMDB-style DBs)
 - New resetField() function for statsDBs
+- Support for building packages using pdnsbuilder
+- Configurable accuracy for HLL and CountMin types
+- DB Synchronization for newly started wforce instances
+- Add configuration settings "addSyncHost" and "setMinSyncHostUptime"
+- Add configuration setting "setWebHookTimeoutSecs"
 
 ### Deprecated
 - GeoIP Legacy support
@@ -20,6 +25,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Refactor webhooks to use libcurl multi interface for performance and
 deprecate per-webhook "num_conns" config
+
+## [1.4.3]
+
+### Fixed
+- Fix broken setVerboseAllowLog() function
 
 ## [1.4.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - DB Synchronization for newly started wforce instances
 - Add configuration settings "addSyncHost" and "setMinSyncHostUptime"
 - Add configuration setting "setWebHookTimeoutSecs"
+- Support for replication over TCP
 
 ### Deprecated
 - GeoIP Legacy support

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -74,7 +74,11 @@ endif
 
 testrunner_SOURCES = \
 	testrunner.cc \
-	test-minicurl.cc
+	test-minicurl.cc \
+	test-serialize.cc
+
+EXTRA_testrunner_DEPENDENCIES = \
+	$(EXT_LIBS)
 
 testrunner_LDFLAGS = \
 	$(AM_LDFLAGS) \

--- a/common/common-lua.cc
+++ b/common/common-lua.cc
@@ -255,6 +255,13 @@ void setupCommonLua(bool client,
   }
 
   if (!multi_lua) {
+    c_lua.writeFunction("setWebHookTimeoutSecs", [](uint64_t timeout_secs) { g_webhook_runner.setTimeout(timeout_secs); });
+  }
+  else {
+    c_lua.writeFunction("setWebHookTimeoutSecs", [](uint64_t timeout_secs) { });
+  }
+  
+  if (!multi_lua) {
     c_lua.writeFunction("showCustomWebHooks", []() {
 	auto webhooks = g_custom_webhook_db.getWebHooks();
 	boost::format fmt("%-9d %-20.20s %-9d %-9d %-s\n");

--- a/common/minicurl.cc
+++ b/common/minicurl.cc
@@ -102,6 +102,11 @@ void MiniCurl::setCurlOption(int option, ...)
   }
 }
 
+void MiniCurl::setTimeout(uint64_t timeout_secs)
+{
+  setCurlOption(CURLOPT_TIMEOUT, timeout_secs);
+}
+
 void MiniCurl::clearCurlHeaders()
 {
   if (d_curl) {
@@ -253,6 +258,13 @@ bool MiniCurlMulti::addPost(unsigned int id, const std::string& url,
     return true;
   }
   return false;
+}
+
+void MiniCurlMulti::setTimeout(uint64_t timeout_secs)
+{
+  for (auto& i : d_ccs) {
+    i.setCurlOption(CURLOPT_TIMEOUT, timeout_secs);
+  }
 }
 
 const std::vector<mcmPostReturn> MiniCurlMulti::runPost()

--- a/common/minicurl.hh
+++ b/common/minicurl.hh
@@ -40,6 +40,7 @@ public:
   void setURLData(const std::string& url, const MiniCurlHeaders& headers);
   std::string getURL(const std::string& url, const MiniCurlHeaders& headers);
   void setCurlOption(int option, ...);
+  void setTimeout(uint64_t timeout_secs);
   void setPostData(const std::string& url, const std::string& post_body,
                    const MiniCurlHeaders& headers);
   std::string getPostResult() { return d_data; }
@@ -90,6 +91,7 @@ public:
                const std::string& post_body,
                const MiniCurlHeaders& headers);
   const std::vector<mcmPostReturn> runPost();
+  void setTimeout(uint64_t timeout_secs);
 protected:
   void initMCurl();
   void finishPost();

--- a/common/sstuff.hh
+++ b/common/sstuff.hh
@@ -236,8 +236,6 @@ public:
       res=::send(d_socket, ptr, toWrite, 0);
       if(res<0) 
         throw NetworkError("Writing to a socket: "+string(strerror(errno)));
-      if(!res)
-        throw NetworkError("EOF on socket");
       toWrite-=res;
       ptr+=res;
     }while(toWrite);

--- a/common/sstuff.hh
+++ b/common/sstuff.hh
@@ -345,6 +345,16 @@ public:
     return res;
   }
 
+  //! Reads a block of data from the socket to a block of memory
+  //! Only returns when all the data requested is available
+  int readAll(char *buffer, int bytes)
+  {
+    int res=::recv(d_socket,buffer,bytes, MSG_WAITALL);
+    if(res<0) 
+      throw NetworkError("Reading from a socket: "+string(strerror(errno)));
+    return res;
+  }
+
   int readWithTimeout(char* buffer, int n, int timeout)
   {
     int err = waitForRWData(d_socket, true, timeout, 0);

--- a/common/test-serialize.cc
+++ b/common/test-serialize.cc
@@ -3,15 +3,13 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include "twmap.hh"
 #include <boost/test/unit_test.hpp>
 
 #include "ext/hyperloglog.hpp"
 #include "ext/count_min_sketch.hpp"
 #include "misc.hh"
-
 #include <iostream>
-
-using namespace std;
 
 BOOST_AUTO_TEST_SUITE(test_serialize)
 
@@ -56,6 +54,48 @@ BOOST_AUTO_TEST_CASE(test_serialize_countmin) {
   cmcopy2.restore(ss2);
 
   BOOST_CHECK((int)cmcopy2.estimate(foo.c_str()) == 2);
+}
+
+BOOST_AUTO_TEST_CASE(test_serialize_statsdb) {
+  TWStatsDB<std::string> sdb1("sdb1", 600, 6);
+  TWStatsDB<std::string> sdb2("sdb2", 600, 6);
+  FieldMap fm;
+
+  fm.insert(std::make_pair("field1", "int"));
+  fm.insert(std::make_pair("field2", "hll"));
+  fm.insert(std::make_pair("field3", "countmin"));
+  sdb1.setFields(fm);
+  sdb2.setFields(fm);
+  
+  sdb1.add(std::string("bar"), "field1", 10);
+  sdb1.add(std::string("bar"), "field2", "diff1");
+  sdb1.add(std::string("bar"), "field3", "diff1");
+
+  sdb1.add(std::string("foo"), "field1", 10);
+  BOOST_CHECK(sdb1.get(std::string("foo"), "field1") == 10);
+
+  sdb1.add(std::string("foo"), "field2", "diff1");
+  sdb1.add(std::string("foo"), "field2", "diff2");
+  sdb1.add(std::string("foo"), "field2", "diff3");
+  BOOST_CHECK(sdb1.get(std::string("foo"), "field2") == 3);
+  
+  sdb1.add(std::string("foo"), "field3", "diff1");
+  sdb1.add(std::string("foo"), "field3", "diff1");
+  sdb1.add(std::string("foo"), "field3", "diff2");
+  BOOST_CHECK(sdb1.get(std::string("foo"), "field3", "diff1") == 2);
+
+  for (auto it = sdb1.startDBDump(); it != sdb1.DBDumpIteratorEnd(); ++it) {
+    TWStatsDBDumpEntry e;
+    std::string key;
+    if (sdb1.DBDumpEntry(it, e, key)) {
+      sdb2.restoreEntry(key, e);
+    }
+  }
+  sdb1.endDBDump();
+
+  BOOST_CHECK(sdb2.get(std::string("foo"), "field1") == 10);
+  BOOST_CHECK(sdb2.get(std::string("foo"), "field2") == 3);
+  BOOST_CHECK(sdb2.get(std::string("foo"), "field3", "diff1") == 2);
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/common/test-serialize.cc
+++ b/common/test-serialize.cc
@@ -1,0 +1,61 @@
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_NO_MAIN
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+#include <boost/test/unit_test.hpp>
+
+#include "ext/hyperloglog.hpp"
+#include "ext/count_min_sketch.hpp"
+#include "misc.hh"
+
+#include <iostream>
+
+using namespace std;
+
+BOOST_AUTO_TEST_SUITE(test_serialize)
+
+BOOST_AUTO_TEST_CASE(test_serialize_hll) {
+  hll::HyperLogLog hll(6);
+  std::string foo="foo";
+  std::string bar="bar";
+  
+  hll.add(foo.c_str(), foo.length());
+  hll.add(bar.c_str(), bar.length());
+  BOOST_CHECK((int)hll.estimate() == 2);
+
+  std::stringstream ss(std::stringstream::in|std::stringstream::out|std::stringstream::binary);
+  hll.dump(ss);
+
+  hll::HyperLogLog hllcopy(6);
+  hllcopy.restore(ss);
+
+  BOOST_CHECK((int)hllcopy.estimate() == 2);
+}
+
+BOOST_AUTO_TEST_CASE(test_serialize_countmin) {
+  CountMinSketch cm(0.05, 0.2);
+  std::string foo="foo";
+  std::string bar="bar";
+  
+  cm.update(foo.c_str(), 2);
+  cm.update(bar.c_str(), 1);
+  BOOST_CHECK((int)cm.estimate(foo.c_str()) == 2);
+
+  // check we can dump and restore
+  std::stringstream ss(std::stringstream::in|std::stringstream::out|std::stringstream::binary);
+  cm.dump(ss);
+  CountMinSketch cmcopy(0.05, 0.2);
+  cmcopy.restore(ss);
+  BOOST_CHECK((int)cmcopy.estimate(foo.c_str()) == 2);
+
+  // check we can dump the copy and restore from that
+  std::stringstream ss2(std::stringstream::in|std::stringstream::out|std::stringstream::binary);
+  cmcopy.dump(ss2);
+  CountMinSketch cmcopy2(0.05, 0.2);
+  cmcopy2.restore(ss2);
+
+  BOOST_CHECK((int)cmcopy2.estimate(foo.c_str()) == 2);
+}
+
+BOOST_AUTO_TEST_SUITE_END();

--- a/common/twmap.hh
+++ b/common/twmap.hh
@@ -76,17 +76,17 @@ public:
   TWStatsMemberInt& operator=(const TWStatsMemberInt&) = delete;
   TWStatsMemberInt(TWStatsMemberInt&&) = delete; // move construct
   TWStatsMemberInt& operator=(TWStatsMemberInt &&) = delete; // move assign
-  void add(int a) { i += a; }
-  void add(const std::string& s) { int a = std::stoi(s); i += a; return; }
-  void add(const std::string& s, int a) { return; }
-  void sub(int a) { i -= a;  }
-  void sub(const std::string& s) { int a = std::stoi(s); i -= a; return; }
-  int get() { return i; }
-  int get(const std::string& s) { return i; }
-  void set(int a) { i = a; }
-  void set(const std::string& s) { return; }
-  void erase() { i = 0; }
-  int sum(const TWStatsBuf& vec)
+  void add(int a) override { i += a; }
+  void add(const std::string& s) override { int a = std::stoi(s); i += a; return; }
+  void add(const std::string& s, int a) override { return; }
+  void sub(int a) override { i -= a;  }
+  void sub(const std::string& s) override { int a = std::stoi(s); i -= a; return; }
+  int get() override { return i; }
+  int get(const std::string& s) override { return i; }
+  void set(int a) override { i = a; }
+  void set(const std::string& s) override { return; }
+  void erase() override { i = 0; }
+  int sum(const TWStatsBuf& vec) override
   {
     int count = 0;
     for (auto a=vec.begin(); a!=vec.end(); ++a)
@@ -95,15 +95,15 @@ public:
       }
     return count;
   }
-  int sum(const std::string& s, const TWStatsBuf& vec) { return 0; }
-  void dump(std::ostream& os) {
+  int sum(const std::string& s, const TWStatsBuf& vec) override { return 0; }
+  void dump(std::ostream& os) override {
     uint32_t neti = htonl(i);
     os.write((char*)&neti, sizeof(neti));
     if(os.fail()) {
       throw std::runtime_error("TWStatsMemberInt: Failed to dump");
     }
   }
-  void restore(std::istream& is) {
+  void restore(std::istream& is) override {
     uint32_t neti = 0;
     is.read((char*)&neti, sizeof(neti));
     i = ntohl(neti);
@@ -125,17 +125,17 @@ public:
   TWStatsMemberHLL& operator=(const TWStatsMemberHLL&) = delete;
   TWStatsMemberHLL(TWStatsMemberHLL&&) = delete; // move construct
   TWStatsMemberHLL& operator=(TWStatsMemberHLL &&) = delete; // move assign
-  void add(int a) { std::string str; str = std::to_string(a); hllp->add(str.c_str(), str.length()); return; }
-  void add(const std::string& s) { hllp->add(s.c_str(), s.length()); }
-  void add(const std::string& s, int a) { return; }
-  void sub(int a) { return; }
-  void sub(const std::string& s) { return; }
-  int get() { return std::lround(hllp->estimate()); }
-  int get(const std::string& s) { hllp->add(s.c_str(), s.length()); return std::lround(hllp->estimate()); } // add and return value
-  void set(int a) { return; }
-  void set(const std::string& s) { hllp->clear(); hllp->add(s.c_str(), s.length()); }
-  void erase() { hllp->clear(); }
-  int sum(const TWStatsBuf& vec)
+  void add(int a) override { std::string str; str = std::to_string(a); hllp->add(str.c_str(), str.length()); return; }
+  void add(const std::string& s) override { hllp->add(s.c_str(), s.length()); }
+  void add(const std::string& s, int a) override { return; }
+  void sub(int a) override { return; }
+  void sub(const std::string& s) override { return; }
+  int get() override { return std::lround(hllp->estimate()); }
+  int get(const std::string& s) override { hllp->add(s.c_str(), s.length()); return std::lround(hllp->estimate()); } // add and return value
+  void set(int a) override { return; }
+  void set(const std::string& s) override { hllp->clear(); hllp->add(s.c_str(), s.length()); }
+  void erase() override { hllp->clear(); }
+  int sum(const TWStatsBuf& vec) override
   {
     hll::HyperLogLog hllsum(num_bits);
     for (auto a = vec.begin(); a != vec.end(); ++a)
@@ -145,11 +145,11 @@ public:
       }
     return std::lround(hllsum.estimate());
   }
-  int sum(const std::string& s, const TWStatsBuf& vec) { return 0; }
-  void dump(std::ostream& os) {
+  int sum(const std::string& s, const TWStatsBuf& vec) override { return 0; }
+  void dump(std::ostream& os) override {
     hllp->dump(os);
   }
-  void restore(std::istream& is) {
+  void restore(std::istream& is) override {
     hllp->restore(is);
   }
   static void setNumBits(unsigned int nbits) {
@@ -178,17 +178,17 @@ public:
   TWStatsMemberCountMin& operator=(const TWStatsMemberCountMin&) = delete;
   TWStatsMemberCountMin(TWStatsMemberCountMin&&) = delete; // move construct
   TWStatsMemberCountMin& operator=(TWStatsMemberCountMin &&) = delete; // move assign
-  void add(int a) { return; }
-  void add(const std::string& s) { cm->update(s.c_str(), 1); }
-  void add(const std::string& s, int a) { cm->update(s.c_str(), a); }
-  void sub(int a) { return; }
-  void sub(const std::string& s) { return; }
-  int get() { return cm->totalcount(); }
-  int get(const std::string& s) { return cm->estimate(s.c_str()); }
-  void set(int a) { return; }
-  void set(const std::string& s) { return; }
-  void erase() { cm->erase(); return; }
-  int sum(const TWStatsBuf& vec)
+  void add(int a) override { return; }
+  void add(const std::string& s) override { cm->update(s.c_str(), 1); }
+  void add(const std::string& s, int a) override { cm->update(s.c_str(), a); }
+  void sub(int a) override { return; }
+  void sub(const std::string& s) override { return; }
+  int get() override { return cm->totalcount(); }
+  int get(const std::string& s) override { return cm->estimate(s.c_str()); }
+  void set(int a) override { return; }
+  void set(const std::string& s) override { return; }
+  void erase() override { cm->erase(); return; }
+  int sum(const TWStatsBuf& vec) override
   {
     int count = 0;
     for (auto a=vec.begin(); a!=vec.end(); ++a)
@@ -197,7 +197,7 @@ public:
       }
     return count;
   }
-  int sum(const std::string&s, const TWStatsBuf& vec)
+  int sum(const std::string&s, const TWStatsBuf& vec) override
   {
     int count = 0;
     for (auto a=vec.begin(); a!=vec.end(); ++a)
@@ -206,10 +206,10 @@ public:
       }
     return count;
   }
-  void dump(std::ostream& os) {
+  void dump(std::ostream& os) override {
     cm->dump(os);
   }
-  void restore(std::istream& is) {
+  void restore(std::istream& is) override {
     cm->restore(is);
   }
   static void setGamma(float g)

--- a/common/twmap.hh
+++ b/common/twmap.hh
@@ -543,7 +543,7 @@ public:
                    TWStatsDBDumpEntry& entry,
                    T& key)
   {
-    const typename TWStatsDBMap::iterator it = stats_db.find(*i);
+    const auto it = stats_db.find(*i);
     if (it != stats_db.end()) {
       key = it->first;
       for (auto fm = it->second.second.begin(); fm != it->second.second.end(); ++fm) {

--- a/common/twmap.hh
+++ b/common/twmap.hh
@@ -405,7 +405,7 @@ public:
     sum_cache_valid = false;
     ssum_cache_valid = false;
     unsigned int j = 0;
-    for (TWStatsBufSerial::iterator i = statsvec.begin(); i != statsvec.end(); ++i, ++j) {
+    for (auto i = statsvec.begin(); i != statsvec.end(); ++i, ++j) {
       stats_array[j].first = i->first;
       stats_array[j].second->restore(i->second);
     }
@@ -469,6 +469,7 @@ typedef std::unique_ptr<TWStatsEntry> TWStatsEntryP;
 
 // key is field name, value is field type
 typedef std::map<std::string, std::string> FieldMap;
+// key is field name, value is a start time and a bunch of time windows
 typedef std::map<std::string, std::pair<std::time_t, TWStatsBufSerial>> TWStatsDBDumpEntry;
 
 const unsigned int ctwstats_map_size_soft = 524288;

--- a/common/webhook.cc
+++ b/common/webhook.cc
@@ -55,6 +55,11 @@ void WebHookRunner::setMaxConns(unsigned int max_conns)
   max_hook_conns = max_conns;
 }
 
+void WebHookRunner::setTimeout(uint64_t tseconds)
+{
+  timeout_secs = tseconds;
+}
+
 // synchronously run the ping command for the hook
 bool WebHookRunner::pingHook(std::shared_ptr<const WebHook> hook, std::string error_msg)
 {
@@ -97,6 +102,7 @@ void WebHookRunner::runHook(const std::string& event_name, std::shared_ptr<const
 void WebHookRunner::_runHookThread(unsigned int num_conns)
 {
   MiniCurlMulti mcm(num_conns);
+  mcm.setTimeout(timeout_secs);
   while (true) {
     std::vector<WebHookQueueItem> events;
     {

--- a/common/webhook.hh
+++ b/common/webhook.hh
@@ -446,6 +446,7 @@ using CurlConns = std::vector<std::shared_ptr<CurlConnection>>;
 #define MAX_HOOK_CONN 10
 #define NUM_WEBHOOK_THREADS 5
 #define QUEUE_SIZE 50000
+#define DEFAULT_TIMEOUT_SECS 2
 
 struct WebHookQueueItem
 {
@@ -461,6 +462,7 @@ public:
   void setNumThreads(unsigned int new_num_threads);
   void setMaxConns(unsigned int max_conns);
   void setMaxQueueSize(unsigned int max_queue);
+  void setTimeout(uint64_t timeout_seconds);
   // synchronously run the ping command for the hook
   bool pingHook(std::shared_ptr<const WebHook> hook, std::string error_msg);
   // asynchronously run the hook with the supplied data (must be in json format)
@@ -478,4 +480,5 @@ private:
   unsigned int max_queue_size = QUEUE_SIZE;
   unsigned int max_hook_conns = MAX_HOOK_CONN;
   unsigned int num_threads = NUM_WEBHOOK_THREADS;
+  uint64_t timeout_secs = DEFAULT_TIMEOUT_SECS;
 };

--- a/docs/manpages/trackalert.conf.5.md
+++ b/docs/manpages/trackalert.conf.5.md
@@ -135,6 +135,31 @@ e.g. GeoIPCityv6.dat -> GeoLiteCityv6.dat. For example:
   
 		initGeoIPISPDB()
 
+* setNumWebHookThreads(\<num threads\>) - Set the number of threads in
+  the pool used to send webhook events. Defaults to 5 if not
+  specified. For example:
+
+		setNumWebHookThreads(2)
+
+* setNumWebHookConnsPerThread(\<num conns\>) - Set the maximum number
+  of connections used by each WebHook thread. Defaults to 10 if not
+  specified. This setting replaces the deprecated "num_conns" per-hook
+  configuration setting. For example:
+
+        setNumWebHookConnsPerThread(50)
+
+* setWebHookQueueSize(\<queue size\>) - Set the size of the queue for
+  webhook events. If the queue gets too big, then webhooks will be
+  discarded, and an error will be logged. The default queue size is
+  50000, which should be appropriate for most use-cases.
+
+        setWebHookQueueSize(100000)
+
+* setWebHookTimeoutSecs(\<timeout secs\>) - Set the maximum time a
+  request can take for webhooks. For example:
+
+        setWebHookTimeoutSecs(2)
+
 * setReport(\<report func\>) - Tell trackalert to use the specified
   Lua function for handling all "report" commands. For example:
   

--- a/docs/manpages/wforce.conf.5.md
+++ b/docs/manpages/wforce.conf.5.md
@@ -337,6 +337,34 @@ cannot be called inside the allow/report/reset functions:
 
 		setVerboseAllowLog()
 
+* addSyncHost(\<sync host address\>, \<sync host password\>,
+  \<replication address\>, \<callback address\>) - If you wish wforce
+  to synchronize the contents of its StatsDBs with the rest of a
+  cluster, then use this configuration command. If any sync hosts are
+  added, wforce will attempt to contact them in turn and find a host
+  which has been up longer than the number of seconds specified in
+  setMinSyncHostUptime(). The sync host address should include a port
+  (it defaults to 8084). If successful, the sync host will send the
+  contents of its StatsDBs to this wforce instance on the replication
+  address specified (this address should have the same port as
+  configured in siblingListener() and defaults to 4001), and when it
+  is finished it will notify this instance of wforce using the
+  callback address (this address should have the same port as
+  configured in webserver and defaults to 8084). For
+  example:
+
+        -- Add 10.2.3.1:8084 as a sync host,
+        -- and use the password "super"
+        -- Send the DB dump to 10.2.1.1:4001
+        -- and let me know on 10.2.1.1:8084 when the dump is finished
+        addSyncHost("10.2.3.1:8084", "super", "10.2.1.1:4001", "10.2.1.1:8084") 
+
+* setMinSyncHostUptime(\<seconds\>) - The minimum time that any sync
+  host must have been up for it to be able to send me the contents of
+  its DBs. Defaults to 3600. For example:
+
+        setMinSyncHostUptime(1800)
+
 # GENERAL FUNCTIONS
 
 The following functions are available anywhere; either as part of the 

--- a/docs/manpages/wforce.conf.5.md
+++ b/docs/manpages/wforce.conf.5.md
@@ -61,21 +61,26 @@ cannot be called inside the allow/report/reset functions:
 
         addCustomStat("custom_stat1")
 
-* setSiblings(\<list of IP[:port]\>) - Set the list of siblings to which
+* setSiblings(\<list of IP[:port[:protocol]]\>) - Set the list of siblings to which
   stats db and blacklist data should be replicated. If port is not specified
-  it defaults to 4001. For example:
+  it defaults to 4001.  If protocol is not specified it defaults to
+  udp. For example:
   
-		setSiblings({"127.0.1.2", "127.0.1.3:4004"})
+		setSiblings({"127.0.1.2", "127.0.1.3:4004", "127.0.2.23:4004:tcp"})
 
-* addSibling(\<IP[:port]\>) - Add a sibling to the list to which all
+* addSibling(\<IP[:port[:protocol]]\>) - Add a sibling to the list to which all
   stats db and blacklist data should be replicated.  If port is not specified
-  it defaults to 4001. For example:
+  it defaults to 4001. If protocol is not specified it defaults to
+  udp. For example:
   
 		addSibling("192.168.1.23")
+		addSibling("192.168.1.23:4001:udp")
+		addSibling("192.168.1.23:4003:tcp")
 
 * siblingListener(\<IP[:port]\>) - Listen for reports from siblings on
   the specified IP address and port.  If port is not specified
-  it defaults to 4001. For example:
+  it defaults to 4001. Wforce will always listen on both UDP and TCP
+  ports. For example:
   
 		siblingListener("0.0.0.0:4001")
 

--- a/docs/manpages/wforce.conf.5.md
+++ b/docs/manpages/wforce.conf.5.md
@@ -160,6 +160,11 @@ cannot be called inside the allow/report/reset functions:
 
         setWebHookQueueSize(100000)
 
+* setWebHookTimeoutSecs(\<timeout secs\>) - Set the maximum time a
+  request can take for webhooks. For example:
+
+        setWebHookTimeoutSecs(2)
+
 * newGeoIP2DB(\<db name\>, \<filename\>) - Opens and initializes a
   GeoIP2 database. A name must be chosen, and the filename of the
   database to open must also be supplied. To obtain an object allowing

--- a/docs/swagger/wforce_api.7.yml
+++ b/docs/swagger/wforce_api.7.yml
@@ -614,7 +614,7 @@ definitions:
       perfstats: {"WTR_0_1": 0, "WTR_100_1000": 0, "WTR_10_100": 0, "WTR_1_10": 0, "WTR_Slow": 0, "WTW_0_1": 1, "WTW_100_1000": 0, "WTW_10_100": 0, "WTW_1_10": 0, "WTW_Slow": 0}
       commandstats: {"addBLEntry": 0, "allow": 0, "delBLEntry": 0, "getBL": 0, "getDBStats": 0, "ping": 0, "report": 0, "reset": 0, "stats": 0}
       customstats: {"custom1": 0, "custom2": 0}
-  SyncDBsParams:
+  syncDBsParams:
     type: object
     required:
       - replication_host

--- a/docs/swagger/wforce_api.7.yml
+++ b/docs/swagger/wforce_api.7.yml
@@ -189,7 +189,6 @@ paths:
                 type: string
             example:
               status: ok
-              status: warmup
         default:
           description: unexpected error
           schema:
@@ -272,7 +271,8 @@ paths:
     post:
       description: This is a request to synchronize StatsDBs.
       operationId: syncDBs
-      produces: application/json
+      produces:
+        - application/json
       parameters:
         - name: "syncDBs"
           in: body

--- a/docs/swagger/wforce_api.7.yml
+++ b/docs/swagger/wforce_api.7.yml
@@ -189,6 +189,29 @@ paths:
                 type: string
             example:
               status: ok
+              status: warmup
+        default:
+          description: unexpected error
+          schema:
+            $ref: "#/definitions/Error"
+  /?command=syncDone:
+    get:
+      description: "Tell the server that DB syncing is done"
+      operationId: "syncDone"
+      produces:
+        - "application/json"
+      responses:
+        "200":
+          description: "syncDone response"
+          schema:
+            type: object
+            required:
+              - status
+            properties:
+              status:
+                type: string
+            example:
+              status: ok
         default:
           description: unexpected error
           schema:
@@ -241,6 +264,34 @@ paths:
           description: "getDBStats response"
           schema:
             $ref: "#/definitions/DBStatsResponse"
+        default:
+          description: unexpected error
+          schema:
+            $ref: "#/definitions/Error"
+  /?command=syncDBs:
+    post:
+      description: This is a request to synchronize StatsDBs.
+      operationId: syncDBs
+      produces: application/json
+      parameters:
+        - name: "syncDBs"
+          in: body
+          description: "The ip and address to sync to"
+          required: true
+          schema:
+            $ref: "#/definitions/syncDBsParams"
+      responses:
+        "200":
+          description: "syncDBs response"
+          schema:
+            type: object
+            required:
+              - status
+            properties:
+              status:
+                type: string
+            example:
+              status: ok
         default:
           description: unexpected error
           schema:
@@ -563,3 +614,19 @@ definitions:
       perfstats: {"WTR_0_1": 0, "WTR_100_1000": 0, "WTR_10_100": 0, "WTR_1_10": 0, "WTR_Slow": 0, "WTW_0_1": 1, "WTW_100_1000": 0, "WTW_10_100": 0, "WTW_1_10": 0, "WTW_Slow": 0}
       commandstats: {"addBLEntry": 0, "allow": 0, "delBLEntry": 0, "getBL": 0, "getDBStats": 0, "ping": 0, "report": 0, "reset": 0, "stats": 0}
       customstats: {"custom1": 0, "custom2": 0}
+  SyncDBsParams:
+    type: object
+    required:
+      - replication_host
+      - replication_port
+      - callback_url
+      - callback_auth_pwd
+    properties:
+      replication_host:
+        type: string
+      replication_port:
+        type: integer
+      callback_url:
+        type: string
+      callback_auth_pw:
+        type: string

--- a/ext/ext/count_min_sketch.cpp
+++ b/ext/ext/count_min_sketch.cpp
@@ -156,6 +156,7 @@ void CountMinSketch::swap(CountMinSketch& rhs)
   std::swap(hashes, rhs.hashes);
 }
 
+// XXX - this function does not currently convert everything to network byte order
 void CountMinSketch::dump(std::ostream& os) const throw(std::runtime_error)
 {
   int i=0;
@@ -173,6 +174,7 @@ void CountMinSketch::dump(std::ostream& os) const throw(std::runtime_error)
   }
 }
 
+// XXX - this function does not currently convert everything from network byte order
 void CountMinSketch::restore(std::istream& is) throw(std::runtime_error)
 {
   float myeps=0;

--- a/ext/ext/count_min_sketch.cpp
+++ b/ext/ext/count_min_sketch.cpp
@@ -11,6 +11,8 @@
 # include <cstdlib>
 # include <ctime>
 # include <limits>
+# include <sstream>
+# include <algorithm>
 # include "count_min_sketch.hpp"
 using namespace std;
 
@@ -143,4 +145,51 @@ unsigned int CountMinSketch::hashstr(const char *str) {
   return hash;
 }
 
+void CountMinSketch::swap(CountMinSketch& rhs)
+{
+  std::swap(eps, rhs.eps);
+  std::swap(this->gamma, rhs.gamma);
+  std::swap(total, rhs.total);
+  std::swap(w, rhs.w);
+  std::swap(d, rhs.d);
+  std::swap(C, rhs.C);
+  std::swap(hashes, rhs.hashes);
+}
 
+void CountMinSketch::dump(std::ostream& os) const throw(std::runtime_error)
+{
+  int i=0;
+  os.write((char*)&eps, sizeof(eps));
+  os.write((char*)&gamma, sizeof(gamma));
+  os.write((char*)&total, sizeof(total));
+  for (i = 0; i < d; i++) {
+    os.write((char*)&(C[i][0]), sizeof(C[i][0])*w);
+  }
+  for (i = 0; i < d; i++) {
+    os.write((char*)&(hashes[i][0]), sizeof(hashes[i][0])*2);
+  }
+  if(os.fail()){
+    throw std::runtime_error("CountMinSketch: Failed to dump");
+  }
+}
+
+void CountMinSketch::restore(std::istream& is) throw(std::runtime_error)
+{
+  float myeps=0;
+  float mygamma=0;
+  int i=0;
+  is.read((char*)&myeps, sizeof(myeps));
+  is.read((char*)&mygamma, sizeof(mygamma));
+  CountMinSketch tempCMS(myeps, mygamma);
+  is.read((char*)&tempCMS.total, sizeof(tempCMS.total));
+  for (i = 0; i < tempCMS.d; i++) {
+    is.read((char*)&(tempCMS.C[i][0]), sizeof(tempCMS.C[i][0])*tempCMS.w);
+  }
+  for (i = 0; i < tempCMS.d; i++) {
+    is.read((char*)&(tempCMS.hashes[i][0]), sizeof(tempCMS.hashes[i][0])*2);
+  }
+  if(is.fail()){
+    throw std::runtime_error("CountMinSketch: Failed to restore");
+  }
+  swap(tempCMS);
+}

--- a/ext/ext/count_min_sketch.hpp
+++ b/ext/ext/count_min_sketch.hpp
@@ -62,6 +62,15 @@ class CountMinSketch {
     // erase counts
     void erase();
 
+    // Exchange the contents of an instance
+    void swap(CountMinSketch& rhs);
+
+    // Dump to a stream
+    void dump(std::ostream& os) const throw(std::runtime_error);
+
+    // Restore from a stream
+    void restore(std::istream& is) throw(std::runtime_error);
+
     // destructor
     ~CountMinSketch();
   };

--- a/ext/ext/count_min_sketch.hpp
+++ b/ext/ext/count_min_sketch.hpp
@@ -6,6 +6,8 @@
     Muthukrishnan and Cormode, 2004
 **/
 
+#pragma once
+
 // define some constants
 # define LONG_PRIME 32993
 #ifndef MIN

--- a/ext/ext/count_min_sketch.hpp
+++ b/ext/ext/count_min_sketch.hpp
@@ -12,57 +12,56 @@
 # define MIN(a,b)  (a < b ? a : b)
 #endif
 
-/** CountMinSketch class definition here **/
+  /** CountMinSketch class definition here **/
 class CountMinSketch {
-  // width, depth 
-  unsigned int w,d;
+  protected:
+    // width, depth
+    unsigned int w,d;
   
-  // eps (for error), 0.01 < eps < 1
-  // the smaller the better
-  float eps;
+    // eps (for error), 0.01 < eps < 1
+    // the smaller the better
+    float eps;
   
-  // gamma (probability for accuracy), 0 < gamma < 1
-  // the bigger the better
-  float gamma;
+    // gamma (probability for accuracy), 0 < gamma < 1
+    // the bigger the better
+    float gamma;
   
-  // total count so far
-  unsigned int total; 
+    // total count so far
+    unsigned int total;
 
-  // array of arrays of counters
-  int **C;
+    // array of arrays of counters
+    int **C;
 
-  // array of hash values for a particular item 
-  // contains two element arrays {aj,bj}
-  int **hashes;
+    // array of hash values for a particular item
+    // contains two element arrays {aj,bj}
+    int **hashes;
 
-  // generate "new" aj,bj
-  void genajbj(int **hashes, int i);
+    // generate "new" aj,bj
+    void genajbj(int **hashes, int i);
 
-public:
-  // constructor
-  CountMinSketch(float eps, float gamma);
+  public:
+    // constructor
+    CountMinSketch(float eps, float gamma);
   
-  // update item (int) by count c
-  void update(int item, int c);
-  // update item (string) by count c
-  void update(const char *item, int c);
+    // update item (int) by count c
+    void update(int item, int c);
+    // update item (string) by count c
+    void update(const char *item, int c);
 
-  // estimate count of item i and return count
-  unsigned int estimate(int item);
-  unsigned int estimate(const char *item);
+    // estimate count of item i and return count
+    unsigned int estimate(int item);
+    unsigned int estimate(const char *item);
 
-  // return total count
-  unsigned int totalcount();
+    // return total count
+    unsigned int totalcount();
 
-  // generates a hash value for a string
-  // same as djb2 hash function
-  unsigned int hashstr(const char *str);
+    // generates a hash value for a string
+    // same as djb2 hash function
+    unsigned int hashstr(const char *str);
 
-  // erase counts
-  void erase();
+    // erase counts
+    void erase();
 
-  // destructor
-  ~CountMinSketch();
-};
-
-
+    // destructor
+    ~CountMinSketch();
+  };

--- a/ext/ext/hyperloglog.hpp
+++ b/ext/ext/hyperloglog.hpp
@@ -66,170 +66,170 @@ static const double neg_pow_2_32 = -4294967296.0; ///< -(2^32)
 class HyperLogLog {
 public:
 
-    /**
-     * Constructor
-     *
-     * @param[in] b bit width (register size will be 2 to the b power).
-     *            This value must be in the range[4,30].Default value is 4.
-     *
-     * @exception std::invalid_argument the argument is out of range.
-     */
-    HyperLogLog(uint8_t b = 4) throw (std::invalid_argument) :
-            b_(b), m_(1 << b), M_(m_, 0) {
+  /**
+   * Constructor
+   *
+   * @param[in] b bit width (register size will be 2 to the b power).
+   *            This value must be in the range[4,30].Default value is 4.
+   *
+   * @exception std::invalid_argument the argument is out of range.
+   */
+  HyperLogLog(uint8_t b = 4) throw (std::invalid_argument) :
+    b_(b), m_(1 << b), M_(m_, 0) {
 
-        if (b < 4 || 30 < b) {
-            throw std::invalid_argument("bit width must be in the range [4,30]");
+    if (b < 4 || 30 < b) {
+      throw std::invalid_argument("bit width must be in the range [4,30]");
+    }
+
+    double alpha;
+    switch (m_) {
+    case 16:
+      alpha = 0.673;
+      break;
+    case 32:
+      alpha = 0.697;
+      break;
+    case 64:
+      alpha = 0.709;
+      break;
+    default:
+      alpha = 0.7213 / (1.0 + 1.079 / m_);
+      break;
+    }
+    alphaMM_ = alpha * m_ * m_;
+  }
+
+  /**
+   * Adds element to the estimator
+   *
+   * @param[in] str string to add
+   * @param[in] len length of string
+   */
+  void add(const char* str, uint32_t len) {
+    uint32_t hash;
+    MurmurHash3_x86_32(str, len, HLL_HASH_SEED, (void*) &hash);
+    uint32_t index = hash & ((1 <<  b_) - 1);
+    uint8_t rank = _GET_CLZ((hash << b_), 32 - b_);
+    if (rank > M_[index]) {
+      M_[index] = rank;
+    }
+  }
+
+  /**
+   * Estimates cardinality value.
+   *
+   * @return Estimated cardinality value.
+   */
+  double estimate() const {
+    double estimate;
+    double sum = 0.0;
+    for (uint32_t i = 0; i < m_; i++) {
+      sum += 1.0 / (1 << M_[i]);
+    }
+    estimate = alphaMM_ / sum; // E in the original paper
+    if (estimate <= 2.5 * m_) {
+      uint32_t zeros = 0;
+      for (uint32_t i = 0; i < m_; i++) {
+        if (M_[i] == 0) {
+          zeros++;
         }
-
-        double alpha;
-        switch (m_) {
-            case 16:
-                alpha = 0.673;
-                break;
-            case 32:
-                alpha = 0.697;
-                break;
-            case 64:
-                alpha = 0.709;
-                break;
-            default:
-                alpha = 0.7213 / (1.0 + 1.079 / m_);
-                break;
-        }
-        alphaMM_ = alpha * m_ * m_;
+      }
+      if (zeros != 0) {
+        estimate = m_ * std::log(static_cast<double>(m_)/ zeros);
+      }
+    } else if (estimate > (1.0 / 30.0) * pow_2_32) {
+      estimate = neg_pow_2_32 * log(1.0 - (estimate / pow_2_32));
     }
+    return estimate;
+  }
 
-    /**
-     * Adds element to the estimator
-     *
-     * @param[in] str string to add
-     * @param[in] len length of string
-     */
-    void add(const char* str, uint32_t len) {
-        uint32_t hash;
-        MurmurHash3_x86_32(str, len, HLL_HASH_SEED, (void*) &hash);
-        uint32_t index = hash & ((1 <<  b_) - 1);
-        uint8_t rank = _GET_CLZ((hash << b_), 32 - b_);
-        if (rank > M_[index]) {
-            M_[index] = rank;
-        }
+  /**
+   * Merges the estimate from 'other' into this object, returning the estimate of their union.
+   * The number of registers in each must be the same.
+   *
+   * @param[in] other HyperLogLog instance to be merged
+   * 
+   * @exception std::invalid_argument number of registers doesn't match.
+   */
+  void merge(const HyperLogLog& other) throw (std::invalid_argument) {
+    if (m_ != other.m_) {
+      std::stringstream ss;
+      ss << "number of registers doesn't match: " << m_ << " != " << other.m_;
+      throw std::invalid_argument(ss.str().c_str());
     }
+    for (uint32_t r = 0; r < m_; ++r) {
+      if (M_[r] < other.M_[r]) {
+        M_[r] |= other.M_[r];
+      }
+    }
+  }
 
-    /**
-     * Estimates cardinality value.
-     *
-     * @return Estimated cardinality value.
-     */
-    double estimate() const {
-        double estimate;
-        double sum = 0.0;
-        for (uint32_t i = 0; i < m_; i++) {
-            sum += 1.0 / (1 << M_[i]);
-        }
-        estimate = alphaMM_ / sum; // E in the original paper
-        if (estimate <= 2.5 * m_) {
-            uint32_t zeros = 0;
-            for (uint32_t i = 0; i < m_; i++) {
-                if (M_[i] == 0) {
-                    zeros++;
-                }
-            }
-            if (zeros != 0) {
-                estimate = m_ * std::log(static_cast<double>(m_)/ zeros);
-            }
-        } else if (estimate > (1.0 / 30.0) * pow_2_32) {
-            estimate = neg_pow_2_32 * log(1.0 - (estimate / pow_2_32));
-        }
-        return estimate;
-    }
+  /**
+   * Clears all internal registers.
+   */
+  void clear() {
+    std::fill(M_.begin(), M_.end(), 0);
+  }
 
-    /**
-     * Merges the estimate from 'other' into this object, returning the estimate of their union.
-     * The number of registers in each must be the same.
-     *
-     * @param[in] other HyperLogLog instance to be merged
-     * 
-     * @exception std::invalid_argument number of registers doesn't match.
-     */
-    void merge(const HyperLogLog& other) throw (std::invalid_argument) {
-        if (m_ != other.m_) {
-            std::stringstream ss;
-            ss << "number of registers doesn't match: " << m_ << " != " << other.m_;
-            throw std::invalid_argument(ss.str().c_str());
-        }
-        for (uint32_t r = 0; r < m_; ++r) {
-            if (M_[r] < other.M_[r]) {
-                M_[r] |= other.M_[r];
-            }
-        }
-    }
+  /**
+   * Returns size of register.
+   *
+   * @return Register size
+   */
+  uint32_t registerSize() const {
+    return m_;
+  }
 
-    /**
-     * Clears all internal registers.
-     */
-    void clear() {
-        std::fill(M_.begin(), M_.end(), 0);
-    }
+  /**
+   * Exchanges the content of the instance
+   *
+   * @param[in,out] rhs Another HyperLogLog instance
+   */
+  void swap(HyperLogLog& rhs) {
+    std::swap(b_, rhs.b_);
+    std::swap(m_, rhs.m_);
+    std::swap(alphaMM_, rhs.alphaMM_);
+    M_.swap(rhs.M_);
+  }
 
-    /**
-     * Returns size of register.
-     *
-     * @return Register size
-     */
-    uint32_t registerSize() const {
-        return m_;
+  /**
+   * Dump the current status to a stream
+   *
+   * @param[out] os The output stream where the data is saved
+   *
+   * @exception std::runtime_error When failed to dump.
+   */
+  void dump(std::ostream& os) const throw(std::runtime_error){
+    os.write((char*)&b_, sizeof(b_));
+    os.write((char*)&M_[0], sizeof(M_[0]) * M_.size());
+    if(os.fail()){
+      throw std::runtime_error("HLL: Failed to dump");
     }
+  }
 
-    /**
-     * Exchanges the content of the instance
-     *
-     * @param[in,out] rhs Another HyperLogLog instance
-     */
-    void swap(HyperLogLog& rhs) {
-        std::swap(b_, rhs.b_);
-        std::swap(m_, rhs.m_);
-        std::swap(alphaMM_, rhs.alphaMM_);
-        M_.swap(rhs.M_);       
+  /**
+   * Restore the status from a stream
+   * 
+   * @param[in] is The input stream where the status is saved
+   *
+   * @exception std::runtime_error When failed to restore.
+   */
+  void restore(std::istream& is) throw(std::runtime_error){
+    uint8_t b = 0;
+    is.read((char*)&b, sizeof(b));
+    HyperLogLog tempHLL(b);
+    is.read((char*)&(tempHLL.M_[0]), sizeof(M_[0]) * tempHLL.m_);
+    if(is.fail()){
+      throw std::runtime_error("HLL: Failed to restore");
     }
-
-    /**
-     * Dump the current status to a stream
-     *
-     * @param[out] os The output stream where the data is saved
-     *
-     * @exception std::runtime_error When failed to dump.
-     */
-    void dump(std::ostream& os) const throw(std::runtime_error){
-        os.write((char*)&b_, sizeof(b_));
-        os.write((char*)&M_[0], sizeof(M_[0]) * M_.size());
-        if(os.fail()){
-            throw std::runtime_error("HLL: Failed to dump");
-        }
-    }
-
-    /**
-     * Restore the status from a stream
-     * 
-     * @param[in] is The input stream where the status is saved
-     *
-     * @exception std::runtime_error When failed to restore.
-     */
-    void restore(std::istream& is) throw(std::runtime_error){
-        uint8_t b = 0;
-        is.read((char*)&b, sizeof(b));
-        HyperLogLog tempHLL(b);
-        is.read((char*)&(tempHLL.M_[0]), sizeof(M_[0]) * tempHLL.m_);
-        if(is.fail()){
-           throw std::runtime_error("HLL: Failed to restore");
-        }       
-        swap(tempHLL);
-    }
+    swap(tempHLL);
+  }
 
 protected:
-    uint8_t b_; ///< register bit width
-    uint32_t m_; ///< register size
-    double alphaMM_; ///< alpha * m^2
-    std::vector<uint8_t> M_; ///< registers
+  uint8_t b_; ///< register bit width
+  uint32_t m_; ///< register size
+  double alphaMM_; ///< alpha * m^2
+  std::vector<uint8_t> M_; ///< registers
 };
 
 /**

--- a/ext/ext/hyperloglog.hpp
+++ b/ext/ext/hyperloglog.hpp
@@ -203,7 +203,7 @@ public:
         os.write((char*)&b_, sizeof(b_));
         os.write((char*)&M_[0], sizeof(M_[0]) * M_.size());
         if(os.fail()){
-            throw std::runtime_error("Failed to dump");
+            throw std::runtime_error("HLL: Failed to dump");
         }
     }
 
@@ -220,7 +220,7 @@ public:
         HyperLogLog tempHLL(b);
         is.read((char*)&(tempHLL.M_[0]), sizeof(M_[0]) * tempHLL.m_);
         if(is.fail()){
-           throw std::runtime_error("Failed to restore");
+           throw std::runtime_error("HLL: Failed to restore");
         }       
         swap(tempHLL);
     }

--- a/regression-tests/runtests.py
+++ b/regression-tests/runtests.py
@@ -27,17 +27,20 @@ if wait:
 
 cmd1 = ("../wforce/wforce -C ./wforce1.conf -R ../wforce/regexes.yaml").split()
 cmd2 = ("../wforce/wforce -C ./wforce2.conf -R ../wforce/regexes.yaml").split()
+cmd4 = ("../wforce/wforce -C ./wforce4.conf -R ../wforce/regexes.yaml").split()
 webcmd = ("/usr/bin/python ./webhook_server.py").split()
 udpsinkcmd = ("/usr/bin/python ./udp_sink.py").split()
 ta_cmd = ("../trackalert/trackalert -C ./trackalert.conf").split()
 report_cmd = (".venv/bin/python ../report_api/runreport.py").split()
 
 # Now run wforce and the tests.
-print "Launching wforce (1 and 2)..."
+print "Launching wforce (1 and 2 and 4)..."
 print ' '.join(cmd1)
 print ' '.join(cmd2)
+print ' '.join(cmd4)
 proc1 = subprocess.Popen(cmd1, close_fds=True)
 proc2 = subprocess.Popen(cmd2, close_fds=True)
+proc4 = subprocess.Popen(cmd4, close_fds=True)
 webproc = subprocess.Popen(webcmd, close_fds=True)
 webpid = webproc.pid
 udpproc = subprocess.Popen(udpsinkcmd, close_fds=True)
@@ -52,6 +55,8 @@ def sighandler(signum, frame):
     proc1.wait()
     proc2.terminate()
     proc2.wait()
+    proc4.terminate()
+    proc4.wait()
     webproc.terminate()
     webproc.wait()
     udpproc.terminate()
@@ -80,6 +85,8 @@ if not available:
     proc1.wait()
     proc2.terminate()
     proc2.wait()
+    proc4.terminate()
+    proc4.wait()
     webproc.terminate()
     webproc.wait()
     udpproc.terminate()
@@ -108,6 +115,8 @@ finally:
     proc1.wait()
     proc2.terminate()
     proc2.wait()
+    proc4.terminate()
+    proc4.wait()
     webproc.terminate()
     webproc.wait()
     udpproc.terminate()

--- a/regression-tests/test_Replication.py
+++ b/regression-tests/test_Replication.py
@@ -37,7 +37,7 @@ class TestTimeWindowsReplication(ApiTestCase):
         r.close()
 
         for i in range(32):
-            r = self.reportFunc('flbaddiereplication', '128.0.0.1', "1234", 'false')
+            r = self.reportFunc('flbaddiereplication', '128.0.0.1', "1234", False)
             r.json()
 
         time.sleep(1)
@@ -79,7 +79,7 @@ class TestTimeWindowsReplication(ApiTestCase):
         r.close()
 
         for i in range(42):
-            r = self.reportFunc('subbaddiereplication', '228.0.0.1', "1234", 'false')
+            r = self.reportFunc('subbaddiereplication', '228.0.0.1', "1234", False)
             r.json()
 
         r = self.allowFuncReplica('subbaddiereplication', '228.0.0.1', "1234")
@@ -185,7 +185,7 @@ class TestTimeWindowsReplication(ApiTestCase):
         r.close()
 
         for i in range(32):
-            r = self.reportFunc('resetbaddiereplication', '128.0.0.1', "1234", 'false')
+            r = self.reportFunc('resetbaddiereplication', '128.0.0.1', "1234", False)
             r.json()
 
         time.sleep(1)

--- a/regression-tests/test_Replication.py
+++ b/regression-tests/test_Replication.py
@@ -24,12 +24,20 @@ class TestTimeWindowsReplication(ApiTestCase):
         j = r.json()
         self.assertEquals(j['status'], -1)
 
+        r = self.allowFuncReplica2('ivbaddiereplication', '127.0.0.1', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], -1)
+        
         # Wait for the time windows to clear and then check again
         time.sleep(16)
         r = self.allowFuncReplica('ivbaddiereplication', '127.0.0.1', "1234")
         j = r.json()
         self.assertEquals(j['status'], 0)
 
+        r = self.allowFuncReplica2('ivbaddiereplication', '127.0.0.1', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], 0)
+        
     def test_FailedLogins(self):
         r = self.allowFunc('flbaddiereplication', '128.0.0.1', "1234")
         j = r.json()
@@ -45,9 +53,17 @@ class TestTimeWindowsReplication(ApiTestCase):
         j = r.json()
         self.assertEquals(j['status'], -1)
 
+        r = self.allowFuncReplica2('flbaddiereplication', '128.0.0.1', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], -1)
+        
         # Wait for the time windows to clear and then check again
         time.sleep(16)
         r = self.allowFuncReplica('flbaddiereplication', '128.0.0.1', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], 0)
+
+        r = self.allowFuncReplica2('flbaddiereplication', '128.0.0.1', "1234")
         j = r.json()
         self.assertEquals(j['status'], 0)
 
@@ -66,9 +82,17 @@ class TestTimeWindowsReplication(ApiTestCase):
         j = r.json()
         self.assertEquals(j['status'], -1)
 
+        r = self.allowFuncReplica2('ipbaddiereplication', '227.0.0.1', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], -1)
+
         # Wait for the time windows to clear and then check again
         time.sleep(16)
         r = self.allowFuncReplica('ipbaddiereplication', '227.0.0.1', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], 0)
+
+        r = self.allowFuncReplica2('ipbaddiereplication', '227.0.0.1', "1234")
         j = r.json()
         self.assertEquals(j['status'], 0)
 
@@ -86,9 +110,17 @@ class TestTimeWindowsReplication(ApiTestCase):
         j = r.json()
         self.assertEquals(j['status'], -1)
 
+        r = self.allowFuncReplica2('subbaddiereplication', '228.0.0.1', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], -1)
+        
         # Wait for the time windows to clear and then check again
         time.sleep(15)
         r = self.allowFuncReplica('subbaddiereplication', '227.0.0.1', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], 0)
+
+        r = self.allowFuncReplica2('subbaddiereplication', '227.0.0.1', "1234")
         j = r.json()
         self.assertEquals(j['status'], 0)
 
@@ -107,9 +139,17 @@ class TestTimeWindowsReplication(ApiTestCase):
         j = r.json()
         self.assertEquals(j['status'], -1)
 
+        r = self.allowFuncReplica2('ipv4baddiereplication', '114.31.193.200', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], -1)
+
         # Wait for the time windows to clear and then check again
         time.sleep(16)
         r = self.allowFuncReplica('ipv4baddiereplication', '114.31.193.200', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], 0)
+
+        r = self.allowFuncReplica2('ipv4baddiereplication', '114.31.193.200', "1234")
         j = r.json()
         self.assertEquals(j['status'], 0)
 
@@ -128,9 +168,17 @@ class TestTimeWindowsReplication(ApiTestCase):
         j = r.json()
         self.assertEquals(j['status'], 0)
 
+        r = self.allowFuncReplica2('mappedipv4baddiereplication', '::ffff:114.31.193.200', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], 0)
+
         # Wait for the time windows to clear and then check again
         time.sleep(16)
         r = self.allowFuncReplica('mappedipv4baddiereplication', '::ffff:114.31.193.200', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], 0)
+
+        r = self.allowFuncReplica2('mappedipv4baddiereplication', '::ffff:114.31.193.200', "1234")
         j = r.json()
         self.assertEquals(j['status'], 0)
 
@@ -149,12 +197,20 @@ class TestTimeWindowsReplication(ApiTestCase):
         j = r.json()
         self.assertEquals(j['status'], -1)
 
+        r = self.allowFuncReplica2('ipv6baddiereplication', '2001:c78::1000', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], -1)
+
         # Wait for the time windows to clear and then check again
         time.sleep(16)
         r = self.allowFuncReplica('ipv6baddiereplication', '2001:c78::1000', "1234")
         j = r.json()
         self.assertEquals(j['status'], 0)
 
+        r = self.allowFuncReplica2('ipv6baddiereplication', '2001:c78::1000', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], 0)
+        
     def test_expiry(self):
         r = self.allowFunc('expirebaddiereplication', '127.0.0.1', "1234")
         j = r.json()
@@ -172,9 +228,17 @@ class TestTimeWindowsReplication(ApiTestCase):
         j = r.json()
         self.assertEquals(j['status'], -1)
 
+        r = self.allowFuncReplica2('expirebaddiereplication', '127.0.0.1', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], -1)
+        
         # Wait for the expiry thread to delete everything bigger than size (10) and then check again
         time.sleep(30)
         r = self.allowFuncReplica('expirebaddiereplication', '127.0.0.1', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], 0)
+
+        r = self.allowFuncReplica2('expirebaddiereplication', '127.0.0.1', "1234")
         j = r.json()
         self.assertEquals(j['status'], 0)
 
@@ -193,6 +257,10 @@ class TestTimeWindowsReplication(ApiTestCase):
         j = r.json()
         self.assertEquals(j['status'], -1)
 
+        r = self.allowFuncReplica2('resetbaddiereplication', '128.0.0.1', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], -1)
+        
         r = self.resetFunc('resetbaddiereplication', '128.0.0.1')
         j = r.json()
         self.assertEquals(j['status'], "ok")
@@ -202,6 +270,10 @@ class TestTimeWindowsReplication(ApiTestCase):
         j = r.json()
         self.assertEquals(j['status'], 0)
 
+        r = self.allowFuncReplica2('resetbaddiereplication', '128.0.0.1', "1234")
+        j = r.json()
+        self.assertEquals(j['status'], 0)
+        
     def test_resetField(self):
         r = self.incLogins("resetFieldTest")
         j = r.json()
@@ -212,6 +284,10 @@ class TestTimeWindowsReplication(ApiTestCase):
         r = self.countLoginsReplica("resetFieldTest")
         j = r.json()
         self.assertEquals(j['r_attrs']['countLogins'], '1')
+
+        r = self.countLoginsReplica2("resetFieldTest")
+        j = r.json()
+        self.assertEquals(j['r_attrs']['countLogins'], '1')
         
         r = self.resetLogins("resetFieldTest")
         j = r.json()
@@ -220,5 +296,9 @@ class TestTimeWindowsReplication(ApiTestCase):
         time.sleep(1)
 
         r = self.countLoginsReplica("resetFieldTest")
+        j = r.json()
+        self.assertEquals(j['r_attrs']['countLogins'], '0')
+
+        r = self.countLoginsReplica2("resetFieldTest")
         j = r.json()
         self.assertEquals(j['r_attrs']['countLogins'], '0')

--- a/regression-tests/test_Replication.py
+++ b/regression-tests/test_Replication.py
@@ -16,7 +16,7 @@ class TestTimeWindowsReplication(ApiTestCase):
         r.close()
 
         for i in range(22):
-            r = self.reportFunc('ivbaddiereplication', '127.0.0.1', "1234'%s" % i, 'true')
+            r = self.reportFunc('ivbaddiereplication', '127.0.0.1', "1234'%s" % i, True)
             r.json()
 
         time.sleep(1)
@@ -58,7 +58,7 @@ class TestTimeWindowsReplication(ApiTestCase):
         r.close()
 
         for i in range(12):
-            r = self.reportFunc('ipbaddiereplication', "227.0.0.%s" % i, "1234", 'true')
+            r = self.reportFunc('ipbaddiereplication', "227.0.0.%s" % i, "1234", True)
             r.json()
 
         time.sleep(1)
@@ -99,7 +99,7 @@ class TestTimeWindowsReplication(ApiTestCase):
         r.close()
 
         for i in range(50):
-            r = self.reportFunc('ipv4baddiereplication%s' % i, "114.31.193.%s" % i, "1234", 'true')
+            r = self.reportFunc('ipv4baddiereplication%s' % i, "114.31.193.%s" % i, "1234", True)
             r.json()
 
         time.sleep(1)
@@ -120,7 +120,7 @@ class TestTimeWindowsReplication(ApiTestCase):
         r.close()
 
         for i in range(50):
-            r = self.reportFunc('mappedipv4baddiereplication%s' % i, "::ffff:%s.31.193.200" % i, "1234", 'true')
+            r = self.reportFunc('mappedipv4baddiereplication%s' % i, "::ffff:%s.31.193.200" % i, "1234", True)
             r.json()
 
         time.sleep(1)
@@ -141,7 +141,7 @@ class TestTimeWindowsReplication(ApiTestCase):
         r.close()
 
         for i in range(50):
-            r = self.reportFunc('ipv6baddiereplication%s' % i, "2001:c78::%s" % i, "1234", 'true')
+            r = self.reportFunc('ipv6baddiereplication%s' % i, "2001:c78::%s" % i, "1234", True)
             r.json()
 
         time.sleep(1)
@@ -162,10 +162,10 @@ class TestTimeWindowsReplication(ApiTestCase):
         r.close()
 
         for i in range(20):
-            r = self.reportFunc('expirebaddiereplication%s' % i, "127.0.0.1", "1234", 'true')
+            r = self.reportFunc('expirebaddiereplication%s' % i, "127.0.0.1", "1234", True)
             r.json()
         for i in range(20):
-            r = self.reportFunc('expirebaddiereplication%s' % i, "127.0.0.1", "1234", 'true')
+            r = self.reportFunc('expirebaddiereplication%s' % i, "127.0.0.1", "1234", True)
             r.json()
 
         r = self.allowFuncReplica('expirebaddiereplication', '127.0.0.1', "1234")

--- a/regression-tests/test_SyncDBs.py
+++ b/regression-tests/test_SyncDBs.py
@@ -25,3 +25,6 @@ class TestSyncDBs(ApiTestCase):
         res2_ss = res2.split("DB Name", 1)[1]
 
         self.assertEqual(res1_ss == res2_ss, True)
+
+        proc3.terminate()
+        proc3.wait()

--- a/regression-tests/test_SyncDBs.py
+++ b/regression-tests/test_SyncDBs.py
@@ -1,0 +1,27 @@
+import requests
+import socket
+import subprocess
+import sys
+import time
+import json
+from test_helper import ApiTestCase
+
+class TestSyncDBs(ApiTestCase):
+    def test_SyncDBs(self):
+        for i in range(42):
+            r = self.reportFunc('subbaddie%s' % i, '128.0.0.%s' % i, "1234", False)
+            r.json()
+
+        res1 = self.writeCmdToConsole("showStringStatsDB()");
+        res1_ss = res1.split("DB Name", 1)[1]
+        
+        time.sleep(11);
+        
+        cmd3 = ("../wforce/wforce -C ./wforce3.conf -R ../wforce/regexes.yaml").split()
+        proc3 = subprocess.Popen(cmd3, close_fds=True)
+        time.sleep(5)
+
+        res2 = self.writeCmdToConsole3("showStringStatsDB()");
+        res2_ss = res2.split("DB Name", 1)[1]
+
+        self.assertEqual(res1_ss == res2_ss, True)

--- a/regression-tests/test_TimeWindows.py
+++ b/regression-tests/test_TimeWindows.py
@@ -96,7 +96,7 @@ class TestTimeWindows(ApiTestCase):
         r.close()
 
         for i in range(50):
-            r = self.reportFunc('ipv4baddie%s' % i, "114.31.192.%s" % i, "1234", 'true')
+            r = self.reportFunc('ipv4baddie%s' % i, "114.31.192.%s" % i, "1234", True)
             r.json()
 
         r = self.allowFunc('ipv4baddie', '114.31.192.200', "1234")
@@ -116,7 +116,7 @@ class TestTimeWindows(ApiTestCase):
         r.close()
 
         for i in range(50):
-            r = self.reportFunc('mappedipv4baddie%s' % i, "::ffff:%s.31.192.200" % i, "1234", 'true')
+            r = self.reportFunc('mappedipv4baddie%s' % i, "::ffff:%s.31.192.200" % i, "1234", True)
             r.json()
 
         r = self.allowFunc('mappedipv4baddie', '::ffff:114.31.192.200', "1234")
@@ -136,7 +136,7 @@ class TestTimeWindows(ApiTestCase):
         r.close()
 
         for i in range(50):
-            r = self.reportFunc('ipv6baddie%s' % i, "2001:c78::%s" % i, "1234", 'true')
+            r = self.reportFunc('ipv6baddie%s' % i, "2001:c78::%s" % i, "1234", True)
             r.json()
 
         r = self.allowFunc('ipv6baddie', '2001:c78::1000', "1234")

--- a/regression-tests/test_TimeWindows.py
+++ b/regression-tests/test_TimeWindows.py
@@ -36,7 +36,7 @@ class TestTimeWindows(ApiTestCase):
         r.close()
 
         for i in range(32):
-            r = self.reportFunc('flbaddie', '128.0.0.1', "1234", 'false')
+            r = self.reportFunc('flbaddie', '128.0.0.1', "1234", False)
             r.json()
 
         r = self.allowFunc('flbaddie', '128.0.0.1', "1234")
@@ -76,7 +76,7 @@ class TestTimeWindows(ApiTestCase):
         r.close()
 
         for i in range(42):
-            r = self.reportFunc('subbaddie', '128.0.0.1', "1234", 'false')
+            r = self.reportFunc('subbaddie', '128.0.0.1', "1234", False)
             r.json()
 
         r = self.allowFunc('subbaddie', '128.0.0.1', "1234")
@@ -180,7 +180,7 @@ class TestTimeWindows(ApiTestCase):
         r.close()
 
         for i in range(32):
-            r = self.reportFunc('resetbaddie', '128.0.0.1', "1234", 'false')
+            r = self.reportFunc('resetbaddie', '128.0.0.1', "1234", False)
             r.json()
 
         r = self.allowFunc('resetbaddie', '128.0.0.1', "1234")

--- a/regression-tests/test_helper.py
+++ b/regression-tests/test_helper.py
@@ -29,6 +29,8 @@ class ApiTestCase(unittest.TestCase):
         self.server2_url = 'http://%s:%s/' % (self.server_address, self.server2_port)
         self.server3_port = 8086
         self.server3_url = 'http://%s:%s/' % (self.server_address, self.server3_port)
+        self.server4_port = 8087
+        self.server4_url = 'http://%s:%s/' % (self.server_address, self.server4_port)
         self.ta_server_port = 8090
         self.ta_server_url = 'http://%s:%s/' % (self.server_address, self.ta_server_port)
 
@@ -77,10 +79,16 @@ class ApiTestCase(unittest.TestCase):
     def allowFuncAttrsReplica(self, login, remote, pwhash, attrs):
         return self.allowFuncAttrsInternal(login, remote, pwhash, attrs, "", "", True)
 
+    def allowFuncReplica2(self, login, remote, pwhash):
+        return self.allowFuncAttrsInternal(login, remote, pwhash, {}, "", "", True, True)
+    
+    def allowFuncAttrsReplica2(self, login, remote, pwhash, attrs):
+        return self.allowFuncAttrsInternal(login, remote, pwhash, attrs, "", "", True, True)
+    
     def allowFuncDeviceProtocol(self, login, remote, pwhash, device_id, protocol):
         return self.allowFuncAttrsInternal(login, remote, pwhash, {}, device_id, protocol, False)
     
-    def allowFuncAttrsInternal(self, login, remote, pwhash, attrs, device_id, protocol, replica):
+    def allowFuncAttrsInternal(self, login, remote, pwhash, attrs, device_id, protocol, replica, replica2=False):
         payload = dict()
         payload['login'] = login
         payload['remote'] = remote
@@ -94,12 +102,18 @@ class ApiTestCase(unittest.TestCase):
                 self.url("/?command=allow"),
                 data=json.dumps(payload),
                 headers={'Content-Type': 'application/json'})
-        else:
+        elif replica and not replica2:
             return self.session.post(
                 self.url2("/?command=allow"),
                 data=json.dumps(payload),
                 headers={'Content-Type': 'application/json'})
+        else:
+            return self.session.post(
+                self.url4("/?command=allow"),
+                data=json.dumps(payload),
+                headers={'Content-Type': 'application/json'})
 
+        
     def reportFunc(self, login, remote, pwhash, success):
         return self.reportFuncAttrsInternal(login, remote, pwhash, success, {}, "", "", False)
 
@@ -183,8 +197,11 @@ class ApiTestCase(unittest.TestCase):
 
     def countLoginsReplica(self, login):
         return self.countLoginsInternal(login, True)
-    
-    def countLoginsInternal(self, login, replica):
+
+    def countLoginsReplica2(self, login):
+        return self.countLoginsInternal(login, True, True)
+
+    def countLoginsInternal(self, login, replica, replica2=False):
         attrs = dict()
         attrs['login'] = login
         payload = dict()
@@ -194,9 +211,14 @@ class ApiTestCase(unittest.TestCase):
                 self.url("/?command=countLogins"),
                 data=json.dumps(payload),
                 headers={'Content-Type': 'application/json'})
-        else:
+        elif replica and not replica2:
             return self.session.post(
                 self.url2("/?command=countLogins"),
+                data=json.dumps(payload),
+                headers={'Content-Type': 'application/json'})
+        else:
+            return self.session.post(
+                self.url4("/?command=countLogins"),
                 data=json.dumps(payload),
                 headers={'Content-Type': 'application/json'})
 
@@ -366,6 +388,9 @@ class ApiTestCase(unittest.TestCase):
     def url3(self, relative_url):
         return urlparse.urljoin(self.server3_url, relative_url)
 
+    def url4(self, relative_url):
+        return urlparse.urljoin(self.server4_url, relative_url)
+    
     def ta_url(self, relative_url):
         return urlparse.urljoin(self.ta_server_url, relative_url)
 

--- a/regression-tests/test_helper.py
+++ b/regression-tests/test_helper.py
@@ -51,6 +51,9 @@ class ApiTestCase(unittest.TestCase):
     def writeCmdToConsole(self, cmd):
         return check_output(["../wforce/wforce", "-c", "./wforce1.conf", "-R", "../wforce/regexes.yaml", "-e", cmd])
 
+    def writeCmdToConsole3(self, cmd):
+        return check_output(["../wforce/wforce", "-c", "./wforce3.conf", "-R", "../wforce/regexes.yaml", "-e", cmd])
+    
     def writeFileToConsoleReplica(self, file):
         fp = open(file)
         cmds_nl = fp.read()

--- a/regression-tests/wforce1.conf
+++ b/regression-tests/wforce1.conf
@@ -1,9 +1,10 @@
 webserver("0.0.0.0:8084", "super")
 setKey("Ay9KXgU3g4ygK+qWT0Ut4gH8PPz02gbtPeXWPdjD0HE=")
-controlSocket("0.0.0.0:4004")
+controlSocket("0.0.0.0:4104")
 
 addSibling("127.0.0.1:4001");
 addSibling("127.0.0.1:4002");
+addSibling("127.0.0.1:4004:tcp");
 siblingListener("0.0.0.0:4001")
 
 dofile("./wforce-tw.conf")

--- a/regression-tests/wforce2.conf
+++ b/regression-tests/wforce2.conf
@@ -1,6 +1,6 @@
 webserver("0.0.0.0:8085", "super")
 setKey("Ay9KXgU3g4ygK+qWT0Ut4gH8PPz02gbtPeXWPdjD0HE=")
-controlSocket("0.0.0.0:4005")
+controlSocket("0.0.0.0:4105")
 
 addSibling("127.0.0.1:4001");
 addSibling("127.0.0.1:4002");

--- a/regression-tests/wforce3.conf
+++ b/regression-tests/wforce3.conf
@@ -4,4 +4,7 @@ controlSocket("0.0.0.0:4006")
 
 blacklistPersistDB("127.0.0.1", 6379)
 
+addSibling("127.0.0.1:4001");
+siblingListener("0.0.0.0:4003")
+
 dofile("./wforce-tw.conf")

--- a/regression-tests/wforce3.conf
+++ b/regression-tests/wforce3.conf
@@ -1,10 +1,11 @@
 webserver("0.0.0.0:8086", "super")
 setKey("Ay9KXgU3g4ygK+qWT0Ut4gH8PPz02gbtPeXWPdjD0HE=")
-controlSocket("0.0.0.0:4006")
+controlSocket("0.0.0.0:4106")
 
 blacklistPersistDB("127.0.0.1", 6379)
 
-addSibling("127.0.0.1:4001");
+setSiblings({"127.0.0.1:4001"})
+addSibling("127.0.0.1:4004:tcp");
 siblingListener("0.0.0.0:4003")
 
 addSyncHost("127.0.0.1:8084", "super", "127.0.0.1:4003", "127.0.0.1:8086")

--- a/regression-tests/wforce3.conf
+++ b/regression-tests/wforce3.conf
@@ -7,4 +7,7 @@ blacklistPersistDB("127.0.0.1", 6379)
 addSibling("127.0.0.1:4001");
 siblingListener("0.0.0.0:4003")
 
+addSyncHost("127.0.0.1:8084", "super", "127.0.0.1:4003", "127.0.0.1:8086")
+setMinSyncHostUptime(10)
+
 dofile("./wforce-tw.conf")

--- a/regression-tests/wforce4.conf
+++ b/regression-tests/wforce4.conf
@@ -1,0 +1,11 @@
+webserver("0.0.0.0:8087", "super")
+setKey("Ay9KXgU3g4ygK+qWT0Ut4gH8PPz02gbtPeXWPdjD0HE=")
+controlSocket("0.0.0.0:4107")
+
+blacklistPersistDB("127.0.0.1", 6379)
+
+setSiblings({"127.0.0.1:4001", "127.0.0.1:4002"});
+addSibling("127.0.0.1:4004:tcp");
+siblingListener("0.0.0.0:4004")
+
+dofile("./wforce-tw.conf")

--- a/wforce/replication.proto
+++ b/wforce/replication.proto
@@ -15,13 +15,24 @@ message SDBOperation {
     SDBOpSub = 1;
     SDBOpReset = 2;
     SDBOpResetField = 3;
+    SDBOpSyncKey = 4;
     SDBOpNone = 999;
+  }
+  message SDBTimeWindow {
+    required uint64 timestamp = 1;
+    required bytes tw_string = 2;
+  }
+  message SDBSyncField {
+    required string field_name = 1;
+    required uint64 start_time = 2; 
+    repeated SDBTimeWindow time_windows = 3;
   }
   required SDBOpType op_type = 2;
   required string key = 3;
   optional string field_name = 4;
   optional string str_param = 5;
   optional uint32 int_param = 6;
+  repeated SDBSyncField sync_fields = 7;
 }
 
 message BLOperation {

--- a/wforce/replication_sdb.hh
+++ b/wforce/replication_sdb.hh
@@ -29,6 +29,9 @@ class SDBReplicationOperation : public AnyReplicationOperation
 {
 public:
   SDBReplicationOperation();
+  SDBReplicationOperation(SDBOperation&& so) {
+    sdb_msg = so;
+  }
   SDBReplicationOperation(const std::string& db_name, SDBOperation_SDBOpType op, const std::string& key);
   SDBReplicationOperation(const std::string& db_name, SDBOperation_SDBOpType op, const std::string& key,
 			  const std::string& field_name, const std::string& s);
@@ -40,6 +43,10 @@ public:
                           SDBOperation_SDBOpType op,
                           const std::string& key,
 			  const std::string& field_name);
+  SDBReplicationOperation(const std::string& my_db_name,
+                          SDBOperation_SDBOpType my_op,
+                          const std::string& my_key,
+                          const TWStatsDBDumpEntry& my_entry);
   std::string serialize();
   AnyReplicationOperationP unserialize(const std::string& str, bool& retval);
   void applyOperation();

--- a/wforce/twmap-wrapper.cc
+++ b/wforce/twmap-wrapper.cc
@@ -331,3 +331,30 @@ int TWStringStatsDBWrapper::numWindows()
 {
   return sdbp->numWindows();
 }
+
+const std::list<std::string>::iterator TWStringStatsDBWrapper::startDBDump()
+{
+  return sdbp->startDBDump();
+}
+
+bool TWStringStatsDBWrapper::DBDumpEntry(std::list<std::string>::iterator& i,
+                                         TWStatsDBDumpEntry& entry,
+                                         std::string& key)
+{
+  return sdbp->DBDumpEntry(i, entry, key);
+}
+
+const std::list<std::string>::iterator TWStringStatsDBWrapper::DBDumpIteratorEnd()
+{
+  return sdbp->DBDumpIteratorEnd();
+}
+
+void TWStringStatsDBWrapper::endDBDump()
+{
+  sdbp->endDBDump();
+}
+
+void TWStringStatsDBWrapper::restoreEntry(const std::string& key, std::map<std::string, std::pair<std::time_t, TWStatsBufSerial>>& entry)
+{
+  sdbp->restoreEntry(key, entry);
+}

--- a/wforce/twmap-wrapper.hh
+++ b/wforce/twmap-wrapper.hh
@@ -65,6 +65,13 @@ public:
   void set_size_soft(unsigned int size);
   int windowSize();
   int numWindows();
+  const std::list<std::string>::iterator startDBDump();
+  bool DBDumpEntry(std::list<std::string>::iterator& i,
+                   TWStatsDBDumpEntry& entry,
+                   std::string& key);
+  const std::list<std::string>::iterator DBDumpIteratorEnd();
+  void endDBDump();
+  void restoreEntry(const std::string& key, std::map<std::string, std::pair<std::time_t, TWStatsBufSerial>>& entry);
 };
 
 extern std::mutex dbMap_mutx;

--- a/wforce/twmap-wrapper.hh
+++ b/wforce/twmap-wrapper.hh
@@ -71,7 +71,7 @@ public:
                    std::string& key);
   const std::list<std::string>::iterator DBDumpIteratorEnd();
   void endDBDump();
-  void restoreEntry(const std::string& key, std::map<std::string, std::pair<std::time_t, TWStatsBufSerial>>& entry);
+  void restoreEntry(const std::string& key, TWStatsDBDumpEntry& entry);
 };
 
 extern std::mutex dbMap_mutx;

--- a/wforce/wforce-lua.cc
+++ b/wforce/wforce-lua.cc
@@ -232,6 +232,8 @@ vector<std::function<void(void)>> setupLua(bool client, bool multi_lua, LuaConte
 	auto launch = [ca]() {
 	  thread t1(receiveReplicationOperations, ca);
 	  t1.detach();
+	  thread t2(receiveReplicationOperationsTCP, ca);
+	  t2.detach();
 	};
 	if(g_launchWork)
 	  g_launchWork->push_back(launch);

--- a/wforce/wforce-lua.cc
+++ b/wforce/wforce-lua.cc
@@ -563,12 +563,12 @@ vector<std::function<void(void)>> setupLua(bool client, bool multi_lua, LuaConte
   }
 
   if (!multi_lua) {
-    c_lua.writeFunction("setVerboseAllowLog()", []() {
+    c_lua.writeFunction("setVerboseAllowLog", []() {
 	g_allowlog_verbose = true;
       });
   }
   else {
-    c_lua.writeFunction("setVerboseAllowLog()", []() { });
+    c_lua.writeFunction("setVerboseAllowLog", []() { });
   }
 
   c_lua.registerMember("attrs", &CustomFuncArgs::attrs);

--- a/wforce/wforce-lua.cc
+++ b/wforce/wforce-lua.cc
@@ -184,9 +184,9 @@ vector<std::function<void(void)>> setupLua(bool client, bool multi_lua, LuaConte
           g_sync_data.webserver_listen_addr = ComboAddress(webserver_address, 8084);
 	}
 	catch (const WforceException& e) {
-          boost::format fmt("%s (%s)\n");
-          errlog("addSyncHost() error parsing address/port. Make sure to use IP addresses not hostnames (%s)", e.reason);
-          g_outputBuffer += (fmt % "addSyncHost(): Error parsing address/port. Make sure to use IP addresses not hostnames" % e.reason).str();
+          const std::string errstr = (boost::format("%s (%s)\n") % "addSyncHost(): Error parsing address/port. Make sure to use IP addresses not hostnames" % e.reason).str();
+          errlog(errstr.c_str());
+          g_outputBuffer += errstr;
 	  return;
 	}
       });
@@ -211,9 +211,9 @@ vector<std::function<void(void)>> setupLua(bool client, bool multi_lua, LuaConte
 	  ca = ComboAddress(address, 4001);
 	}
 	catch (const WforceException& e) {
-          boost::format fmt("%s (%s)\n");
-          errlog("addSibling() error parsing address/port [%s]. Make sure to use IP addresses not hostnames", address);
-          g_outputBuffer += (fmt % "addSibling(): Error parsing address/port. Make sure to use IP addresses not hostnames" % e.reason).str();
+          const std::string errstr = (boost::format("%s [%s]. %s (%s)\n") % "addSibling() error parsing address/port" % address % "Make sure to use IP addresses not hostnames" % e.reason).str();
+          errlog(errstr.c_str());
+          g_outputBuffer += errstr;
 	  return;
 	}
 	g_siblings.modify([ca](vector<shared_ptr<Sibling>>& v) { v.push_back(std::make_shared<Sibling>(ca)); });
@@ -231,9 +231,9 @@ vector<std::function<void(void)>> setupLua(bool client, bool multi_lua, LuaConte
             v.push_back(std::make_shared<Sibling>(ComboAddress(p.second, 4001)));
           }
           catch (const WforceException& e) {
-            boost::format fmt("%s [%s] %s (%s)\n");
-            errlog("setSiblings() error parsing address/port [%s]. Make sure to use IP addresses not hostnames", p.second);
-            g_outputBuffer += (fmt % "setSiblings(): Error parsing address/port" % p.second % "Make sure to use IP addresses not hostnames" % e.reason).str();
+            const std::string errstr = (boost::format("%s [%s]. %s (%s)\n") % "addSibling() error parsing address/port" % p.second % "Make sure to use IP addresses not hostnames" % e.reason).str();
+            errlog(errstr.c_str());
+            g_outputBuffer += errstr;
           }
 	}
 	g_siblings.setState(v);
@@ -250,9 +250,9 @@ vector<std::function<void(void)>> setupLua(bool client, bool multi_lua, LuaConte
 	  ca = ComboAddress(address, 4001);
 	}
 	catch (const WforceException& e) {
-          boost::format fmt("%s (%s)\n");
-          errlog("siblingListener() error parsing address/port [%s]. Make sure to use IP addresses not hostnames", address);
-          g_outputBuffer += (fmt % "siblingListener(): Error parsing address/port. Make sure to use IP addresses not hostnames" % e.reason).str();
+          const std::string errstr = (boost::format("%s [%s]. %s (%s)\n") % "addSibling() error parsing address/port" % address % "Make sure to use IP addresses not hostnames" % e.reason).str();
+          errlog(errstr.c_str());
+          g_outputBuffer += errstr;
 	  return;
 	}
 	auto launch = [ca]() {

--- a/wforce/wforce-web.cc
+++ b/wforce/wforce-web.cc
@@ -879,7 +879,7 @@ void parseCustomCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const st
   incCommandStat(command);
 }
 
-bool g_ping_up = false;
+std::atomic<bool> g_ping_up{false};
 
 void parsePingCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const std::string& command)
 {

--- a/wforce/wforce-web.cc
+++ b/wforce/wforce-web.cc
@@ -51,9 +51,10 @@ using namespace boost::gregorian;
 GlobalStateHolder<vector<shared_ptr<Sibling>>> g_report_sinks;
 GlobalStateHolder<std::map<std::string, std::pair<std::shared_ptr<std::atomic<unsigned int>>, vector<shared_ptr<Sibling>>>>> g_named_report_sinks;
 
+static time_t start=time(0);
+
 static int uptimeOfProcess()
 {
-  static time_t start=time(0);
   return time(0) - start;
 }
 

--- a/wforce/wforce-web.hh
+++ b/wforce/wforce-web.hh
@@ -20,11 +20,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <atomic>
 #include "yahttp/yahttp.hpp"
 
 // If false, then ping commands will return "warmup".
 // If true then ping commands will return "ok"
-extern bool g_ping_up;
+extern std::atomic<bool> g_ping_up;
 
 void parseCustomCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const std::string& command);
 void registerWebserverCommands();

--- a/wforce/wforce-web.hh
+++ b/wforce/wforce-web.hh
@@ -22,5 +22,9 @@
 
 #include "yahttp/yahttp.hpp"
 
+// If false, then ping commands will return "warmup".
+// If true then ping commands will return "ok"
+extern bool g_ping_up;
+
 void parseCustomCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const std::string& command);
 void registerWebserverCommands();

--- a/wforce/wforce.cc
+++ b/wforce/wforce.cc
@@ -475,6 +475,11 @@ void encryptMsg(const std::string& msg, std::string& packet)
 bool decryptMsg(const char* buf, int len, std::string& msg)
 {
   SodiumNonce nonce;
+
+  if (len < crypto_secretbox_NONCEBYTES) {
+    errlog("Could not decrypt replication operation: not enough bytes (%d) to hold nonce", len);
+    return false;
+  }
   memcpy((char*)&nonce, buf, crypto_secretbox_NONCEBYTES);
   string packet(buf + crypto_secretbox_NONCEBYTES, buf+len);
   try {

--- a/wforce/wforce.cc
+++ b/wforce/wforce.cc
@@ -467,7 +467,7 @@ void Sibling::send(const std::string& msg)
 
     uint16_t nsize = htons(msg.length());
     try {
-      sockp->write((char*)&nsize, sizeof(nsize));
+      sockp->writen(std::string((char*)&nsize, sizeof(nsize)));
       sockp->writen(msg);
       ++success;
     }
@@ -608,7 +608,7 @@ void syncDBThread(const ComboAddress& ca, const std::string& callback_url,
             string packet;
             encryptMsg(msg, packet);
             uint16_t nsize = htons(packet.length());
-            rep_sock.write((char*)&nsize, sizeof(nsize));
+            rep_sock.writen(std::string((char*)&nsize, sizeof(nsize)));
             rep_sock.writen(packet);
             num_synced++;
           }

--- a/wforce/wforce.cc
+++ b/wforce/wforce.cc
@@ -564,6 +564,11 @@ void syncDBThread(const ComboAddress& ca, const std::string& callback_url,
           auto eptr = std::current_exception();
           std::rethrow_exception(eptr);
         }
+        catch(const std::exception& e) {
+          sdb.endDBDump();
+          auto eptr = std::current_exception();
+          std::rethrow_exception(eptr);
+        }
       }
       sdb.endDBDump();
     }
@@ -573,8 +578,10 @@ void syncDBThread(const ComboAddress& ca, const std::string& callback_url,
     errlog("Synchronizing DBs to: %s did not complete. [Network Error: %s]", ca.toStringWithPort(), e.what());
   }
   catch(const WforceException& e) {
-    errlog("Synchronizing DBs to: %s did not complete. [Network Error: %s]", ca.toStringWithPort(), e.reason);
-
+    errlog("Synchronizing DBs to: %s did not complete. [Wforce Error: %s]", ca.toStringWithPort(), e.reason);
+  }
+  catch (const std::exception& e) {
+    errlog("Synchronizing DBs to: %s did not complete. [exception Error: %s]", ca.toStringWithPort(), e.what());
   }
   // Once we've finished replicating we need to let the requestor know we're
   // done by calling the callback URL

--- a/wforce/wforce.cc
+++ b/wforce/wforce.cc
@@ -421,7 +421,7 @@ void Sibling::connectSibling()
       sockp->connect(rem);
     }
     catch (const NetworkError& e) {
-      debuglog("TCP Connect to Sibling %s failed (%s)", rem
+      vdebuglog("TCP Connect to Sibling %s failed (%s)", rem
                .toStringWithPort(), e.what());
     }
   }
@@ -473,7 +473,7 @@ void Sibling::send(const std::string& msg)
     }
     catch (const NetworkError& e) {
       ++failures;
-      debuglog("Error writing to Sibling %s, reconnecting (%s)", rem.toStringWithPort(), e.what());
+      vdebuglog("Error writing to Sibling %s, reconnecting (%s)", rem.toStringWithPort(), e.what());
       connectSibling();
     }
   }

--- a/wforce/wforce.cc
+++ b/wforce/wforce.cc
@@ -469,8 +469,10 @@ void Sibling::send(const std::string& msg)
     try {
       sockp->write((char*)&nsize, sizeof(nsize));
       sockp->writen(msg);
+      ++success;
     }
     catch (const NetworkError& e) {
+      ++failures;
       debuglog("Error writing to Sibling %s, reconnecting (%s)", rem.toStringWithPort(), e.what());
       connectSibling();
     }

--- a/wforce/wforce.cc
+++ b/wforce/wforce.cc
@@ -735,7 +735,7 @@ void parseTCPReplication(std::shared_ptr<Socket> sockp, const ComboAddress& remo
         break;
       }
       int size_read = 0;
-      if ((size_read = sockp->read(buffer, size)) != size) {
+      if ((size_read = sockp->readAll(buffer, size)) != size) {
         errlog("parseTCPReplication: Told to read %d bytes, but actually read %d bytes", size, size_read);
         break;
       }

--- a/wforce/wforce.hh
+++ b/wforce/wforce.hh
@@ -66,6 +66,7 @@ extern std::string g_outputBuffer; // locking for this is ok, as locked by g_lua
 extern WforceWebserver g_webserver;
 
 void receiveReports(ComboAddress local);
+void receiveReplicationOperationsTCP(ComboAddress local);
 void receiveReplicationOperations(ComboAddress local);
 struct Sibling
 {

--- a/wforce/wforce.hh
+++ b/wforce/wforce.hh
@@ -112,3 +112,13 @@ extern bool g_allowlog_verbose; // Whether to log allow returns of 0
 
 void syncDBThread(const ComboAddress& ca, const std::string& callback_url,
                   const std::string& calback_pw);
+
+struct syncData {
+  std::vector<std::pair<ComboAddress, std::string>> sync_hosts;
+  unsigned int min_sync_host_uptime;
+  ComboAddress sibling_listen_addr;
+  ComboAddress webserver_listen_addr;
+  std::string  webserver_password;
+};
+
+extern syncData g_sync_data;

--- a/wforce/wforce.hh
+++ b/wforce/wforce.hh
@@ -108,3 +108,6 @@ extern WebHookDB g_custom_webhook_db;
 extern std::shared_ptr<UserAgentParser> g_ua_parser_p;
 
 extern bool g_allowlog_verbose; // Whether to log allow returns of 0
+
+void syncDBThread(const ComboAddress& ca, const std::string& callback_url,
+                  const std::string& calback_pw);


### PR DESCRIPTION
As per #48 and #50:

- Set a "min time sibling must be up" before a newly started server will pull old stats from it
- Set a list of "sync" servers that will be used for pulling stats
- Contact each configured sync server and see if it has been up long enough
- If wforce finds any catchup servers which have been up long enough:
  - Set ping status to "warming up" - this needs a new ping command response (see #48)
  - Contacts a catchup server that has been up long enough, and tell it to send us all stats (including the current time window)
 - Keep going until we have all the old time windows and all the keys (we know this because we set a callback for the catchup server to tell us when its done)
 - Set ping status to "ready"
- If no catchup servers available which exceed the minimum uptime, then set ping status to "ready"

Also adds replication over TCP using an additional ":tcp" specifier for Sibling addresses.

Note that means the following behaviour changes:
- If no sync servers are defined, or wforce doesn't find any that exceed the minimum uptime, or doesn't find any responding with a "status: ok" response to syncDBs command, then the server will start in the "ready" ping state.
- If a sync server is found, and it responds with "status: ok" then wforce will be in the "warmup" ping state until the callback is received. If the callback URL is misconfigured then wforce will never leave the ping "warmup" state.
- Note that all of this only changes the ping-state; all other commands works as normal including allow and report etc. So this *only* affects deployments where the client (or an intermediary) such as HAProxy uses the ping response to determine whether to send requests to a wforce instance. Currently Dovecot does not use this, although it may in future.
- A server designated as a "sync" server probably shouldn't be a production wforce server. Synchronizing DBs not only places a large load on the server, but it also locks the each Stats DB for the duration of the sync. This could cause delays in responding to allow/report requests. 