### PR TITLE
Fix breaking CI and Package builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ matrix:
       - BUILDER_TARGET=debian-buster
 before_script:
  - git clone https://github.com/jupp0r/prometheus-cpp.git
+ - ( cd prometheus-cpp && git checkout tags/v0.9.0 -b v0.9.0 )
  - (cd prometheus-cpp && git submodule init && git submodule update && mkdir _build && cd _build && cmake .. -DBUILD_SHARED_LIBS=off -DENABLE_PULL=off -DENABLE_PUSH=off -DENABLE_COMPRESSION=off && make && sudo make install)
 script:
  - autoreconf -i

--- a/builder-support/dockerfiles/Dockerfile.wforce
+++ b/builder-support/dockerfiles/Dockerfile.wforce
@@ -29,6 +29,7 @@ WORKDIR /wforce/
 RUN mkdir /sdist
 
 RUN git clone https://github.com/jupp0r/prometheus-cpp.git
+RUN cd prometheus-cpp && git checkout tags/v0.9.0 -b v0.9.0
 RUN echo 'include(CPack)' >> prometheus-cpp/CMakeLists.txt
 RUN cat prometheus-cpp/CMakeLists.txt
 RUN cd prometheus-cpp && git submodule init && git submodule update && \

--- a/docker/regression/Dockerfile
+++ b/docker/regression/Dockerfile
@@ -48,6 +48,7 @@ WORKDIR /wforce/
 RUN mkdir /sdist
 
 RUN git clone https://github.com/jupp0r/prometheus-cpp.git
+RUN cd prometheus-cpp && git checkout tags/v0.9.0 -b v0.9.0
 RUN cd prometheus-cpp && git submodule init && git submodule update && mkdir _build && cd _build && cmake .. -DBUILD_SHARED_LIBS=off && make && make install
 
 ADD CHANGELOG.md configure.ac ext LICENSE Makefile.am README.md NOTICE trigger_policy_build.sh /wforce/

--- a/report_api/requirements.txt
+++ b/report_api/requirements.txt
@@ -6,7 +6,7 @@ Flask-Elastic==0.2
 Flask-HTTPAuth==3.2.3
 itsdangerous==0.24
 Jinja2==2.10.1
-MarkupSafe==1.0
+MarkupSafe==1.1.0
 pytz==2017.2
 urllib3==1.24.2
 Werkzeug==0.15.3


### PR DESCRIPTION
- A prometheus-cpp master update broke CI which is bad
- MarkupSafe python library started breaking package building, the fix for which is to update to 1.1.0 from 1.0