### PR TITLE
Fix typo in function name

### DIFF
--- a/wforce/wforce.conf.example
+++ b/wforce/wforce.conf.example
@@ -192,7 +192,7 @@ function allow(lt)
    if (sdb:twGet(lt.login, "diffPasswords") > 90)
    then
       -- blacklist the login for 300 seconds
-      blackistLogin(lt.login, 300, "too many different incorrect password attempts")
+      blacklistLogin(lt.login, 300, "too many different incorrect password attempts")
       return -1, "too many different password attempts for this account", "diffPasswords", { diffPasswords=90 }
    end
    


### PR DESCRIPTION
While running some basic tests (I am a newbie) I found an error message when I was expecting `wforce` to simply reject a sign in. The problem seems to be a typo in the name of a function in the example configuration (`wforce.conf.example`). See the request and the error:

```
root@0e396863053b:/wforce/wforce-2.0.0.70.g40d0506.dirty/wforce# curl -X POST -H "Content-Type: application/json" --data '{"login":"bob", "remote": "172.19.90.20", "pwhash":"abc123"}' http://127.0.0.1:8084/?command=allow -u wforce:super
{"status":"failure", "reason":"[string "chunk"]:195: attempt to call global 'blackistLogin' (a nil value)"}
```

I think that the name of the function should be `blacklistLogin` as opposed to `blackistLogin`.