### PR TITLE
Performance Improvements

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -96,7 +96,7 @@ testrunner_SOURCES = \
 	test-serialize.cc
 
 EXTRA_testrunner_DEPENDENCIES = \
-	$(EXT_LIBS)
+	libweakforce.la $(EXT_LIBS)
 
 testrunner_LDFLAGS = \
 	$(AM_LDFLAGS) \

--- a/docker/Makefile.am
+++ b/docker/Makefile.am
@@ -2,15 +2,17 @@ DCMP = docker-compose
 COMPOSE_SOURCE = docker-compose.yml elasticsearch/Dockerfile logstash/Dockerfile logstash/config/logstash.conf logstash/templates/wforce_template.json regression/Dockerfile
 COMPOSE_TARGET = .docker
 GEOIP_FILENAME = GeoLite2-City.mmdb
-GEOIP_FILE_GZ = logstash/geoip/$(GEOIP_FILENAME).gz
+GEOIP_FILE_GZ = logstash/geoip/$(GEOIP_FILENAME).tar.gz
 GEOIP_FILE = logstash/geoip/$(GEOIP_FILENAME)
 REGRESSION_SERVICE = regression
 
 $(GEOIP_FILE_GZ):
-	wget -N -O $(GEOIP_FILE_GZ) http://geolite.maxmind.com/download/geoip/database/$(GEOIP_FILENAME).gz
+	wget -N -O $(GEOIP_FILE_GZ) "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=SPdi9BhAhMj6oOpw&suffix=tar.gz"
+
 
 $(GEOIP_FILE): $(GEOIP_FILE_GZ)
-	gunzip -c $(GEOIP_FILE_GZ) >$(GEOIP_FILE)
+	gunzip -c $(GEOIP_FILE_GZ) | tar xvf -
+	mv GeoLite2*/GeoLite2-City.mmdb $(GEOIP_FILE)
 
 $(COMPOSE_TARGET): $(COMPOSE_SOURCE) $(GEOIP_FILE) $(shell find ../common -type f) $(shell find ../wforce -type f) $(shell find ../trackalert -type f) $(shell find ../ext -type f) $(shell find ../regression-tests -type f)
 	$(DCMP) down -v

--- a/docker/logstash/Dockerfile
+++ b/docker/logstash/Dockerfile
@@ -4,9 +4,10 @@ USER root
 RUN yum install -y wget
 RUN mkdir -p /usr/share/logstash/geoip
 RUN chown -R logstash:logstash /usr/share/logstash/geoip
-RUN wget http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz
-RUN gunzip GeoLite2-City.mmdb.gz
-RUN mv GeoLite2-City.mmdb /usr/share/logstash/geoip
+RUN wget -O GeoLite2-City.mmdb.tar.gz "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=SPdi9BhAhMj6oOpw&suffix=tar.gz"
+RUN gunzip GeoLite2-City.mmdb.tar.gz
+RUN tar xvf GeoLite2-City.mmdb.tar
+RUN mv GeoLite2*/GeoLite2-City.mmdb /usr/share/logstash/geoip
 USER logstash
 
 RUN logstash-plugin install logstash-input-udp

--- a/docker/regression/Dockerfile
+++ b/docker/regression/Dockerfile
@@ -36,7 +36,9 @@ RUN apt-get update && \
 
 # Disable Ipv6 for redis
 RUN sed -i "s/bind .*/bind 127.0.0.1/g" /etc/redis/redis.conf
+RUN echo "AccountID 164476\nLicenseKey W68a2SACgoSv\nEditionIDs GeoLite2-ASN GeoLite2-City GeoLite2-Country" >/etc/GeoIP.conf
 RUN echo "DatabaseDirectory /usr/share/GeoIP" >>/etc/GeoIP.conf
+RUN cat /etc/GeoIP.conf
 RUN geoipupdate -v
 RUN pip3 install bottle virtualenv
 RUN update-rc.d redis-server enable

--- a/docker/regression/regression.sh
+++ b/docker/regression/regression.sh
@@ -28,7 +28,7 @@ tar xvf wforce-$WF_VERSION.tar.gz
 cd wforce-$WF_VERSION
 autoreconf -i
 cd ..
