### PR TITLE
Doc and regression test improvements, and protobuf UTF-8 fix.

### DIFF
--- a/docs/manpages/wforce.conf.5.md
+++ b/docs/manpages/wforce.conf.5.md
@@ -262,6 +262,11 @@ cannot be called inside the allow/report/reset functions:
   
 		statsdb:twEnableReplication()
 
+* disableBuiltinBlacklists() - Disable the built-in blacklisting checks,
+  enabling them to be checked from Lua instead. For example:
+
+        disableBuiltinBlacklists()
+
 * blacklistPersistDB(\<ip\>, \<port\>) - Make the blacklist persistent
   by storing entries in the specified redis DB. The IP address is a
   string, and port should be 6379 unless you are running redis
@@ -287,6 +292,11 @@ cannot be called inside the allow/report/reset functions:
   error will be logged. For example:
 
 		blacklistPersistConnectTimeout(2)
+
+* disableBuiltinWhitelists() - Disable the built-in whitelisting checks,
+  enabling them to be checked from Lua instead. For example:
+
+        disableBuiltinWhitelists()
 
 * whitelistPersistDB(\<ip\>, \<port\>) - Make the whitelist persistent
   by storing entries in the specified redis DB. The IP address is a

--- a/regression-tests/test_TimeWindows.py
+++ b/regression-tests/test_TimeWindows.py
@@ -24,7 +24,7 @@ class TestTimeWindows(ApiTestCase):
         self.assertEquals(j['status'], -1)
 
         # Wait for the time windows to clear and then check again
-        time.sleep(16)
+        time.sleep(20)
         r = self.allowFunc('ivbaddie', '127.0.0.1', "1234")
         j = r.json()
         self.assertEquals(j['status'], 0)
@@ -44,7 +44,7 @@ class TestTimeWindows(ApiTestCase):
         self.assertEquals(j['status'], -1)
 
         # Wait for the time windows to clear and then check again
-        time.sleep(16)
+        time.sleep(20)
         r = self.allowFunc('flbaddie', '128.0.0.1', "1234")
         j = r.json()
         self.assertEquals(j['status'], 0)
@@ -64,7 +64,7 @@ class TestTimeWindows(ApiTestCase):
         self.assertEquals(j['status'], -1)
 
         # Wait for the time windows to clear and then check again
-        time.sleep(16)
+        time.sleep(20)
         r = self.allowFunc('ipbaddie', '127.0.0.1', "1234")
         j = r.json()
         self.assertEquals(j['status'], 0)
@@ -84,7 +84,7 @@ class TestTimeWindows(ApiTestCase):
         self.assertEquals(j['status'], -1)
 
         # Wait for the time windows to clear and then check again
-        time.sleep(16)
+        time.sleep(20)
         r = self.allowFunc('subbaddie', '127.0.0.1', "1234")
         j = r.json()
         self.assertEquals(j['status'], 0)
@@ -104,7 +104,7 @@ class TestTimeWindows(ApiTestCase):
         self.assertEquals(j['status'], -1)
 
         # Wait for the time windows to clear and then check again
-        time.sleep(16)
+        time.sleep(20)
         r = self.allowFunc('ipv4baddie', '114.31.192.200', "1234")
         j = r.json()
         self.assertEquals(j['status'], 0)
@@ -124,7 +124,7 @@ class TestTimeWindows(ApiTestCase):
         self.assertEquals(j['status'], 0)
 
         # Wait for the time windows to clear and then check again
-        time.sleep(16)
+        time.sleep(20)
         r = self.allowFunc('mappedipv4baddie', '::ffff:114.31.192.200', "1234")
         j = r.json()
         self.assertEquals(j['status'], 0)
@@ -144,7 +144,7 @@ class TestTimeWindows(ApiTestCase):
         self.assertEquals(j['status'], -1)
 
         # Wait for the time windows to clear and then check again
-        time.sleep(16)
+        time.sleep(20)
         r = self.allowFunc('ipv6baddie', '2001:c78::1000', "1234")
         j = r.json()
         self.assertEquals(j['status'], 0)
@@ -167,7 +167,7 @@ class TestTimeWindows(ApiTestCase):
         self.assertEquals(j['status'], -1)
 
         # Wait for the expiry thread to delete everything bigger than size (10) and then check again
-        time.sleep(30)
+        time.sleep(35)
         r = self.allowFunc('expirebaddie', '127.0.01', "1234")
         j = r.json()
         self.assertEquals(j['status'], 0)
@@ -207,5 +207,3 @@ class TestTimeWindows(ApiTestCase):
         r = self.countLogins("resetFieldTest")
         j = r.json()
         self.assertEquals(j['r_attrs']['countLogins'], '0')
-
-        

--- a/wforce/replication.proto
+++ b/wforce/replication.proto
@@ -23,14 +23,14 @@ message SDBOperation {
     required bytes tw_string = 2;
   }
   message SDBSyncField {
-    required string field_name = 1;
+    required bytes field_name = 1;
     required uint64 start_time = 2; 
     repeated SDBTimeWindow time_windows = 3;
   }
   required SDBOpType op_type = 2;
-  required string key = 3;
-  optional string field_name = 4;
-  optional string str_param = 5;
+  required bytes key = 3;
+  optional bytes field_name = 4;
+  optional bytes str_param = 5;
   optional uint32 int_param = 6;
   repeated SDBSyncField sync_fields = 7;
 }
@@ -43,9 +43,9 @@ message BLOperation {
   }
   required BLOpType op_type = 1;
   required uint32 type = 2;
-  required string key = 3;
+  required bytes key = 3;
   optional uint32 ttl = 4;
-  optional string reason = 5;
+  optional bytes reason = 5;
 }
 
 message WforceReplicationMsg {


### PR DESCRIPTION
- Add docs for disabling white and blacklists
- Make regression tests more reliable
- Fix issue with protobuf complaining about non-UTF-8 strings by moving to bytes for everything