### PR TITLE
Code Cleanup/Refactor

### DIFF
--- a/wforce/replication.hh
+++ b/wforce/replication.hh
@@ -31,7 +31,7 @@ typedef std::shared_ptr<AnyReplicationOperation> AnyReplicationOperationP;
 class AnyReplicationOperation
 {
 public:
-  virtual ~AnyReplicationOperation() {}
+  virtual ~AnyReplicationOperation() = default;
   virtual std::string serialize()=0;
   virtual AnyReplicationOperationP unserialize(const std::string& data, bool& retval)=0;
   virtual void applyOperation()=0;

--- a/wforce/replication_bl.hh
+++ b/wforce/replication_bl.hh
@@ -30,7 +30,6 @@ class BLReplicationOperation : public AnyReplicationOperation
 public:
   BLReplicationOperation();
   BLReplicationOperation(BLOperation_BLOpType op_type, BLWLType bl_type, const std::string& key, time_t ttl, const std::string& reason);
-  ~BLReplicationOperation() {}
   std::string serialize();
   AnyReplicationOperationP unserialize(const std::string& str, bool& retval);
   void applyOperation();

--- a/wforce/replication_sdb.hh
+++ b/wforce/replication_sdb.hh
@@ -32,7 +32,6 @@ public:
   SDBReplicationOperation(SDBOperation&& so) {
     sdb_msg = so;
   }
-  ~SDBReplicationOperation() {}
   SDBReplicationOperation(const std::string& db_name, SDBOperation_SDBOpType op, const std::string& key);
   SDBReplicationOperation(const std::string& db_name, SDBOperation_SDBOpType op, const std::string& key,
 			  const std::string& field_name, const std::string& s);

--- a/wforce/twmap-wrapper.cc
+++ b/wforce/twmap-wrapper.cc
@@ -29,8 +29,6 @@ TWStringStatsDBWrapper::TWStringStatsDBWrapper(const std::string& name, int wind
 {
   sdbp = std::make_shared<TWStatsDB<std::string>>(name, window_size, num_windows);
   replicated = std::make_shared<bool>(false);
-  thread t(TWStatsDB<std::string>::twExpireThread, sdbp);
-  t.detach();
 }
 
 TWStringStatsDBWrapper::TWStringStatsDBWrapper(const std::string& name, int window_size, int num_windows, const std::vector<pair<std::string, std::string>>& fmvec)
@@ -38,8 +36,6 @@ TWStringStatsDBWrapper::TWStringStatsDBWrapper(const std::string& name, int wind
   sdbp = std::make_shared<TWStatsDB<std::string>>(name, window_size, num_windows);    
   replicated = std::make_shared<bool>(false);
   (void)setFields(fmvec);
-  thread t(TWStatsDB<std::string>::twExpireThread, sdbp);
-  t.detach();
 }
 
 void TWStringStatsDBWrapper::enableReplication()
@@ -357,4 +353,10 @@ void TWStringStatsDBWrapper::endDBDump()
 void TWStringStatsDBWrapper::restoreEntry(const std::string& key, std::map<std::string, std::pair<std::time_t, TWStatsBufSerial>>& entry)
 {
   sdbp->restoreEntry(key, entry);
+}
+
+void TWStringStatsDBWrapper::startExpireThread()
+{
+  thread t(TWStatsDB<std::string>::twExpireThread, sdbp);
+  t.detach();
 }

--- a/wforce/twmap-wrapper.hh
+++ b/wforce/twmap-wrapper.hh
@@ -72,6 +72,7 @@ public:
   const std::list<std::string>::iterator DBDumpIteratorEnd();
   void endDBDump();
   void restoreEntry(const std::string& key, TWStatsDBDumpEntry& entry);
+  void startExpireThread();
 };
 
 extern std::mutex dbMap_mutx;

--- a/wforce/wforce.cc
+++ b/wforce/wforce.cc
@@ -1293,6 +1293,12 @@ try
 
   // Start the replication worker threads
   startReplicationWorkerThreads();
+
+  // Start the StatsDB expire threads (this must be done after any daemonizing)
+  std::lock_guard<std::mutex> lock(dbMap_mutx);
+  for (auto& i : dbMap) {
+    i.second.startExpireThread();
+  }
   
   // start the threads created by lua setup. Includes the webserver accept thread
   for(auto& t : todo)

--- a/wforce/wforce.cc
+++ b/wforce/wforce.cc
@@ -1295,9 +1295,11 @@ try
   startReplicationWorkerThreads();
 
   // Start the StatsDB expire threads (this must be done after any daemonizing)
-  std::lock_guard<std::mutex> lock(dbMap_mutx);
-  for (auto& i : dbMap) {
-    i.second.startExpireThread();
+  {
+    std::lock_guard<std::mutex> lock(dbMap_mutx);
+    for (auto& i : dbMap) {
+      i.second.startExpireThread();
+    }
   }
   
   // start the threads created by lua setup. Includes the webserver accept thread


### PR DESCRIPTION
Reviewing the code for a possible memory leak at Comcast found a few issues including:
- StatsDB expiry was broken when running with -d (demonised) - thread initialisation needed to be moved after the fork() rather than in the constructor
- The way the replication thread pool was initialised was not actually thread-safe, so this has been moved to the main initialisation section, which is also cleaner and removes the need for it to be thread-safe.

There's also a cleanup of the replication destructors which isn't functional but rather to make it cleaner:
- Use default rather than {} in the virtual destructor
- Remove the child class destructors (not all of them had destructors anyway) as they were just {}

Finally fix a deadlock bug introduced by not scoping the dbMap mutex correctly.