### PR TITLE
Support Kafka REST Proxy in webhooks

### DIFF
--- a/common/twmap.hh
+++ b/common/twmap.hh
@@ -653,7 +653,7 @@ void TWStatsDB<T>::expireEntries()
       unsigned int num_expire = stats_db.size() - map_size_soft;
       unsigned int num_expired = num_expire;
 
-      infolog("About to expire %d entries from stats db %s", num_expire, db_name);
+      vinfolog("About to expire %d entries from stats db %s", num_expire, db_name);
 
       // this just uses the front of the key tracker list, which always contains the Least Recently Modified keys
       while (num_expire--) {
@@ -663,7 +663,7 @@ void TWStatsDB<T>::expireEntries()
 	  key_tracker.pop_front();
 	}
       }
-      infolog("Finished expiring %d entries from stats db %s", num_expired, db_name);
+      vinfolog("Finished expiring %d entries from stats db %s", num_expired, db_name);
     }
   }
 }

--- a/common/webhook.cc
+++ b/common/webhook.cc
@@ -71,7 +71,7 @@ bool WebHookRunner::pingHook(std::shared_ptr<const WebHook> hook, std::string er
   return _runHooks(wqi, mcm);
 }
 
-// asynchronously run the hook with the supplied data (must be a string in json format)
+// asynchronously run the hook with the supplied data
 void WebHookRunner::runHook(const std::string& event_name, std::shared_ptr<const WebHook> hook, const std::string& hook_data)
 {
   std::string err_msg;
@@ -98,6 +98,17 @@ void WebHookRunner::runHook(const std::string& event_name, std::shared_ptr<const
       setPrometheusWebhookQueueSize(queue.size());
     }
     cv.notify_one();
+  }
+}
+
+void WebHookRunner::runHook(const std::string& event_name, std::shared_ptr<const WebHook> hook, const json11::Json& json_data)
+{
+  if (hook->getConfigKey("kafka") == "true") {
+    Json kobj = Json::object{{"records", Json(Json::array{Json(Json::object{{"value", json_data}})})}};
+    runHook(event_name, hook, kobj.dump());
+  }
+  else {
+    runHook(event_name, hook, json_data.dump());
   }
 }
 

--- a/common/webhook.hh
+++ b/common/webhook.hh
@@ -486,8 +486,9 @@ public:
   void setTimeout(uint64_t timeout_seconds);
   // synchronously run the ping command for the hook
   bool pingHook(std::shared_ptr<const WebHook> hook, std::string error_msg);
-  // asynchronously run the hook with the supplied data (must be in json format)
+  // asynchronously run the hook with the supplied data
   void runHook(const std::string& event_name, std::shared_ptr<const WebHook> hook, const std::string& hook_data);
+  void runHook(const std::string& event_name, std::shared_ptr<const WebHook> hook, const json11::Json& json_data);
   void startThreads();
 protected:
   void _runHookThread(unsigned int num_conns);

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -36,6 +36,42 @@ services:
     depends_on:
       - elasticsearch
       - logstash
+      - kafka-rest
+
+  # The following three images are for kafka regression testing
+  zookeeper:
+    image: confluentinc/cp-zookeeper:latest
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  kafka:
+    image: confluentinc/cp-kafka:latest
+    depends_on:
+      - zookeeper
+    ports:
+      - 9092:9092
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+
+  kafka-rest:
+    image: confluentinc/cp-kafka-rest:latest
+    ports:
+      - 8082:8082
+    environment:
+      KAFKA_REST_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_REST_LISTENERS: http://0.0.0.0:8082
+      KAFKA_REST_HOST_NAME: localhost
+      KAFKA_REST_BOOTSTRAP_SERVERS: kafka:29092
+    depends_on:
+      - zookeeper
+      - kafka
+
 volumes:
   esdata:
     driver: local

--- a/docs/manpages/wforce_webhook.5.md
+++ b/docs/manpages/wforce_webhook.5.md
@@ -119,6 +119,14 @@ setting. The following configuration keys can be used for all events:
 
         config_key["api-key"] = "myapikeysecret"
 
+* kafka - When this is set to "true" then the webhook will be
+  sent with a Content-Type of "application/vnd.kafka.json.v2+json"
+  and the json will be wrapped according to the Kafka REST Proxy
+  requirements (https://docs.confluent.io/current/kafka-rest/api.html). 
+  The webhook "url" config key should be set to
+  the correct topic, e.g. "http://kafka-rest:8082/topics/foo"
+  for the topic named "foo".
+
 The following configuration keys are custom to specific events:
 
 * allow_filter - Filters allow webhooks based on the allow response

--- a/regression-tests/test_WebHooks.py
+++ b/regression-tests/test_WebHooks.py
@@ -3,6 +3,7 @@ import mmap
 import re
 import time
 import os
+import json
 from test_helper import ApiTestCase
 
 class TestWebHooks(ApiTestCase):
@@ -27,6 +28,16 @@ class TestWebHooks(ApiTestCase):
         s.close()
         logfile.close()
 
+    def test_kafka_webhooks(self):
+        self.writeCmdToConsole("addWebHook(events, kafka_ck)")
+        self.reportFunc('kafkawebhooktest', '4.4.3.1', '1234', False)
+        self.reportFunc('kafkawebhooktest', '4.4.3.1', '1234', False)
+        time.sleep(5)
+        r = self.kafkaProducer()
+        j = r.json()
+        print(json.dumps(j))
+        self.assertGreater(j['offsets'][0]['offset'], 0)
+        
     def test_customwebhooks(self):
         self.writeCmdToConsole("addCustomWebHook(\"customwebhook\", ck)")
         r = self.customFunc("custom1")

--- a/regression-tests/test_helper.py
+++ b/regression-tests/test_helper.py
@@ -471,6 +471,13 @@ class ApiTestCase(unittest.TestCase):
             data=json.dumps(payload),
             headers={'Content-Type': 'application/json'}) 
 
