### PR TITLE
Redis Keepalive and Configurable Timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - New wf_dump_entries tool to dump stats DBs to file
 - Support for new "forwarding" type in replication messages
 - Support for Prometheus via the new /metrics REST endpoint
+- Enable TCP keepalive for redis connections
+- Configurable timeout for R/W on redis connections
 
 ### Changed
 - Fix duplicate command stats under some circumstances

--- a/docs/manpages/wforce.conf.5.md
+++ b/docs/manpages/wforce.conf.5.md
@@ -309,6 +309,11 @@ cannot be called inside the allow/report/reset functions:
 
 		blacklistPersistConnectTimeout(2)
 
+* blacklistPersistRWTimeout(<timeout secs>, <timeout usecs>) - Set the
+  timeout for reading from/writing to the Redis DB. For example:
+
+        blacklistPersistRWTimeout(0, 50000)
+
 * disableBuiltinWhitelists() - Disable the built-in whitelisting checks,
   enabling them to be checked from Lua instead. For example:
 
@@ -339,6 +344,11 @@ cannot be called inside the allow/report/reset functions:
   error will be logged. For example:
 
 		whitelistPersistConnectTimeout(2)
+
+* whitelistPersistRWTimeout(<timeout secs>, <timeout usecs>) - Set the
+  timeout for reading from/writing to the Redis DB. For example:
+
+        whitelistPersistRWTimeout(0, 50000)
 
 * setBlacklistIPRetMsg(<msg>) - Set the message to be returned to
   clients whose IP address is blacklisted. For example:

--- a/docs/release_notes/ReleaseNotes-2.4.0.md
+++ b/docs/release_notes/ReleaseNotes-2.4.0.md
@@ -8,6 +8,8 @@
 * Add Date, Last-Modified and Cache-Control headers to all responses
 * Session-ID now logged for allow/report commands
 * Improved logging to show line numbers for Lua errors
+* Enable TCP keepalive for redis connections
+* Configurable timeout for R/W on redis connections
 
 ## Bug Fixes/Changes
 * Fix duplicate command stats under some circumstances
@@ -64,6 +66,20 @@ The allow and report logs will now contain session_id information.
 The Lua wrapper code has been updated to provide better traceback
 information, including line numbers, for Lua errors. This helps when
 writing Lua policy that triggers a Lua exception.
+
+## Enable TCP keepalive for redis connections
+
+Redis connections could be timed-out by middleboxes, which would not
+be detected because keepalive was not enabled for Redis
+connections. Now it is enabled (always).
+
+## Configurable timeout for R/W on redis connections
+
+Previously reads from and writes to Redis were subject to the
+underlying socket timeout defaults. Now the timeout defaults to 100000
+microseconds, and is configurable with new Lua functions:
+blacklistPersistRWTimeout() and whitelistPersistRWTimeout(). See
+wforce.conf for more details.
 
 ## Fix Duplicate Command Stats
 

--- a/regression-tests/wforce3.conf
+++ b/regression-tests/wforce3.conf
@@ -3,7 +3,9 @@ setKey("Ay9KXgU3g4ygK+qWT0Ut4gH8PPz02gbtPeXWPdjD0HE=")
 controlSocket("0.0.0.0:4106")
 
 blacklistPersistDB("127.0.0.1", 6379)
+blacklistPersistRWTimeout(0, 50000)
 whitelistPersistDB("127.0.0.1", 6379)
+whitelistPersistRWTimeout(0, 50000)
 
 setSiblings({"127.0.0.1:4001"})
 addSibling("127.0.0.1:4004:tcp");

--- a/wforce/blackwhitelist.cc
+++ b/wforce/blackwhitelist.cc
@@ -558,6 +558,12 @@ void BlackWhiteListDB::setConnectTimeout(int timeout)
   redis_timeout = timeout; // atomic
 }
 
+void BlackWhiteListDB::setRWTimeout(int timeout_secs, int timeout_usecs)
+{
+  redis_rw_timeout_usecs = timeout_usecs; // atomic
+  redis_rw_timeout_secs = timeout_secs; // atomic
+}
+
 bool BlackWhiteListDB::checkSetupContext()
 {
   if (redis_context == NULL || redis_context->err) {
@@ -579,6 +585,20 @@ bool BlackWhiteListDB::checkSetupContext()
       else
         incPrometheusRedisWLConnFailed();
       return false;
+    }
+    else {
+      struct timeval tv;
+      tv.tv_sec = static_cast<time_t>(redis_rw_timeout_secs);
+      tv.tv_usec = static_cast<suseconds_t>(redis_rw_timeout_usecs);
+      if (redisSetTimeout(redis_context, tv) == REDIS_ERR) {
+        errlog("Could not set Redis Timeout to %u seconds, %u microseconds", tv.tv_sec, tv.tv_usec);
+      }
+      else {
+        infolog("Set Redis RW Timeout to %u seconds, %u microseconds", tv.tv_sec, tv.tv_usec);
+      }
+      if (redisEnableKeepAlive(redis_context) == REDIS_ERR) {
+        errlog("Could not enable Redis KeepAlive");
+      }
     }
   }
   return true;