-rm -f build
+rm -rf build
 mkdir build
 cd build
 ../wforce-$WF_VERSION/configure --enable-trackalert CC=$MYCC CXX=$MYCXX

--- a/docs/manpages/wforce.1.md
+++ b/docs/manpages/wforce.1.md
@@ -109,16 +109,16 @@ started with the -c option.
 		192.168.1.30:4501                   25        0
 
 * showStringStatsDB() - Returns information about configured stats
-  databases. This includes the DB Name, whether it is configured for
-  replication, the size and number of windows, the maximum size, the
-  current size, and finally all the configured fields and their
-  types. For example:
+  databases. This includes the DB Name/number of shards, whether it is
+  configured for replication, the size and number of windows, the
+  maximum size, the current size, and finally all the configured
+  fields and their types. For example:
 
 		> showStringStatsDB()
-		DB Name        Repl? Win Size/No Max Size  Cur Size  Field Name       Type
-		MyDB1          yes   1/15        524288    0         countLogins      int
+		DB Name/Shards Repl? Win Size/No Max Size  Cur Size  Field Name       Type
+		MyDB1/1        yes   1/15        524288    0         countLogins      int
 		                                                     diffPasswords    hll
-		MyDB2          no    600/6       5000      2093      diffIPs          hll
+		MyDB2/10       no    600/6       5000      2093      diffIPs          hll
 
 * showACL() - Returns the configured ACLs for the wforce server.
 

--- a/docs/manpages/wforce.conf.5.md
+++ b/docs/manpages/wforce.conf.5.md
@@ -84,6 +84,16 @@ cannot be called inside the allow/report/reset functions:
   
 		siblingListener("0.0.0.0:4001")
 
+* setMaxSiblingQueueSize(\<size\>) - Sets the maximum size of the
+  queue for replication events waiting to be processed. Defaults
+  to 5000. This is only to handle short-term spikes in load/latency -
+  if error messages relating to the queue max size being reached are
+  seen, then you should consider using sharded string stats dbs
+  (newShardedStringStatsDB), and/or tuning the stats db expiry sleep
+  time (twSetExpireSleep).
+
+        setMaxSiblingQueueSize(10000)
+
 * setNamedReportSinks(\<name\>, \<list of IP[:port]\>) - Set a named list
   of report sinks to which all received reports should be forwarded
   over UDP. Reports will be sent to the configured report sinks for a
@@ -709,6 +719,12 @@ a Netmask. For example:
   name. For example:
   
 		statsdb:twResetField(lt.login, "countLogins")
+
+* StringStatsDB:twSetExpireSleep(\<miliseconds\>) - Set the sleep
+  interval between checks to expire/expunge entries. Defaults to
+  250ms. For example:
+
+        statsdb:twSetExpireSleep(200)
 
 * infoLog(\<log string\>, \<key-value map\>) - Log at LOG_INFO level t<he
   specified string, adding "key=value" strings to the log for all the

--- a/docs/manpages/wforce.conf.5.md
+++ b/docs/manpages/wforce.conf.5.md
@@ -239,6 +239,12 @@ cannot be called inside the allow/report/reset functions:
 		field_map["countCountries"] = "countmin"
 		newStringStatsDB("OneHourDB", 900, 4, field_map)
 
+* newShardedStringStatsDB(\<stats db name\>, \<window size\>, \<num windows\>,
+  \<field map\>, \<num shards\>) - Identical to "newStringStatsDB"
+  except that it creates a sharded DB, which is more scalable at
+  higher query loads. A good starting value for the number of shards
+  might be 10.
+
 * StringStatsDB:twSetv4Prefix(\<prefix\>) - Set the prefix to use for
   any IPv4 ComboAddress keys stored in the db. For example, specify 24 to
   group statistics for class C networks. For example:

--- a/regression-tests/wforce-tw.conf
+++ b/regression-tests/wforce-tw.conf
@@ -9,19 +9,19 @@ field_map["diffPasswords"] = "hll"
 field_map["diffIPs"] = "hll"
 field_map["countryCount"] = "countmin"
 
-newStringStatsDB("15SecondsFirstDB",1,15,field_map)
+newShardedStringStatsDB("15SecondsFirstDB",1,15,field_map, 10)
 sdb = getStringStatsDB("15SecondsFirstDB")
 sdb:twEnableReplication()
 sdb:twSetExpireSleep(250)
 
