### PR TITLE
Forwarding Support

### DIFF
--- a/common/wforce_ns.hh
+++ b/common/wforce_ns.hh
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#include <memory>
+
 namespace wforce {
   template<typename T, typename... Ts>
   std::unique_ptr<T> make_unique(Ts&&... params)

--- a/wforce/blackwhitelist.cc
+++ b/wforce/blackwhitelist.cc
@@ -25,14 +25,16 @@
 #include "replication_bl.hh"
 #include "replication_wl.hh"
 #include "replication.pb.h"
-#include "wforce.hh"
 #include "wforce-prometheus.hh"
+#include "json11.hpp"
 #include <boost/version.hpp>
 #include <boost/date_time/posix_time/ptime.hpp>
 #include <boost/date_time/gregorian/gregorian.hpp>
 #include <boost/date_time/posix_time/posix_time_duration.hpp>
 #include <hiredis/hiredis.h>
 #include <ostream>
+
+using namespace json11;
 
 BlackWhiteListDB g_bl_db(BLWLDBType::BLACKLIST);
 BlackWhiteListDB g_wl_db(BLWLDBType::WHITELIST);

--- a/wforce/blackwhitelist.hh
+++ b/wforce/blackwhitelist.hh
@@ -39,6 +39,7 @@
 #include <boost/date_time/posix_time/posix_time_io.hpp>
 #include <hiredis/hiredis.h>
 #include "ext/threadname.hh"
+#include "webhook.hh"
 
 struct BlackWhiteListEntry {
   std::string key;
@@ -185,3 +186,7 @@ private:
 
 extern BlackWhiteListDB g_bl_db;
 extern BlackWhiteListDB g_wl_db;
+
+// These are expected to be instantiated elsewhere
+extern WebHookRunner g_webhook_runner;
+extern WebHookDB g_webhook_db;

--- a/wforce/replication.cc
+++ b/wforce/replication.cc
@@ -32,6 +32,7 @@ std::string ReplicationOperation::serialize() const
 
   msg.set_rep_type(obj_type);
   msg.set_rep_op(bytes);
+  msg.set_forwarded(forwarded);
 
   std::string ret_str;
   msg.SerializeToString(&ret_str);
@@ -60,7 +61,8 @@ bool ReplicationOperation::unserialize(const std::string& str)
     }
     else
       retval = false;
-  }  
+  }
+  forwarded = msg.forwarded();
   return retval;
 }
 

--- a/wforce/replication.hh
+++ b/wforce/replication.hh
@@ -52,8 +52,11 @@ public:
   std::string serialize() const;
   bool unserialize(const std::string& str);
   void applyOperation();
-
+  void setForwarded(bool fwd) { forwarded = fwd; }
+  bool getForwarded() { return forwarded; }
+  
 private:
+  bool forwarded = false;
   AnyReplicationOperationP rep_op;
   WforceReplicationMsg_RepType obj_type;
 };

--- a/wforce/replication.hh
+++ b/wforce/replication.hh
@@ -54,6 +54,7 @@ public:
   void applyOperation();
   void setForwarded(bool fwd) { forwarded = fwd; }
   bool getForwarded() { return forwarded; }
+  WforceReplicationMsg_RepType getType() { return obj_type; }
   
 private:
   bool forwarded = false;

--- a/wforce/replication.proto
+++ b/wforce/replication.proto
@@ -57,4 +57,5 @@ message WforceReplicationMsg {
   }
   required RepType rep_type = 1;
   required bytes rep_op = 2;
+  optional bool forwarded = 3;
 }

--- a/wforce/wforce-sibling.hh
+++ b/wforce/wforce-sibling.hh
@@ -35,7 +35,7 @@
 
 struct Sibling
 {
-  enum class Protocol : int { UDP=SOCK_DGRAM, TCP=SOCK_STREAM };
+  enum class Protocol : int { UDP=SOCK_DGRAM, TCP=SOCK_STREAM, NONE=-1 };
   explicit Sibling(const ComboAddress& ca);
   explicit Sibling(const ComboAddress& ca, const Protocol& p);
   ~Sibling();


### PR DESCRIPTION
- Enable support for a new replication type to distinguish messages which are forwarded.
- Enable Siblings to be created without an associated protocol (i.e. they don't make connections)
- Cleanup dependencies in blackwhitelist.cc and .hh