### PR TITLE
Blacklist Improvements

### DIFF
--- a/docs/manpages/wforce.conf.5.md
+++ b/docs/manpages/wforce.conf.5.md
@@ -685,6 +685,21 @@ a Netmask. For example:
   
 		debugLog("This will only log if wforce is started with -v", { logging=1, foo=bar })
 
+* getBlacklistIPRetMsg() - Get the message to be returned to
+  clients whose IP address is blacklisted. For example:
+
+        local retmsg = getBlackistIPRetMsg()
+
+* getBlacklistLoginRetMsg() - Get the message to be returned to
+  clients whose login is blacklisted. For example:
+
+        local retmsg = getBlackistLoginRetMsg()
+
+* getBlacklistIPLoginRetMsg() - Get the message to be returned to
+  clients whose IP address/login is blacklisted. For example:
+
+        local retmsg = getBlackistIPLoginRetMsg()
+
 * blacklistNetmask(\<Netmask\>, \<expiry\>, \<reason string\>) - Blacklist the
   specified netmask for expiry seconds, with the specified reason. Netmask
   address must be a Netmask object, e.g. created with newNetmask(). For example:

--- a/regression-tests/wforce-tw.conf
+++ b/regression-tests/wforce-tw.conf
@@ -76,6 +76,11 @@ function twallow(lt)
 	sdb_prefix = getStringStatsDB("15SecondsSecondDB")
 	sdb_small = getStringStatsDB("15SecondsSmallDB")
 
+        -- check the getBLRetMsg functions work
+        getBlacklistIPRetMsg()
+        getBlacklistLoginRetMsg()
+        getBlacklistIPLoginRetMsg()
+
         for k, v in pairs(lt.attrs) do
              if ((k == "accountStatus") and (v == "blocked"))
              then

--- a/wforce/wforce-lua.cc
+++ b/wforce/wforce-lua.cc
@@ -646,6 +646,15 @@ vector<std::function<void(void)>> setupLua(bool client, bool multi_lua, LuaConte
         auto bl = g_bl_db.getIPLoginEntries();
         return getWLBLKeys(bl, "iplogin");
       });
+    c_lua.writeFunction("getBlacklistIPRetMsg", []() {
+        return g_bl_db.getIPRetMsg();
+      });
+    c_lua.writeFunction("getBlacklistLoginRetMsg", []() {
+        return g_bl_db.getLoginRetMsg();
+      });
+    c_lua.writeFunction("getBlacklistIPLoginRetMsg", []() {
+        return g_bl_db.getIPLoginRetMsg();
+      });
   }
   else {
     c_lua.writeFunction("blacklistNetmask", [](const Netmask& nm, unsigned int seconds, const std::string& reason) {
@@ -681,6 +690,9 @@ vector<std::function<void(void)>> setupLua(bool client, bool multi_lua, LuaConte
     c_lua.writeFunction("getIPBlacklist", []() {});
     c_lua.writeFunction("getLoginBlacklist", []() {});
     c_lua.writeFunction("getIPLoginBlacklist", []() {});
+    c_lua.writeFunction("getBlacklistIPRetMsg", []() {});
+    c_lua.writeFunction("getBlacklistLoginRetMsg", []() {});
+    c_lua.writeFunction("getBlacklistIPLoginRetMsg", []() {});
   }
   
   if (!multi_lua) {


### PR DESCRIPTION
Getting the blacklist return message from Lua is essential in order to implement Lua-based blacklist checks in policy.