-newStringStatsDB("15SecondsSecondDB",1,15,field_map)
+newShardedStringStatsDB("15SecondsSecondDB",1,15,field_map, 10)
 sdb_prefix = getStringStatsDB("15SecondsSecondDB")
 sdb_prefix:twSetv4Prefix(24)
 sdb_prefix:twSetv6Prefix(64)
 sdb_prefix:twEnableReplication()
 sdb_prefix:twSetExpireSleep(250)
 
-newStringStatsDB("15SecondsSmallDB",1,15,field_map)
+newShardedStringStatsDB("15SecondsSmallDB",1,15,field_map, 10)
 sdb_small = getStringStatsDB("15SecondsSmallDB")
 sdb_small:twSetMaxSize(10)
 sdb_small:twEnableReplication()

--- a/regression-tests/wforce-tw.conf
+++ b/regression-tests/wforce-tw.conf
@@ -12,12 +12,14 @@ field_map["countryCount"] = "countmin"
 newStringStatsDB("15SecondsFirstDB",1,15,field_map)
 sdb = getStringStatsDB("15SecondsFirstDB")
 sdb:twEnableReplication()
+sdb:twSetExpireSleep(250)
 
 newStringStatsDB("15SecondsSecondDB",1,15,field_map)
 sdb_prefix = getStringStatsDB("15SecondsSecondDB")
 sdb_prefix:twSetv4Prefix(24)
 sdb_prefix:twSetv6Prefix(64)
 sdb_prefix:twEnableReplication()
+sdb_prefix:twSetExpireSleep(250)
 
 newStringStatsDB("15SecondsSmallDB",1,15,field_map)
 sdb_small = getStringStatsDB("15SecondsSmallDB")

--- a/wforce/twmap-wrapper.cc
+++ b/wforce/twmap-wrapper.cc
@@ -313,6 +313,11 @@ void TWStringStatsDBWrapper::set_size_soft(unsigned int size)
   sdbp->set_map_size_soft(size);
 }
 
