### PR TITLE
Fix control socket leak when client closes connection immediately

### DIFF
--- a/wforce/wforce.cc
+++ b/wforce/wforce.cc
@@ -157,13 +157,13 @@ string g_key;
 void controlClientThread(int fd, ComboAddress client)
 try
 {
+  Socket sock(fd);
   SodiumNonce theirs, ours, readingNonce, writingNonce;
   ours.init();
   readn2(fd, (char*)theirs.value, sizeof(theirs.value));
   writen2(fd, (char*)ours.value, sizeof(ours.value));
   readingNonce.merge(ours, theirs);
   writingNonce.merge(theirs, ours);
-  Socket sock(fd);
   
   setThreadName("wf/ctrl-client");
 


### PR DESCRIPTION
The socket is wrapped in a Socket class, which closes the socket
when destructed. However the Socket was not declared first, which
meant that the read/write before it was declared could trigger
an exception, meaning the socket would not be closed.
Declaring the Socket class as the first line in the function
fixes this error.