### PR TITLE
Sibling fixes

### DIFF
--- a/wforce/wforce-sibling.cc
+++ b/wforce/wforce-sibling.cc
@@ -109,17 +109,19 @@ Sibling::~Sibling()
 
 void Sibling::checkIgnoreSelf(const ComboAddress& ca)
 {
-  ComboAddress actualLocal;
-  actualLocal.sin4.sin_family = ca.sin4.sin_family;
-  socklen_t socklen = actualLocal.getSocklen();
-
-  if(getsockname(sockp->getHandle(), (struct sockaddr*) &actualLocal, &socklen) < 0) {
-    return;
-  }
-
-  actualLocal.sin4.sin_port = ca.sin4.sin_port;
-  if(actualLocal == rem) {
-    d_ignoreself=true;
+  if (proto != Protocol::NONE) {
+    ComboAddress actualLocal;
+    actualLocal.sin4.sin_family = ca.sin4.sin_family;
+    socklen_t socklen = actualLocal.getSocklen();
+    
+    if(getsockname(sockp->getHandle(), (struct sockaddr*) &actualLocal, &socklen) < 0) {
+      return;
+    }
+    
+    actualLocal.sin4.sin_port = ca.sin4.sin_port;
+    if(actualLocal == rem) {
+      d_ignoreself=true;
+    }
   }
 }
 

--- a/wforce/wforce-sibling.cc
+++ b/wforce/wforce-sibling.cc
@@ -69,6 +69,7 @@ void Sibling::connectSibling()
 Sibling::Sibling(const ComboAddress& ca, const Protocol& p) : rem(ca), proto(p), queue_thread_run(true), d_ignoreself(false)
 {
   if (proto != Protocol::NONE) {
+    connectSibling();
     // std::thread is moveable
     queue_thread = std::thread([this]() {
         thread_local bool init=false;
@@ -76,7 +77,6 @@ Sibling::Sibling(const ComboAddress& ca, const Protocol& p) : rem(ca), proto(p),
           setThreadName("wf/sibling-worker");
           init = true;
         }
-        connectSibling();
         while (true) {
           std::string msg;
           {


### PR DESCRIPTION
This fixes a crash bug due to dereferencing an uninitialised sockp member variable. 
The socket used by the Sibling class was originally initialised in the constructor
directly, by calling connectSibling().
It was then moved into a thread that itself was initialized in
the constructor. This created a possible race condition whereby the unique
pointer to the socket might not have been initialised before being referenced.
This PR fixes that by moving the connectSibling() call back into the
constructor directly.
It also prevent the checkIgnoreSelf() function from dereferencing sockp unless it has been initialised.