--- a/wforce/blackwhitelist.cc
+++ b/wforce/blackwhitelist.cc
@@ -592,12 +592,14 @@ bool BlackWhiteListDB::checkSetupContext()
       tv.tv_usec = static_cast<suseconds_t>(redis_rw_timeout_usecs);
       if (redisSetTimeout(redis_context, tv) == REDIS_ERR) {
         errlog("Could not set Redis Timeout to %u seconds, %u microseconds", tv.tv_sec, tv.tv_usec);
+        throw WforceException("Error: could not set Redis Timeout in BlackWhitelist");
       }
       else {
         infolog("Set Redis RW Timeout to %u seconds, %u microseconds", tv.tv_sec, tv.tv_usec);
       }
       if (redisEnableKeepAlive(redis_context) == REDIS_ERR) {
         errlog("Could not enable Redis KeepAlive");
+        throw WforceException("Error: Could not enable Redis KeepAlive in BlackWhitelist");
       }
     }
   }

--- a/wforce/blackwhitelist.hh
+++ b/wforce/blackwhitelist.hh
@@ -78,6 +78,7 @@ public:
     redis_context = NULL;
     redis_port = 6379;
     redis_timeout=1;
+    redis_rw_timeout_usecs = 100000;
   }
   BlackWhiteListDB(const BlackWhiteListDB&) = delete;
 
@@ -123,6 +124,7 @@ public:
   std::vector<BlackWhiteListEntry> getIPLoginEntries() const;
 
   void setConnectTimeout(int timeout);
+  void setRWTimeout(int timeout_secs, int timeout_usecs);
 
   const std::string& getIPRetMsg() const { return ip_ret_msg;}
   const std::string& getLoginRetMsg() const { return login_ret_msg; }
@@ -161,6 +163,8 @@ private:
   unsigned int redis_port;
   redisContext* redis_context;
   std::atomic<int> redis_timeout;
+  std::atomic<int> redis_rw_timeout_secs;
+  std::atomic<int> redis_rw_timeout_usecs;
   std::string redis_prefix = {"wfbl"};
   BLWLDBType db_type;
   std::string ip_ret_msg;

--- a/wforce/wforce-lua.cc
+++ b/wforce/wforce-lua.cc
@@ -735,6 +735,7 @@ vector<std::function<void(void)>> setupLua(bool client, bool multi_lua, LuaConte
       });
     c_lua.writeFunction("blacklistPersistReplicated", []() { g_bl_db.persistReplicated(); });
     c_lua.writeFunction("blacklistPersistConnectTimeout", [](int timeout_secs) { g_bl_db.setConnectTimeout(timeout_secs); });
+    c_lua.writeFunction("blacklistPersistRWTimeout", [](int timeout_secs, int timeout_usecs) { g_bl_db.setRWTimeout(timeout_secs, timeout_usecs); });
     c_lua.writeFunction("setBlacklistIPRetMsg", [](const std::string& msg) {
         g_bl_db.setIPRetMsg(msg);
       });
@@ -749,7 +750,7 @@ vector<std::function<void(void)>> setupLua(bool client, bool multi_lua, LuaConte
     c_lua.writeFunction("blacklistPersistDB", [](const std::string& ip, unsigned int port) {});
     c_lua.writeFunction("blacklistPersistReplicated", []() {});
     c_lua.writeFunction("blacklistPersistConnectTimeout", [](int timeout_secs) {});
-    c_lua.writeFunction("setBlacklistIPRetMsg", [](const std::string& msg) {});
+    c_lua.writeFunction("blacklistPersistRWTimeout", [](int timeout_secs, int timeout_usecs) {});
     c_lua.writeFunction("setBlacklistLoginRetMsg", [](const std::string& msg) {});
     c_lua.writeFunction("setBlacklistIPLoginRetMsg", [](const std::string& msg) {});
   }
@@ -866,11 +867,14 @@ vector<std::function<void(void)>> setupLua(bool client, bool multi_lua, LuaConte
       });
     c_lua.writeFunction("whitelistPersistReplicated", []() { g_wl_db.persistReplicated(); });
     c_lua.writeFunction("whitelistPersistConnectTimeout", [](int timeout_secs) { g_wl_db.setConnectTimeout(timeout_secs); });
+    c_lua.writeFunction("whitelistPersistRWTimeout", [](int timeout_secs, int timeout_usecs) { g_wl_db.setRWTimeout(timeout_secs, timeout_usecs); });
+
   }
   else {
     c_lua.writeFunction("whitelistPersistDB", [](const std::string& ip, unsigned int port) {});
     c_lua.writeFunction("whitelistPersistReplicated", []() {});
     c_lua.writeFunction("whitelistPersistConnectTimeout", [](int timeout_secs) {});
+    c_lua.writeFunction("whitelistPersistRWTimeout", [](int timeout_secs, int timeout_usecs) {});
   }
   // End whitelists
   


### PR DESCRIPTION
This PR adds the following to the redis black/whitelist capability:

1) Enable TCP keepalive for redis connections
2) Add a configurable timeout for reads/writes on redis connections. Defaults to 0 seconds and 100,000 microseconds.

Fixes #313 