### PR TITLE
Asynchronous Replication for siblings sending replication messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,9 @@ instead
 protobuf errors for non-UTF-8 StatsDB keys or values.
 - Remove ctpl from wforce
 - Sibling threads now use explicit std::queue instead of ctpl
-- Only connect to TCP siblings when necessary (not on startup) to
-prevent delays on startup.
+- Perform replication to siblings asynchronously instead of synchronously,
+  preventing delays at startup and in REST API functions which triggered
+  replication.
 
 ## [2.0.0]
 

--- a/wforce/wforce.cc
+++ b/wforce/wforce.cc
@@ -547,7 +547,7 @@ void sendReportSink(const LoginTuple& lt)
   // round-robin between report sinks
   unsigned int i = g_report_sink_rr++ % vsize;
 
-  (*rsinks)[i]->send(msg);
+  (*rsinks)[i]->queueMsg(msg);
 }
 
 void sendNamedReportSink(const std::string& msg)
@@ -564,7 +564,7 @@ void sendNamedReportSink(const std::string& msg)
     unsigned int j = (*i.second.first)++ % vsize;
     auto& vec = i.second.second;
 
-    vec[j]->send(msg);
+    vec[j]->queueMsg(msg);
   }
 }
 

--- a/wforce/wforce.cc
+++ b/wforce/wforce.cc
@@ -427,7 +427,8 @@ void doConsole()
 
 Sibling::Sibling(const ComboAddress& ca) : rem(ca), proto(Protocol::UDP), d_ignoreself(false)
 {
-  connectSibling(false);
+  if (!g_cmdLine.beClient)
+    connectSibling(false);
 }
 
 void Sibling::connectSibling(bool connect_tcp=true)


### PR DESCRIPTION
Previously the only mechanism to send messages was the send() method,
which sent messages synchronously, blocking the calling thread. This
meant that any delays or failures would cause the report function to
hang for a long time. This commit adds a new queueMsg() method, which
adds the replication message to a queue, which is read by a thread
initialized in the constructor, which performs the actual send.
The asynchronous queueMsg() method is now used exclusively instead of send.
The send() method is still thread-safe, in case any new code decides to
use the synchronous method.