### PR TITLE
Add BUILDER_EPOCH to build dockerfiles

### DIFF
--- a/builder-support/dockerfiles/Dockerfile.debbuild
+++ b/builder-support/dockerfiles/Dockerfile.debbuild
@@ -36,6 +36,7 @@ WORKDIR /wforce
 
 ARG BUILDER_VERSION
 ARG BUILDER_RELEASE
+ARG BUILDER_EPOCH
 
 COPY --from=sdist /sdist/ /sdist/
 

--- a/builder-support/dockerfiles/Dockerfile.rpmbuild
+++ b/builder-support/dockerfiles/Dockerfile.rpmbuild
@@ -12,6 +12,7 @@ ARG BUILDER_PACKAGE_MATCH
 
 ARG BUILDER_VERSION
 ARG BUILDER_RELEASE
+ARG BUILDER_EPOCH
 
 @IF [ ! -z "$M_all$M_wforce" ]
 COPY --from=sdist /sdist /sdist


### PR DESCRIPTION
Epoch command line argument is not passed to builder properly.