### PR TITLE
Fix bad fd bug and python security vulns

### DIFF
--- a/regression-tests/requirements.txt
+++ b/regression-tests/requirements.txt
@@ -10,6 +10,6 @@ itsdangerous==0.24
 Jinja2==2.10.1
 MarkupSafe==1.0
 pytz==2017.2
-urllib3==1.23
+urllib3==1.24.2
 Werkzeug==0.12.2
 bottle==0.12.16

--- a/report_api/requirements.txt
+++ b/report_api/requirements.txt
@@ -8,7 +8,7 @@ itsdangerous==0.24
 Jinja2==2.10.1
 MarkupSafe==1.0
 pytz==2017.2
-urllib3==1.23
+urllib3==1.24.2
 Werkzeug==0.12.2
 requests==2.20
 gunicorn==19.9.0

--- a/wforce/wforce.cc
+++ b/wforce/wforce.cc
@@ -241,15 +241,12 @@ try
     putMsgLen(fd, response.length());
     writen2(fd, response.c_str(), (uint16_t)response.length());
   }
+  // The Socket class wrapper will close the socket for us
   infolog("Closed control connection from %s", client.toStringWithPort());
-  close(fd);
-  fd=-1;
 }
 catch(std::exception& e)
 {
   errlog("Got an exception in client connection from %s: %s", client.toStringWithPort(), e.what());
-  if(fd >= 0)
-    close(fd);
 }
 
 


### PR DESCRIPTION
- The control connection now has a Socket class wrapper to implement keep alive, which means that manual closes are redundant and will cause bad fd errors when the Socket class destructor is called.
- Update urllib3 requirements owing to security vulnerabilities flagged by GitHub