### PR TITLE
Dump Entries Functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- New wf_dump_entries tool to dump stats DBs to file
+- Support building debian buster packages
+- Support for new "forwarding" type in replication messages
+- Support for Prometheus via the new /metrics REST endpoint
+- StatsDBs can now be sharded for better performance
+- StatsDB expiry thread now runs more often by default
+- StatsDB expiry thread sleep time is now configurable
+
+### Changed
+- Fix control socket leak when client closes connection immediately
+
 ## [2.2.1]
 
 ### Changed

--- a/builder-support/specs/wforce.spec
+++ b/builder-support/specs/wforce.spec
@@ -328,12 +328,14 @@ fi
 %files
 %defattr(-,root,root,-)
 %{_bindir}/%{name}
+%{_bindir}/wf_dump_entries
 %ghost %{_sysconfdir}/%{name}.conf
 %attr(0644,root,root) %config(noreplace,missingok) %{_sysconfdir}/%{name}/%{name}.conf
 %{_sysconfdir}/%{name}/regexes.yaml
 %{_docdir}/%{name}-%{version}/*
 %{_unitdir}/%{name}.service
 %{_mandir}/man1/%{name}.1.gz
+%{_mandir}/man1/wf_dump_entries.1.gz
 %{_mandir}/man5/%{name}.conf.5.gz
 %{_mandir}/man5/%{name}_webhook.5.gz
 %doc CHANGELOG.md README.md

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -4,7 +4,7 @@ if WITH_TRACKALERT
 TRACKALERT_MANPAGES_TARGET = trackalert.1 trackalert.conf.5
 TRACKALERT_APIDOC = trackalert_api.7
 endif
-MANPAGES_TARGET = wforce.1 wforce.conf.5 wforce_webhook.5 $(TRACKALERT_MANPAGES_TARGET)
+MANPAGES_TARGET = wforce.1 wforce.conf.5 wforce_webhook.5 wf_dump_entries.1 $(TRACKALERT_MANPAGES_TARGET)
 
 APIDOC = wforce_api.7 report_api.7 $(TRACKALERT_APIDOC)
 SWAG2MD_PROG = swag2md.pl

--- a/docs/manpages/wf_dump_entries.1.md
+++ b/docs/manpages/wf_dump_entries.1.md
@@ -1,0 +1,52 @@
+% WF_DUMP_ENTRIES(1)
+% Open-Xchange
+% 2020
+
+# NAME
+**wf_dump_entries** - Tool to dump the entries from the wforce stats
+DBs to stdout or a file
+
+# SYNOPSIS
+wf_dump_entries [-u,--uri wforce uri] [-l,--local-addr address] [-p,--local-port port] [-w,--wforce-pwd password] [-f,--filename file] [-h,--help] 
+
+# DESCRIPTION
+**wf_dump_entries** connects to the specified wforce server, and asks
+it to send a dump of all the stats DBs to itself over TCP/IP. It then
+sends the results to stdout or a file. 
+
+**wf_dump_entries** firstly acts as a TCP client, connecting to wforce
+and invoking the 'dumpEntries' command. Then it acts as a server,
+receiving the dumped entries, and printing them to stdout or to a file.
+
+# SCOPE
+**wf_dump_entries** requires a running wforce daemon to connect
+to.
+
+# OPTIONS
+-u *URI*
+:    Provides the URI of the wforce daemon, ideally without a path or
+     query. For example: http://127.0.0.1:8084/. The query
+     "?command=dumpEntries" will be appended to the command if the URI
+     does not end with "dumpEntries".
+
+-w,--wforce-pwd *PASSWORD*
+:    The password to use for basic authentication to wforce.
+
+-l,--local-addr *IP ADDRESS*
+:    The IP address to use to send the entries to. This must be a
+     configured IP address on the localhost. The wf_dump_entries program
+     will listen on this IP address.
+
+-p,--local-port *PORT*
+:    The port number to use when sending the entries. The
+     wf_dump_entries program will listen on this port.
+
+-f,--filename *FILENAME*
+:    Send the dumped entries to the specified file instead of stdout.
+
+-h,--help
+:    Display a helpful message and exit.
+
+# SEE ALSO
+wforce(1)
+

--- a/docs/swagger/wforce_api.7.yml
+++ b/docs/swagger/wforce_api.7.yml
@@ -370,6 +370,35 @@ paths:
           description: unexpected error
           schema:
             $ref: "#/definitions/Error"
+  /?command=dumpEntries:
+    post:
+      description: This is a request to dump StatsDB entries (consisting of the values of each of the time windows for each field) to a specified IP address and port over TCP.
+      operationId: dumpEntries
+      produces:
+        - application/json
+      parameters:
+        - name: "dumpEntries"
+          in: body
+          description: "The ip and port to dump to"
+          required: true
+          schema:
+            $ref: "#/definitions/dumpEntriesParams"
+      responses:
+        "200":
+          description: "dumpEntries response"
+          schema:
+            type: object
+            required:
+              - status
+            properties:
+              status:
+                type: string
+            example:
+              status: ok
+        default:
+          description: unexpected error
+          schema:
+            $ref: "#/definitions/Error"
   /?command=customEndpoint:
     post:
       description: Extensible mechanism allows custom REST endpoints to be defined - this is an example
@@ -747,3 +776,13 @@ definitions:
         type: string
       callback_auth_pw:
         type: string
+  dumpEntriesParams:
+    type: object
+    required:
+      - dump_host
+      - dump_port
+    properties:
+      dump_host:
+        type: string
+      dump_port:
+        type: integer

--- a/regression-tests/test_DumpEntries.py
+++ b/regression-tests/test_DumpEntries.py
@@ -1,0 +1,25 @@
+import requests
+import socket
+import time
+import json
+import os
+from subprocess import call
+from test_helper import ApiTestCase
+
+class TestDumpEntries(ApiTestCase):
+
+    def test_dumpentries(self):
+        for i in range(100):
+            r = self.reportFunc('dumpentries', '199.99.99.99', "1234'%s" % i, False)
+
+            dumpfile = "/tmp/wfdb.txt"
+            result = call(["../wforce/wf_dump_entries", "-f", dumpfile, "-u", "http://127.0.0.1:8084/", "-l", "127.0.0.1", "-p", "9999", "-w", os.environ.get('APIKEY', 'super')])
+            if result:
+                f = open(dumpfile, "r")
+                found = False
+                for x in f:
+                    if x.find("199.99.99.99"):
+                        found = True
+                        break
+
+                selfAssertTrue(found)

--- a/wforce/.gitignore
+++ b/wforce/.gitignore
@@ -1,4 +1,5 @@
 /TAGS
 /wforce
+/wf_dump_entries
 /regexes.yaml
 /*.service

--- a/wforce/Makefile.am
+++ b/wforce/Makefile.am
@@ -29,7 +29,8 @@ distclean-local:
 
 sysconf_DATA= wforce.conf wforce.conf.example $(UAP_REGEX_FILE)
 
-bin_PROGRAMS = wforce
+bin_PROGRAMS =  wforce \
+		wf_dump_entries
 
 wforce_SOURCES = \
 	wforce.cc wforce.hh \
@@ -60,6 +61,18 @@ wforce_LDADD = \
 
 EXTRA_wforce_DEPENDENCIES = \
 	$(EXT_LIBS) $(WFORCE_LIBS)
+
+wf_dump_entries_SOURCES = \
+	dump_entries.cc
+
+wf_dump_entries_LDFLAGS = \
+	$(AM_LDFLAGS)
+
+wf_dump_entries_LDADD = \
+	$(WFORCE_LIBS) $(LIBCURL) ${libsodium_LIBS}
+
+EXTRA_wf_dump_entries_DEPENDENCIES = \
+	$(WFORCE_LIBS)
 
 noinst_HEADERS = \
 	blackwhitelist.hh \

--- a/wforce/dump_entries.cc
+++ b/wforce/dump_entries.cc
@@ -136,6 +136,7 @@ int main(int argc, char** argv)
   SSetsockopt(listen_sock, SOL_SOCKET, SO_REUSEADDR, 1);
   SBind(listen_sock, local_ca);
   SListen(listen_sock, 1024);
+  Socket listen_sock_wrapper(listen_sock); // This ensures the socket gets closed
 
   // Connect to the specified wforce address and port
   // and request to dump entries to our local address and port

--- a/wforce/dump_entries.cc
+++ b/wforce/dump_entries.cc
@@ -1,0 +1,191 @@
+/*
+ * This file is part of PowerDNS or weakforced.
+ * Copyright -- PowerDNS.COM B.V. and its contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of version 3 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * In addition, for the avoidance of any doubt, permission is granted to
+ * link this program with OpenSSL and to (re)distribute the binaries
+ * produced as the result of such linking.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "config.h"
+#include <stddef.h>
+#define SYSLOG_NAMES
+#include <syslog.h>
+#include <getopt.h>
+#include <netinet/tcp.h>
+#include <limits>
+#include "minicurl.hh"
+#include <iostream>
+#include <fstream>
+#include "iputils.hh"
+#include "json11.hpp"
+#include "base64.hh"
+#include "sstuff.hh"
+
+using namespace std;
+using namespace json11;
+
+void print_help()
+{
+  cout<<"Syntax: dump_entries [-u,--uri wforce uri] [-l,--local-addr address] [-p,--local-port port] [-w,--wforce-pwd password] [-f,--filename file] [-h,--help]\n";
+  cout<<"\n";
+  cout<<"-u,--uri address          <Mandatory> Connect to wforce on the specified URI\n";
+  cout<<"-l,--local-addr address   <Mandatory> Listen for results on the specified local IP address\n";
+  cout<<"-p,--local-port port      <Mandatory> Listen on the specified port\n";
+  cout<<"-w,--wforce-pwd password  <Mandatory> The password to authenticate to wforce\n";
+  cout<<"-f,--filename file        <Optional>  Send the results to a file\n";
+  cout<<"-h,--help                 Display this helpful message\n";
+  cout<<"\n";
+}
+
+bool g_console = true;
+
+int main(int argc, char** argv)
+{
+  string uri, local_addr, password, filename;
+  int local_port=0;
+  struct option longopts[]={ 
+    {"uri", required_argument, 0, 'u'},
+    {"local-addr", required_argument, 0, 'l'},
+    {"local-port", required_argument, 0, 'p'},
+    {"wforce-pwd", required_argument, 0, 'w'},
+    {"filename", required_argument, 0, 'f'},
+    {"help", 0, 0, 'h'},
+    {0,0,0,0}
+  };
+  int longindex=0;
+  for(;;) {
+    int c=getopt_long(argc, argv, "hu:l:p:w:f:", longopts, &longindex);
+    if(c==-1)
+      break;
+    switch(c) {
+    case 'u':
+      uri = optarg;
+      break;
+    case 'l':
+      local_addr = optarg;
+      break;
+    case 'p':
+      try {
+        local_port = stoi(optarg);
+      }
+      catch (const std::exception& e) {
+        cerr << "Could not parse local port - must be an integer" << endl;
+        exit(EXIT_FAILURE);
+      }
+      break;
+    case 'w':
+      password = optarg;
+      break;
+    case 'f':
+      filename = optarg;
+      break;
+    case 'h':
+      print_help();
+      exit(EXIT_SUCCESS);
+      break;
+    }
+  }
+  argc-=optind;
+  argv+=optind;
+
+  if ((uri.empty()) ||
+      (local_addr.empty()) ||
+      (local_port == 0) ||
+      (password.empty())) {
+    cout << "Missing mandatory arguments...\n";
+    print_help();
+    exit(EXIT_FAILURE);
+  }
+
+  // Open file if specified
+  ofstream myfile;
+  if (!filename.empty()) {
+    myfile.open(filename, ios::out | ios::trunc);
+
+    if (!myfile.is_open()) {
+      cerr << "Could not open " << filename << " for writing." << endl;
+      exit(EXIT_FAILURE);
+    }
+  }
+  
+  // Listen on local IP and port
+  ComboAddress local_ca;
+  try {
+    local_ca = ComboAddress(local_addr, local_port);
+  }
+  catch (const WforceException& e) {
+    cerr << "Error parsing local address and port " << local_addr << ", " << local_port << ". Make sure to use IP addresses not hostnames" << endl;
+    exit(EXIT_FAILURE);
+  }
+  cout << "Listening on " << local_ca.toStringWithPort() << endl;
+  
+  int listen_sock = socket(local_ca.sin4.sin_family, SOCK_STREAM, 0);
+  SSetsockopt(listen_sock, SOL_SOCKET, SO_REUSEADDR, 1);
+  SBind(listen_sock, local_ca);
+  SListen(listen_sock, 1024);
+
+  // Connect to the specified wforce address and port
+  // and request to dump entries to our local address and port
+  MiniCurl mc;
+  MiniCurlHeaders mch;
+  string error_msg;
+  mch.insert(make_pair("Authorization", "Basic " + Base64Encode("wforce:"+password)));
+  mch.insert(make_pair("Content-Type", "application/json"));
+  Json::object post_json = {{"dump_host", local_addr},
+                            {"dump_port", local_port}};
+  if (uri.find("dumpEntries") == string::npos) {
+    uri += "/?command=dumpEntries";
+  }
+  if (mc.postURL(uri, Json(post_json).dump(), mch, error_msg) != true) {
+    cerr << "Post to wforce URI [" << uri << "] failed, error=" << error_msg;
+    exit(EXIT_FAILURE);
+  }
+  
+  // Finally wait for the dumped entries and print them out
+  try {
+    ComboAddress remote(local_ca);
+    int fd = SAccept(listen_sock, remote);
+    Socket sock(fd);
+    string buf;
+
+    try {
+      for (;;) {
+        sock.read(buf);
+        if (buf.empty())
+          break;
+        if (filename.empty())
+          cout << buf;
+        else
+          myfile << buf;
+      }
+    }
+    catch (const NetworkError& e) {
+      cerr << e.what() << endl;
+    }
+  }
+  catch(std::exception& e) {
+    cerr << "dump_entries: error accepting new connection: " << e.what();
+    exit(EXIT_FAILURE);
+  }
+  if (filename.empty())
+    cout << endl;
+  else
+    myfile << endl;
+  if (myfile.is_open())
+    myfile.close();
+  exit(EXIT_SUCCESS);
+}

--- a/wforce/dump_entries.cc
+++ b/wforce/dump_entries.cc
@@ -131,7 +131,6 @@ int main(int argc, char** argv)
     cerr << "Error parsing local address and port " << local_addr << ", " << local_port << ". Make sure to use IP addresses not hostnames" << endl;
     exit(EXIT_FAILURE);
   }
-  cout << "Listening on " << local_ca.toStringWithPort() << endl;
   
   int listen_sock = socket(local_ca.sin4.sin_family, SOCK_STREAM, 0);
   SSetsockopt(listen_sock, SOL_SOCKET, SO_REUSEADDR, 1);

--- a/wforce/twmap-wrapper.cc
+++ b/wforce/twmap-wrapper.cc
@@ -409,6 +409,14 @@ bool TWStringStatsDBWrapper::DBDumpEntry(VTWPtr::const_iterator& sdbp,
   return (*sdbp)->DBDumpEntry(i, entry, key);
 }
 
+bool TWStringStatsDBWrapper::DBGetEntry(VTWPtr::const_iterator& sdbp,
+                                        std::list<std::string>::const_iterator& i,
+                                        TWStatsDBEntry& entry,
+                                        std::string& key) const
+{
+  return (*sdbp)->DBGetEntry(i, entry, key);
+}
+
 const std::list<std::string>::const_iterator TWStringStatsDBWrapper::DBDumpIteratorEnd(VTWPtr::const_iterator& sdbp) const
 {
   return (*sdbp)->DBDumpIteratorEnd();

--- a/wforce/twmap-wrapper.hh
+++ b/wforce/twmap-wrapper.hh
@@ -83,6 +83,10 @@ public:
                    std::list<std::string>::const_iterator& i,
                    TWStatsDBDumpEntry& entry,
                    std::string& key) const;
+  bool DBGetEntry(VTWPtr::const_iterator& sdbp,
+                   std::list<std::string>::const_iterator& i,
+                   TWStatsDBEntry& entry,
+                   std::string& key) const;
   const std::list<std::string>::const_iterator DBDumpIteratorEnd(VTWPtr::const_iterator& sdbp) const;
   void endDBDump(VTWPtr::const_iterator& sdbp) const;
   void restoreEntry(const std::string& key, TWStatsDBDumpEntry& entry);

--- a/wforce/wforce-replication.cc
+++ b/wforce/wforce-replication.cc
@@ -186,7 +186,7 @@ void parseTCPReplication(std::shared_ptr<Socket> sockp, const ComboAddress& remo
 
   infolog("New TCP Replication connection from %s", remote.toString());
   uint16_t size;
-  size_t ssize = sizeof(size);
+  ssize_t ssize = static_cast<ssize_t>(sizeof(size));
   char buffer[65535];
   ssize_t len;
   unsigned int num_rcvd=0;

--- a/wforce/wforce-web.cc
+++ b/wforce/wforce-web.cc
@@ -147,6 +147,47 @@ bool canonicalizeLogin(std::string& login, YaHTTP::Response& resp)
   return retval;
 }
 
+void parseDumpEntriesCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const std::string& command)
+{
+  using namespace json11;
+  Json msg;
+  string err;
+
+  resp.status = 200;
+
+  msg = Json::parse(req.body, err);
+  if (msg.is_null()) {
+    resp.status=500;
+    std::stringstream ss;
+    ss << "{\"status\":\"failure\", \"reason\":\"" << err << "\"}";
+    resp.body=ss.str();
+  }
+  else {
+    try {
+      if (msg["dump_host"].is_null() ||
+          msg["dump_port"].is_null()) {
+        throw WforceException("One of mandatory parameters [dump_host, dump_port] is missing");
+      }
+      string myip = msg["dump_host"].string_value();
+      int myport = msg["dump_port"].int_value();
+      ComboAddress replication_ca(myip, myport);
+      thread t(dumpEntriesThread, replication_ca);
+      t.detach();
+    }
+    catch(const WforceException& e) {
+      resp.status=500;
+      std::stringstream ss;
+      ss << "{\"status\":\"failure\", \"reason\":\"" << e.reason << "\"}";
+      resp.body=ss.str();
+      errlog("Exception in command [%s] exception: %s", command, e.reason);
+    }
+  }
+  if (resp.status == 200)
+    resp.body=R"({"status":"ok"})";
+  incCommandStat("dumpEntries");
+  incPrometheusCommandMetric("dumpEntries");
+}
+
 void parseSyncCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const std::string& command)
 {
   using namespace json11;
@@ -1221,4 +1262,7 @@ void registerWebserverCommands()
   addCommandStat("syncDone");
   addPrometheusCommandMetric("syncDone");
   g_webserver.registerFunc("syncDone", HTTPVerb::GET, WforceWSFunc(parseSyncDoneCmd));
+  addCommandStat("dumpEntries");
+  addPrometheusCommandMetric("dumpEntries");
+  g_webserver.registerFunc("dumpEntries", HTTPVerb::POST, WforceWSFunc(parseDumpEntriesCmd));
 }

--- a/wforce/wforce.cc
+++ b/wforce/wforce.cc
@@ -539,7 +539,9 @@ unsigned int dumpEntriesToNetwork(const ComboAddress& ca)
   return num_synced;
 }
 
-void dumpEntriesThread(const ComboAddress& ca)
+// This function is only called once the lock on the mutex is acquired
+// The lock is released automatically once this function finishes
+void dumpEntriesThread(const ComboAddress& ca, std::unique_lock<std::mutex> lock)
 {
   unsigned int num_synced = 0;
   

--- a/wforce/wforce.hh
+++ b/wforce/wforce.hh
@@ -92,6 +92,7 @@ extern std::shared_ptr<UserAgentParser> g_ua_parser_p;
 
 extern bool g_allowlog_verbose; // Whether to log allow returns of 0
 
+void dumpEntriesThread(const ComboAddress& ca);
 void syncDBThread(const ComboAddress& ca, const std::string& callback_url,
                   const std::string& calback_pw);
 

--- a/wforce/wforce.hh
+++ b/wforce/wforce.hh
@@ -92,7 +92,7 @@ extern std::shared_ptr<UserAgentParser> g_ua_parser_p;
 
 extern bool g_allowlog_verbose; // Whether to log allow returns of 0
 
-void dumpEntriesThread(const ComboAddress& ca);
+void dumpEntriesThread(const ComboAddress& ca, std::unique_lock<std::mutex> lock);
 void syncDBThread(const ComboAddress& ca, const std::string& callback_url,
                   const std::string& calback_pw);
 


### PR DESCRIPTION
New functionality to allow the stats DBs to be dumped to a file for debugging purposes (or other reasons).

This consists of a new REST API endpoint that sends all the dumped entries to a specified IP address and port, and a new command line tool "wf_dump_entries" that uses the new API.

The reason this doesn't just return the entries in the REST API response is twofold:
1) To do so would require allocating a giant data structure to hold everything which is unfeasible
2) It would lock up a REST API worker thread for a very long time.

This PR also updates the CHANGELOG with all changes since 2.2.1