+    def kafkaProducer(self):
+        payload = {"records": [ { "value": { "foo": "bar" }}]}
+        return self.session.post(
+            "http://kafka-rest:8082/topics/wforce",
+            data=json.dumps(payload),
+            headers={'Content-Type': 'application/vnd.kafka.json.v2+json'})
+    
     def getWforceMetrics(self):
         return self.session.get(
             self.url("/metrics"))

--- a/regression-tests/wforce-tw.conf
+++ b/regression-tests/wforce-tw.conf
@@ -49,6 +49,11 @@ ls_ck = {}
 ls_ck["url"] = "http://logstash:8080"
 ls_ck["secret"] = "verysecretcode"
 
+kafka_ck = {}
+kafka_ck["url"] = "http://kafka-rest:8082/topics/wforce"
+kafka_ck["kafka"] = "true"
+kafka_events = { "report" }
+
 function twreport(lt)
 	local tls = lt.tls
 	local session_id = lt.session_id

--- a/wforce/blackwhitelist.cc
+++ b/wforce/blackwhitelist.cc
@@ -155,10 +155,9 @@ void BlackWhiteListDB::addEntryInternal(const std::string& key, time_t seconds, 
   // only generate webhook for this event for the first add, not for replicas
   if (replicate == true) {
     Json jobj = Json::object{{"key", key}, {type_name, BLWLTypeToName(blwl_type)}, {"reason", reason}, {"expire_secs", (int)seconds}, {"type", "wforce_addblwl"}};
-    std::string hook_data = jobj.dump();
     for (const auto& h : g_webhook_db.getWebHooksForEvent(event_name)) {
       if (auto hs = h.lock())
-	g_webhook_runner.runHook(event_name, hs, hook_data);
+	g_webhook_runner.runHook(event_name, hs, jobj);
     }
   }
 }
@@ -350,10 +349,9 @@ void BlackWhiteListDB::deleteEntryInternal(const std::string& key, BLWLType blwl
   // only generate webhook for this event for the first delete, not for replicas
   if (replicate == true) {
     Json jobj = Json::object{{"key", key}, {type_name, BLWLTypeToName(blwl_type)}, {"type", "wforce_delblwl"}};
-    std::string hook_data = jobj.dump();
     for (const auto& h : g_webhook_db.getWebHooksForEvent(event_name)) {
       if (auto hs = h.lock())
-	g_webhook_runner.runHook(event_name, hs, hook_data);
+	g_webhook_runner.runHook(event_name, hs, jobj);
     }
   }
 
@@ -460,10 +458,9 @@ void BlackWhiteListDB::_purgeEntries(BLWLType blt, blackwhitelist_t& blackwhitel
   for (auto tit = timeindex.begin(); tit != timeindex.end();) {
     if (tit->expiration <= now) {
       Json jobj = Json::object{{"key", tit->key}, {type_name, BLWLTypeToName(blwl_type)}, {"type", "wforce_expireblwl"}};
-      std::string hook_data = jobj.dump();
       for (const auto& h : g_webhook_db.getWebHooksForEvent(event_name)) {
 	if (auto hs = h.lock())
-	  g_webhook_runner.runHook(event_name, hs, hook_data);
+	  g_webhook_runner.runHook(event_name, hs, jobj);
       }
       expireEntryLog(blt, tit->key);
       if (blwl_type == IP_BLWL)

--- a/wforce/wforce-lua.cc
+++ b/wforce/wforce-lua.cc
@@ -979,6 +979,11 @@ vector<std::function<void(void)>> setupLua(bool client, bool multi_lua, LuaConte
         for (const auto& ck : ck_vec) {
           config_keys.insert(ck);
         }
+        auto i = config_keys.find("kafka");
+        if (i != config_keys.end()) {
+          if (i->second == "true")
+            config_keys.insert(make_pair("content-type", "application/vnd.kafka.json.v2+json"));
+        }
         auto ret = g_webhook_db.addWebHook(WebHook(id, events, true, config_keys), err);
         if (ret != true) {
           errlog("Registering webhook id=%d from Lua failed [%s]", id, err);


### PR DESCRIPTION
Certain folks like to use Kafka as a front-end for all events. Rather than support native kafka, which is a lot of work, this PR supports sending to the Kafka REST Proxy via webhooks, which only requires slightly modifying the webhook content-type and wrapping the json in the format required by Kafka.

This also adds Kafka to the regression tests using the supported Kafka Docker images.