+void TWStringStatsDBWrapper::set_expire_sleep(unsigned int ms)
+{
+  sdbp->set_expire_sleep(ms);
+}
+
 unsigned int TWStringStatsDBWrapper::get_max_size()
 {	
   return sdbp->get_max_size();

--- a/wforce/twmap-wrapper.hh
+++ b/wforce/twmap-wrapper.hh
@@ -63,6 +63,7 @@ public:
   unsigned int get_size();
   unsigned int get_max_size();
   void set_size_soft(unsigned int size);
+  void set_expire_sleep(unsigned int ms);
   int windowSize();
   int numWindows();
   const std::list<std::string>::iterator startDBDump();

--- a/wforce/wforce-lua.cc
+++ b/wforce/wforce-lua.cc
@@ -235,6 +235,16 @@ vector<std::function<void(void)>> setupLua(bool client, bool multi_lua, LuaConte
   else {
     c_lua.writeFunction("setMinSyncHostUptime", [](unsigned int uptime) {});
   }
+
+  if (!multi_lua) {
+    c_lua.writeFunction("setMaxSiblingQueueSize", [](unsigned int size) {
+        setMaxSiblingQueueSize(size);
+      });
+  }
+  else {
+    c_lua.writeFunction("setMaxSiblingQueueSize", [](unsigned int size) {});
+  }
+
   
   if (!multi_lua && !client) {
     c_lua.writeFunction("addSibling", [](const std::string& address) {
@@ -579,7 +589,7 @@ vector<std::function<void(void)>> setupLua(bool client, bool multi_lua, LuaConte
   c_lua.registerFunction("twResetField", &TWStringStatsDBWrapper::resetField);
   c_lua.registerFunction("twEnableReplication", &TWStringStatsDBWrapper::enableReplication);
   c_lua.registerFunction("twGetName", &TWStringStatsDBWrapper::getDBName);
-
+  c_lua.registerFunction("twSetExpireSleep", &TWStringStatsDBWrapper::set_expire_sleep);
   // Blacklists
   if (!multi_lua) {
     c_lua.writeFunction("disableBuiltinBlacklists", []() {

--- a/wforce/wforce-replication.cc
+++ b/wforce/wforce-replication.cc
@@ -53,7 +53,7 @@ struct SiblingQueueItem {
 static std::mutex g_sibling_queue_mutex;
 static std::queue<SiblingQueueItem> g_sibling_queue;
 static std::condition_variable g_sibling_queue_cv;
-const size_t g_max_sibling_queue_size = 1000;
+size_t max_sibling_queue_size = 5000;
 
 GlobalStateHolder<vector<shared_ptr<Sibling>>> g_siblings;
 unsigned int g_num_sibling_threads = WFORCE_NUM_SIBLING_THREADS;
@@ -158,8 +158,8 @@ void parseReceivedReplicationMsg(const std::string& msg, const ComboAddress& rem
   SiblingQueueItem sqi = { msg, remote, recv_sibling };
   {
     std::lock_guard<std::mutex> lock(g_sibling_queue_mutex);
-    if (g_sibling_queue.size() >= g_max_sibling_queue_size) {
-      errlog("parseReceivedReplicationMsg: max sibling queue size (%d) reached - dropping replication msg", g_max_sibling_queue_size);
+    if (g_sibling_queue.size() >= max_sibling_queue_size) {
+      errlog("parseReceivedReplicationMsg: max sibling queue size (%d) reached - dropping replication msg", max_sibling_queue_size);
       return;
     }
     else {
@@ -278,4 +278,9 @@ void receiveReplicationOperations(const ComboAddress& local)
     }
     parseReceivedReplicationMsg(msg, remote, recv_sibling);
   }
+}
+
+void setMaxSiblingQueueSize(size_t size)
+{
+  max_sibling_queue_size = size;
 }

--- a/wforce/wforce-replication.cc
+++ b/wforce/wforce-replication.cc
@@ -177,7 +177,7 @@ void parseTCPReplication(std::shared_ptr<Socket> sockp, const ComboAddress& remo
   uint16_t size;
   size_t ssize = sizeof(size);
   char buffer[65535];
-  int len;
+  ssize_t len;
   unsigned int num_rcvd=0;
   
   try {

--- a/wforce/wforce-replication.cc
+++ b/wforce/wforce-replication.cc
@@ -159,7 +159,7 @@ void parseReceivedReplicationMsg(const std::string& msg, const ComboAddress& rem
   {
     std::lock_guard<std::mutex> lock(g_sibling_queue_mutex);
     if (g_sibling_queue.size() >= g_max_sibling_queue_size) {
-      errlog("parseReceivedReplicationMsg: max sibling queue size (%d) reached - dropping replication msg");
+      errlog("parseReceivedReplicationMsg: max sibling queue size (%d) reached - dropping replication msg", g_max_sibling_queue_size);
       return;
     }
     else {

--- a/wforce/wforce-replication.hh
+++ b/wforce/wforce-replication.hh
@@ -41,3 +41,4 @@ void startReplicationWorkerThreads();
 void encryptMsg(const std::string& msg, std::string& packet);
 bool decryptMsg(const char* buf, size_t len, std::string& msg);
 
+void setMaxSiblingQueueSize(size_t size);

--- a/wforce/wforce-sibling.cc
+++ b/wforce/wforce-sibling.cc
@@ -151,7 +151,7 @@ void Sibling::queueMsg(const std::string& msg)
   {
     std::lock_guard<std::mutex> lock(queue_mutx);
     if (queue.size() >= max_queue_size) {
-      errlog("Sibling::queueMsg: max sibling queue size (%d) reached - dropping replication msg");
+      errlog("Sibling::queueMsg: max sibling queue size (%d) reached - dropping replication msg", max_queue_size);
       return;
     }
     else {

--- a/wforce/wforce.cc
+++ b/wforce/wforce.cc
@@ -505,39 +505,41 @@ void syncDBThread(const ComboAddress& ca, const std::string& callback_url,
     for (auto& i : dbMap) {
       TWStringStatsDBWrapper sdb = i.second;
       std::string db_name = i.first;
-      for (auto it = sdb.startDBDump(); it != sdb.DBDumpIteratorEnd(); ++it) {
-        try {
-          TWStatsDBDumpEntry entry;
-          std::string key;
-          if (sdb.DBDumpEntry(it, entry, key)) {
-            std::shared_ptr<SDBReplicationOperation> sdb_rop = std::make_shared<SDBReplicationOperation>(db_name, SDBOperation_SDBOpType_SDBOpSyncKey, key, entry);
-            ReplicationOperation rep_op(sdb_rop, WforceReplicationMsg_RepType_SDBType);
-            string msg = rep_op.serialize();
-            string packet;
-            encryptMsg(msg, packet);
-            uint16_t nsize = htons(packet.length());
-            rep_sock.writen(std::string((char*)&nsize, sizeof(nsize)));
-            rep_sock.writen(packet);
-            num_synced++;
+      for (auto vi = sdb.begin(); vi != sdb.end(); ++vi) {
+        for (auto it = sdb.startDBDump(vi); it != sdb.DBDumpIteratorEnd(vi); ++it) {
+          try {
+            TWStatsDBDumpEntry entry;
+            std::string key;
+            if (sdb.DBDumpEntry(vi, it, entry, key)) {
+              std::shared_ptr<SDBReplicationOperation> sdb_rop = std::make_shared<SDBReplicationOperation>(db_name, SDBOperation_SDBOpType_SDBOpSyncKey, key, entry);
+              ReplicationOperation rep_op(sdb_rop, WforceReplicationMsg_RepType_SDBType);
+              string msg = rep_op.serialize();
+              string packet;
+              encryptMsg(msg, packet);
+              uint16_t nsize = htons(packet.length());
+              rep_sock.writen(std::string((char*)&nsize, sizeof(nsize)));
+              rep_sock.writen(packet);
+              num_synced++;
+            }
+          }
+          catch(const NetworkError& e) {
+            sdb.endDBDump(vi);
+            auto eptr = std::current_exception();
+            std::rethrow_exception(eptr);
+          }
+          catch(const WforceException& e) {
+            sdb.endDBDump(vi);
+            auto eptr = std::current_exception();
+            std::rethrow_exception(eptr);
+          }
+          catch(const std::exception& e) {
+            sdb.endDBDump(vi);
+            auto eptr = std::current_exception();
+            std::rethrow_exception(eptr);
           }
         }
-        catch(const NetworkError& e) {
-          sdb.endDBDump();
-          auto eptr = std::current_exception();
-          std::rethrow_exception(eptr);
-        }
-        catch(const WforceException& e) {
-          sdb.endDBDump();
-          auto eptr = std::current_exception();
-          std::rethrow_exception(eptr);
-        }
-        catch(const std::exception& e) {
-          sdb.endDBDump();
-          auto eptr = std::current_exception();
-          std::rethrow_exception(eptr);
-        }
+        sdb.endDBDump(vi);
       }
-      sdb.endDBDump();
     }
     infolog("Synchronizing DBs to: %s was completed. Synced %d entries.", ca.toStringWithPort(), num_synced);
   }

--- a/wforce/wforce.cc
+++ b/wforce/wforce.cc
@@ -522,16 +522,6 @@ void syncDBThread(const ComboAddress& ca, const std::string& callback_url,
               num_synced++;
             }
           }
-          catch(const NetworkError& e) {
-            sdb.endDBDump(vi);
-            auto eptr = std::current_exception();
-            std::rethrow_exception(eptr);
-          }
-          catch(const WforceException& e) {
-            sdb.endDBDump(vi);
-            auto eptr = std::current_exception();
-            std::rethrow_exception(eptr);
-          }
           catch(const std::exception& e) {
             sdb.endDBDump(vi);
             auto eptr = std::current_exception();


### PR DESCRIPTION
Three main improvements, all coming from experience at a very large customer with 30 million email subscribers:
1) Make the default statsdb expire/expunge thread sleep much shorter (30 secs -> 250ms), and also configurable. The 30s expiry sleep was causing noticeable spikes in latency causing sibling replication worker thread queues to fill up (this was the visible sign of the underlying issue). Doing expire more frequently means that most requests will take very slightly longer, but will avoid the big latency spikes every 30 seconds.
2) Make the sibling replication worker thread queue size configurable
3) Add an option to make stats dbs sharded. This creates multiple underlying stats dbs underneath the "hood" fo a single Lua statsdb. By doing so, it removes the single-lock contention and should make it much more scalable.

This PR includes regression tests and documentation for new config options