### PR TITLE
Blacklist improvements

### DIFF
--- a/common/common-lua.cc
+++ b/common/common-lua.cc
@@ -105,7 +105,9 @@ void setupCommonLua(bool client,
   c_lua.writeFunction("debugLog", [](const std::string& msg, const std::vector<pair<std::string, std::string>>& kvs) {
       if (g_verbose) {
 	std::ostringstream os;
-	os << msg << ": ";
+	os << msg;
+        if (kvs.size())
+          os << ": ";
 	for (const auto& i : kvs) {
 	  os << i.first << "="<< "\"" << i.second << "\"" << " ";
 	}
@@ -116,7 +118,9 @@ void setupCommonLua(bool client,
   c_lua.writeFunction("vinfoLog", [](const std::string& msg, const std::vector<pair<std::string, std::string>>& kvs) {
       if (g_verbose) {
 	std::ostringstream os;
-	os << msg << ": ";
+	os << msg;
+        if (kvs.size())
+          os << ": ";
 	for (const auto& i : kvs) {
 	  os << i.first << "="<< "\"" << i.second << "\"" << " ";
 	}
@@ -126,7 +130,9 @@ void setupCommonLua(bool client,
   
   c_lua.writeFunction("infoLog", [](const std::string& msg, const std::vector<pair<std::string, std::string>>& kvs) {
       std::ostringstream os;
-      os << msg << ": ";
+      os << msg;
+      if (kvs.size())
+        os << ": ";
       for (const auto& i : kvs) {
 	os << i.first << "="<< "\"" << i.second << "\"" << " ";
       }
@@ -135,7 +141,9 @@ void setupCommonLua(bool client,
 
   c_lua.writeFunction("warnLog", [](const std::string& msg, const std::vector<pair<std::string, std::string>>& kvs) {
       std::ostringstream os;
-      os << msg << ": ";
+      os << msg;
+      if (kvs.size())
+        os << ": ";
       for (const auto& i : kvs) {
 	os << i.first << "="<< "\"" << i.second << "\"" << " ";
       }
@@ -144,7 +152,9 @@ void setupCommonLua(bool client,
 
   c_lua.writeFunction("errorLog", [](const std::string& msg, const std::vector<pair<std::string, std::string>>& kvs) {
       std::ostringstream os;
-      os << msg << ": ";
+      os << msg;
+      if (kvs.size())
+        os << ": ";
       for (const auto& i : kvs) {
 	os << i.first << "="<< "\"" << i.second << "\"" << " ";
       }	

--- a/common/sodcrypto.hh
+++ b/common/sodcrypto.hh
@@ -33,8 +33,10 @@ struct SodiumNonce
   void init(){};
   void merge(const SodiumNonce& lower, const SodiumNonce& higher){};
   void increment(){};
+  std::string toString() { return string(""); }
   unsigned char value[1];
 };
+#define crypto_secretbox_NONCEBYTES 0
 #else
 #include <sodium.h>
 

--- a/common/wforce-webserver.cc
+++ b/common/wforce-webserver.cc
@@ -262,7 +262,13 @@ void WforceWebserver::connectionThread(WforceWebserver* wws)
       ofs << resp;
       string done;
       done=ofs.str();
-      writen2(wfc->fd, done.c_str(), done.size());
+      try {
+        wfc->s.writenWithTimeout(done.c_str(), done.size(), timeout);
+      }
+      catch (const NetworkError& e) {
+        warnlog("WforceWebserver: Network error writing to sock: %s", e.what());
+        closeConnection = true;
+      }
     }
 
     if (closeConnection) {

--- a/common/wforce-webserver.cc
+++ b/common/wforce-webserver.cc
@@ -118,7 +118,8 @@ bool WforceWebserver::registerFunc(const std::string& command, HTTPVerb verb, Wf
 void WforceWebserver::connectionThread(WforceWebserver* wws)
 {
   using namespace json11;
-
+  const std::string ct_json = "application/json";
+  
   while (true) {
     std::shared_ptr<WFConnection> wfc;
     {
@@ -233,7 +234,7 @@ void WforceWebserver::connectionThread(WforceWebserver* wws)
             f->second(req, resp, command);
           }
         }
-        else if ((command != "") && (ctype.compare("application/json") != 0)) {
+        else if ((command != "") && (ctype.compare(0, ct_json.length(), ct_json) != 0)) {
           errlog("HTTP Request \"%s\" from %s: Content-Type not application/json", req.url.path, wfc->remote.toStringWithPort());
           resp.status = 415;
           std::stringstream ss;

--- a/docs/manpages/wforce.conf.5.md
+++ b/docs/manpages/wforce.conf.5.md
@@ -638,7 +638,7 @@ a Netmask. For example:
   specified netmask for expiry seconds, with the specified reason. Netmask
   address must be a Netmask object, e.g. created with newNetmask(). For example:
   
-		blacklistIP(newNetmask("12.32.0.0/16"), 300, "Attempted password brute forcing")
+		blacklistNetmask(newNetmask("12.32.0.0/16"), 300, "Attempted password brute forcing")
 
 * blacklistIP(\<ip\>, \<expiry\>, \<reason string\>) - Blacklist the
   specified IP for expiry seconds, with the specified reason. IP

--- a/docs/manpages/wforce.conf.5.md
+++ b/docs/manpages/wforce.conf.5.md
@@ -660,6 +660,27 @@ a Netmask. For example:
   
 		blacklistIPLogin(lt.remote, lt.login, 300, "Account and IP are suspicious")
 
+* unblacklistNetmask(\<Netmask\>) Remove the blacklist for the
+  specified netmask. Netmask address must be a Netmask object,
+  e.g. created with newNetmask(). For example:
+  
+		unblacklistNetmask(newNetmask("12.32.0.0/16"))
+
+* unblacklistIP(\<ip\>) - Remove the blacklist for the specified
+  IP. IP address must be a ComboAddress. For example:
+  
+		unblacklistIP(lt.remote)
+
+* unblacklistLogin(\<login\>) - Remove the blacklist for the specified
+  login. For example:
+  
+		unblacklistLogin(lt.login)
+
+* unblacklistIPLogin(\<ip\>) - Remove the blacklist for the specified
+  IP-Login tuple. IP address must be a ComboAddress. For example:
+  
+		unblacklistIPLogin(lt.remote)
+
 * LoginTuple - The only parameter to both the allow and report
   functions is a LoginTuple table. This table contains the following
   fields:

--- a/docs/release_notes/ReleaseNotes-2.0.0.md
+++ b/docs/release_notes/ReleaseNotes-2.0.0.md
@@ -3,6 +3,9 @@
 New Features/Bug Fixes
 ------------
 
+* Fix extra : at the end of custom log lines when kv table is empty
+* Return additional info about blacklist in allow and getDBStats RESTAPI functions
+* New Lua functions to remove blacklist entries 
 * Add configuration setting "setNumWebHookConnsPerThread"
 * Add configuration setting "setWebHookTimeoutSecs"
 * Add support for querying replication status in showStringStatsDB()
@@ -19,6 +22,50 @@ New Features/Bug Fixes
 * Logstash Configuration and Elasticsearch Templates
 * Kibana Reports and Dashboards
 * Report API
+
+Fix Extra : at end of Custom Log Lines
+-----
+
+The Lua infoLog, errorLog etc. functions would previously, when called
+as 'errorLog("foo", {})' log:
+
+foo :
+
+Now the same call will log only:
+
+foo
+
+Return additional info about blacklist in allow and getDBStats REST API functions
+---
+
+The allow command will now return additional information when an
+IP/Login is blacklisted. The 'r_attrs' object will contain four new
+fields:
+
+* expiration - A string showing the date/time when the blacklist will
+expire
+* reason - A string stating why the blacklist was created
+* key - What was blacllisted, i.e. either ip, login or iplogin
+* blacklisted - This will be set to 1
+
+The getDBStats command will return additional information about
+blacklisted objects:
+
+* bl_expire - A string showing the date/time when the blacklist will
+expire
+* lb_reason - A string stating why the blacklist was created
+
+New Lua functions to remove blacklist entries 
+----
+
+The following new Lua functions are available:
+
+* unblacklistNetmask
+* unblacklistIP
+* unblacklistLogin
+* unblacklistIPLogin
+
+See the wforce.conf manpage for more details.
 
 New Configuration Setting setNumWebHookConnsPerThread
 ------

--- a/docs/swagger/wforce_api.7.yml
+++ b/docs/swagger/wforce_api.7.yml
@@ -525,6 +525,10 @@ definitions:
         type: string
       blacklisted:
         type: boolean
+      bl_expire:
+        type: string
+      bl_reason:
+        type: string
       stats:
         $ref: "#/definitions/DBStatsEntry"
   DBStatsEntry:

--- a/regression-tests/test_Basics.py
+++ b/regression-tests/test_Basics.py
@@ -49,6 +49,7 @@ class TestBasics(ApiTestCase):
         r = self.getDBStatsIP('1.4.3.2')
         j = r.json();
         self.assertRegexpMatches(json.dumps(j), "countLogins")
+        self.assertRegexpMatches(json.dumps(j), "bl_reason")
 
     def chunkGen(self):
         payload = dict()

--- a/regression-tests/wforce-tw.conf
+++ b/regression-tests/wforce-tw.conf
@@ -26,6 +26,9 @@ sdb_small:twEnableReplication()
 
 addCustomStat("customStat")
 
+blacklistIP(newCA("127.0.0.1"), 3600, "this will get deleted")
+unblacklistIP(newCA("127.0.0.1"))
+
 ck={}
 ck["url"] = "http://localhost:9080/webhook/regression"
 ck["secret"] = "secret"

--- a/wforce/wforce-lua.cc
+++ b/wforce/wforce-lua.cc
@@ -562,38 +562,65 @@ vector<std::function<void(void)>> setupLua(bool client, bool multi_lua, LuaConte
   c_lua.registerFunction("twEnableReplication", &TWStringStatsDBWrapper::enableReplication);
   c_lua.registerFunction("twGetName", &TWStringStatsDBWrapper::getDBName);
 
-  c_lua.writeFunction("blacklistNetmask", [](const Netmask& nm, unsigned int seconds, const std::string& reason) {
-      g_bl_db.addEntry(nm, seconds, reason);
-    });
+  if (!client) {
+    c_lua.writeFunction("blacklistNetmask", [](const Netmask& nm, unsigned int seconds, const std::string& reason) {
+        g_bl_db.addEntry(nm, seconds, reason);
+      });
   
-  c_lua.writeFunction("blacklistIP", [](const ComboAddress& ca, unsigned int seconds, const std::string& reason) {
-      g_bl_db.addEntry(ca, seconds, reason);
-    });
+    c_lua.writeFunction("blacklistIP", [](const ComboAddress& ca, unsigned int seconds, const std::string& reason) {
+        g_bl_db.addEntry(ca, seconds, reason);
+      });
 
-  c_lua.writeFunction("blacklistLogin", [](const std::string& login, unsigned int seconds, const std::string& reason) {
-      g_bl_db.addEntry(login, seconds, reason);
-    });
+    c_lua.writeFunction("blacklistLogin", [](const std::string& login, unsigned int seconds, const std::string& reason) {
+        g_bl_db.addEntry(login, seconds, reason);
+      });
 
-  c_lua.writeFunction("blacklistIPLogin", [](const ComboAddress& ca, const std::string& login, unsigned int seconds, const std::string& reason) {
-      g_bl_db.addEntry(ca, login, seconds, reason);
-    });
+    c_lua.writeFunction("blacklistIPLogin", [](const ComboAddress& ca, const std::string& login, unsigned int seconds, const std::string& reason) {
+        g_bl_db.addEntry(ca, login, seconds, reason);
+      });
 
-  c_lua.writeFunction("unblacklistNetmask", [](const Netmask& nm) {
-      g_bl_db.deleteEntry(nm);
-    });
+    c_lua.writeFunction("unblacklistNetmask", [](const Netmask& nm) {
+        g_bl_db.deleteEntry(nm);
+      });
   
-  c_lua.writeFunction("unblacklistIP", [](const ComboAddress& ca) {
-      g_bl_db.deleteEntry(ca);
-    });
+    c_lua.writeFunction("unblacklistIP", [](const ComboAddress& ca) {
+        g_bl_db.deleteEntry(ca);
+      });
 
-  c_lua.writeFunction("unblacklistLogin", [](const std::string& login) {
-      g_bl_db.deleteEntry(login);
-    });
+    c_lua.writeFunction("unblacklistLogin", [](const std::string& login) {
+        g_bl_db.deleteEntry(login);
+      });
 
-  c_lua.writeFunction("unblacklistIPLogin", [](const ComboAddress& ca) {
-      g_bl_db.deleteEntry(ca);
-    });
-    
+    c_lua.writeFunction("unblacklistIPLogin", [](const ComboAddress& ca) {
+        g_bl_db.deleteEntry(ca);
+      });
+  }
+  else {
+    c_lua.writeFunction("blacklistNetmask", [](const Netmask& nm, unsigned int seconds, const std::string& reason) {
+      });
+  
+    c_lua.writeFunction("blacklistIP", [](const ComboAddress& ca, unsigned int seconds, const std::string& reason) {
+      });
+
+    c_lua.writeFunction("blacklistLogin", [](const std::string& login, unsigned int seconds, const std::string& reason) {
+      });
+
+    c_lua.writeFunction("blacklistIPLogin", [](const ComboAddress& ca, const std::string& login, unsigned int seconds, const std::string& reason) {
+      });
+
+    c_lua.writeFunction("unblacklistNetmask", [](const Netmask& nm) {
+      });
+  
+    c_lua.writeFunction("unblacklistIP", [](const ComboAddress& ca) {
+      });
+
+    c_lua.writeFunction("unblacklistLogin", [](const std::string& login) {
+      });
+
+    c_lua.writeFunction("unblacklistIPLogin", [](const ComboAddress& ca) {
+      });
+  }
+  
   if (!multi_lua) {
     c_lua.writeFunction("blacklistPersistDB", [](const std::string& ip, unsigned int port) {
 	g_bl_db.makePersistent(ip, port);

--- a/wforce/wforce-lua.cc
+++ b/wforce/wforce-lua.cc
@@ -578,6 +578,22 @@ vector<std::function<void(void)>> setupLua(bool client, bool multi_lua, LuaConte
       g_bl_db.addEntry(ca, login, seconds, reason);
     });
 
+  c_lua.writeFunction("unblacklistNetmask", [](const Netmask& nm) {
+      g_bl_db.deleteEntry(nm);
+    });
+  
+  c_lua.writeFunction("unblacklistIP", [](const ComboAddress& ca) {
+      g_bl_db.deleteEntry(ca);
+    });
+
+  c_lua.writeFunction("unblacklistLogin", [](const std::string& login) {
+      g_bl_db.deleteEntry(login);
+    });
+
+  c_lua.writeFunction("unblacklistIPLogin", [](const ComboAddress& ca) {
+      g_bl_db.deleteEntry(ca);
+    });
+    
   if (!multi_lua) {
     c_lua.writeFunction("blacklistPersistDB", [](const std::string& ip, unsigned int port) {
 	g_bl_db.makePersistent(ip, port);


### PR DESCRIPTION
Some bug fixes reported by users:
- Allow modifiers after content-type header
- Don't log redundant colon in custom logs
- Use non-block aware writes for non-blocking sockets
- Compilation errors when libsodium not available
Some new features:
- unblacklist functions in Lua
- Add more information about blacklisting in allow/getDBStats command return values

Plus release notes for the above