### PR TITLE
Don't connect to sibling TCP sockets on startup

### DIFF
--- a/gendata/send_reports.py
+++ b/gendata/send_reports.py
@@ -13,7 +13,7 @@ import time
 WEBPORT = '8084'
 APIKEY = 'super'
 
-cmd1 = ("../wforce/wforce -C ./wforce_elastic.conf -R ../regexes.yaml").split()
+cmd1 = ("../wforce/wforce -C ./wforce_elastic.conf -R ../wforce/regexes.yaml").split()
 wrksuccesscmd = ("wrk -c 2 -d 60 -t 2 -s ./gen_success_reports.lua -R 30 http://127.0.0.1:8084").split()
 wrkfailcmd = ("wrk -c 2 -d 60 -t 2 -s ./gen_fail_reports.lua -R 20 http://127.0.0.1:8084").split()
 

--- a/wforce/wforce.hh
+++ b/wforce/wforce.hh
@@ -84,7 +84,7 @@ struct Sibling
   std::atomic<unsigned int> rcvd_success{0};
   void send(const std::string& msg);
   void checkIgnoreSelf(const ComboAddress& ca);
-  void connectSibling();
+  void connectSibling(bool connect_tcp);
   static Protocol stringToProtocol(const std::string& s) {
     if (s.compare("tcp") == 0)
       return Sibling::Protocol::TCP;


### PR DESCRIPTION
- wait until they are first used

This prevents startup delays if siblings are not available (which could easily happen when cluster starts up and all the wforce instances wait for each other to be available).

One caveat - if there is static configuration creating blacklist or whitelist entries, those will cause immediate replication activity, and thus still cause a startup delay.