### PR TITLE
Support dynamic management of siblings and per-sibling encryption keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,6 +95,7 @@ stages:
   - name: deploy
     if: branch = master AND env(DOCKER_USERNAME) IS present AND env(DOCKER_PASSWORD) IS present
 before_script:
+ - echo "$DOCKER_PASSWORD"
  - echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
  - git clone https://github.com/jupp0r/prometheus-cpp.git
  - ( cd prometheus-cpp && git checkout tags/v0.9.0 -b v0.9.0 )

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,6 @@ stages:
   - name: deploy
     if: branch = master AND env(DOCKER_USERNAME) IS present AND env(DOCKER_PASSWORD) IS present
 before_script:
- - echo "$DOCKER_PASSWORD"
  - echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
  - git clone https://github.com/jupp0r/prometheus-cpp.git
  - ( cd prometheus-cpp && git checkout tags/v0.9.0 -b v0.9.0 )

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: cpp
 dist: trusty
-env:
-  global:
-    - secure: "LzLVM/dN1L/MCqBrU3oWXFg86L6denRTcH+CdxOZWu5Y5PxWTzmfxYvPQS+C7EsVp8cuaS54vPy39HihJIYG5wmBBZxRhq3pNSJt25+dxx4Qe/WXooxlkCQ6JKhJB8vBCHEFPFd5CKlZOd6QacauS18KAQNZx+D/wWtT+f19Mata+C/POGbIa4+JQ9imwSPDJg+wpTSbgjfvuf/UyQFMXIXI83fjFx90+c18iLjv8b0xyCvIieIxjFR5wyZCeoXvlQYLkmObxdFedQaiTzo5EJZwsYzfKfF1ltGf45/olMVsSjI/tOOGxmprCk2tS2q1GVd/H+Cz27SqgXJIRSUogCa0r3mSfQ8+SpiM1du6OEYf823/WpOO8H6VrokRmdnjvizBicjYVs93MSFWm73LVbRsHncBQvqKw4J1VEPQRlluCOwg+yFbHFFyH6wdtIvAfxvekVym717WlmDk9wmrielPRQ6YfQKp4nRkuu4bgWTO27vVo1MRdet7DaNOuqyoYRRfoINkL8LiHh1lM1DUdIVKMP1M0r1lzZVKritw45/GoLTfx1k2Muz/gCg9QczQmXnyX8CnsTtengNDcFfuQ2TeP77YqtGN1ewlpG8jYq5DZOvzOEzJCRxUyqlPCNEanpJXQkmRzMPsy0c6P2Ac7GIo4/Wmk+YHrvbCdCrtLtU="
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,6 +95,7 @@ stages:
   - name: deploy
     if: branch = master AND env(DOCKER_USERNAME) IS present AND env(DOCKER_PASSWORD) IS present
 before_script:
+ - echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
  - git clone https://github.com/jupp0r/prometheus-cpp.git
  - ( cd prometheus-cpp && git checkout tags/v0.9.0 -b v0.9.0 )
  - (cd prometheus-cpp && git submodule init && git submodule update && mkdir _build && cd _build && cmake .. -DBUILD_SHARED_LIBS=off -DENABLE_PULL=off -DENABLE_PUSH=off -DENABLE_COMPRESSION=off && make && sudo make install)

--- a/common/sholder.hh
+++ b/common/sholder.hh
@@ -55,7 +55,7 @@ template<typename T>
 class LocalStateHolder
 {
 public:
-  explicit LocalStateHolder(GlobalStateHolder<T>* source) : d_source(source)
+  explicit LocalStateHolder(const GlobalStateHolder<T>* source) : d_source(source)
   {}
 
   const T* operator->()  // fast const-only access, but see "read-only" above
@@ -88,7 +88,7 @@ class GlobalStateHolder
 public:
   GlobalStateHolder() : d_state(std::make_shared<T>())
   {}
-  LocalStateHolder<T> getLocal()
+  LocalStateHolder<T> getLocal() const
   {
     return LocalStateHolder<T>(this);
   }

--- a/common/sstuff.hh
+++ b/common/sstuff.hh
@@ -198,7 +198,7 @@ public:
         throw NetworkError(strerror(errno));
       }
       else {
-        struct pollfd pf = { d_socket, POLLRDNORM, 0 };
+        struct pollfd pf = { d_socket, POLLWRNORM, 0 };
         int poll_ret;
         poll_ret = poll(&pf, 1, timeout);
         int saved_errno = errno;
@@ -211,6 +211,11 @@ public:
         }
         if (poll_ret <=0) {
           throw NetworkError(strerror(saved_errno));
+        }
+        else {
+          if (!(pf.revents & POLLWRNORM)) {
+            throw NetworkError("Connection timed out");
+          }
         }
       }
     }

--- a/common/sstuff.hh
+++ b/common/sstuff.hh
@@ -198,7 +198,7 @@ public:
         throw NetworkError(strerror(errno));
       }
       else {
-        struct pollfd pf = { d_socket, POLLWRNORM, 0 };
+        struct pollfd pf = { d_socket, POLLOUT, 0 };
         int poll_ret;
         poll_ret = poll(&pf, 1, timeout);
         int saved_errno = errno;

--- a/common/sstuff.hh
+++ b/common/sstuff.hh
@@ -209,13 +209,11 @@ public:
         if(fcntl(d_socket, F_SETFL, arg) < 0) {
           throw NetworkError(strerror(errno));
         }
-        if (poll_ret <=0) {
+        if (poll_ret < 0) {
           throw NetworkError(strerror(saved_errno));
         }
-        else {
-          if (!(pf.revents & POLLWRNORM)) {
-            throw NetworkError("Connection timed out");
-          }
+        else if (poll_ret == 0) {
+          throw NetworkError("Connection timed out");
         }
       }
     }

--- a/docker/Makefile.am
+++ b/docker/Makefile.am
@@ -26,13 +26,10 @@ clean_elastic: stop
 	docker volume rm docker_esdata
 	rm $(COMPOSE_TARGET)
 
-clean_geoip:
-	rm -rf logstash/geoip/*
-
 clean_docker:
 	docker-compose down -v
 
-clean: clean_docker clean_geoip
+clean: clean_docker
 
 regression-gcc: build_image start
 	$(DCMP) exec $(REGRESSION_SERVICE) docker/regression/regression.sh gcc g++

--- a/docs/manpages/wforce.conf.5.md
+++ b/docs/manpages/wforce.conf.5.md
@@ -61,37 +61,53 @@ cannot be called inside the allow/report/reset functions:
 
         addCustomStat("custom_stat1")
 
-* setSiblings(\<list of IP[:port[:protocol]]\>) - Set the list of siblings to which
+* setSiblings(\<list of IP/Host[:port[:protocol]]\>) - Set the list of siblings to which
   stats db and blacklist/whitelist data should be replicated. If port
   is not specified it defaults to 4001.  If protocol is not specified
   it defaults to udp. This function is safe to call while wforce is running. For example:
   
-		setSiblings({"127.0.1.2", "127.0.1.3:4004", "127.0.2.23:4004:tcp"})
+		setSiblings({"127.0.1.2", "sibling1.example.com:4004", "[::1]:4004:tcp"})
 
-* addSibling(\<IP[:port[:protocol]]\>) - Add a sibling to the list to which all
-  stats db and blacklist/whitelist data should be replicated.  If port
-  is not specified it defaults to 4001. If protocol is not specified
+* setSiblingsWithKey(\<list of {IP/Host[:port[:protocol]], Encryption Key\>) - Identical
+  to setSiblings() except that it allows an encryption key to be specified for
+  each sibling. For example:
+
+  	setSiblingsWithKey({{"127.0.1.2", "Ay9KXgU3g4ygK+qWT0Ut4gH8PPz02gbtPeXWPdjD0HE="}, {"127.0.1.3:4004:tcp", "KaiQkCHloe2ysXv2HbxBAFqHI4N8+ahmwYwsbYlDdF0="}})
+
+* addSibling(\<IP/Hostname[:port[:protocol]]\>) - Add a sibling to the list to which all
+  stats db and blacklist/whitelist data should be replicated. Use [] to enclose
+  IPv6 addresses. If port is not specified it defaults to 4001. If protocol is not specified
   it defaults to udp. This function is safe to call while wforce is running. For example:
-  
-		addSibling("192.168.1.23")
-		addSibling("192.168.1.23:4001:udp")
-		addSibling("192.168.1.23:4003:tcp")
 
-* removeSibling(\<IP[:port[:protocol]]\>) - Remove a sibling to the list to which all
-  stats db and blacklist/whitelist data should be replicated.  If port
+        addSibling("192.168.1.23")
+        addSibling("192.168.1.23:4001:udp")
+        addSibling("192.168.1.23:4003:tcp")
+        addSibling("[::1]:4003:tcp")
+        addSibling("sibling1.example.com")
+
+* addSiblingWithKey(\<IP[:port[:protocol]]\>, \<Encryption Key\>) - Identical 
+  to addSibling(), except that an encryption key is specified to enable per-sibling
+  encryption.For example:
+
+  	addSiblingWithKey("192.168.1.23", "Ay9KXgU3g4ygK+qWT0Ut4gH8PPz02gbtPeXWPdjD0HE=")
+
+* removeSibling(\<IP/Host[:port[:protocol]]\>) - Remove a sibling to the list to which all
+  stats db and blacklist/whitelist data should be replicated.  Use [] to enclose
+  IPv6 addresses. If port
   is not specified it defaults to 4001. If protocol is not specified
   it defaults to udp. This function is safe to call while wforce is running. For example:
 
   	removeSibling("192.168.1.23")
-  	removeSibling("192.168.1.23:4001:udp")
-  	removeSibling("192.168.1.23:4003:tcp")
+  	removeSibling("sibling1.example.com:4001:udp")
+  	removeSibling("[::1]:4003:tcp")
 
 * siblingListener(\<IP[:port]\>) - Listen for reports from siblings on
   the specified IP address and port.  If port is not specified
   it defaults to 4001. Wforce will always listen on both UDP and TCP
   ports. For example:
   
-		siblingListener("0.0.0.0:4001")
+        siblingListener("0.0.0.0:4001")
+        siblingListener("[::1]:4001")
 
 * setSiblingConnectTimeout(\<timeout ms\>) - Sets a timeout in milliseconds 
   for new connections to siblings. Defaults to 5000 ms (5 seconds). For example:
@@ -478,7 +494,10 @@ cannot be called inside the allow/report/reset functions:
   configured in siblingListener() and defaults to 4001), and when it
   is finished it will notify this instance of wforce using the
   callback address (this address should have the same port as
-  configured in webserver and defaults to 8084). For
+  configured in webserver and defaults to 8084). N.B. It should be noted
+  that the encryption key of the local instance is sent to the sync host,
+  so to protect the confidentiality of the key, you may want to consider
+  running an HTTPS reverse proxy in front of the sync host. For
   example:
 
         -- Add 10.2.3.1:8084 as a sync host,
@@ -486,6 +505,12 @@ cannot be called inside the allow/report/reset functions:
         -- Send the DB dump to 10.2.1.1:4001
         -- and let me know on 10.2.1.1:8084 when the dump is finished
         addSyncHost("10.2.3.1:8084", "super", "10.2.1.1:4001", "10.2.1.1:8084") 
+        -- Add https://10.2.3.1:8084 as a sync host,
+        -- and use the password "super"
+        -- Send the DB dump to https://10.2.1.1:4001
+        -- Note this config requires HTTPS reverse proxies in front of both
+        -- wforce instances
+        addSyncHost("https://10.2.3.1:8084", "super", "10.2.1.1:4001", "https://10.2.1.1:8084") 
 
 * setMinSyncHostUptime(\<seconds\>) - The minimum time that any sync
   host must have been up for it to be able to send me the contents of

--- a/docs/manpages/wforce.conf.5.md
+++ b/docs/manpages/wforce.conf.5.md
@@ -64,18 +64,27 @@ cannot be called inside the allow/report/reset functions:
 * setSiblings(\<list of IP[:port[:protocol]]\>) - Set the list of siblings to which
   stats db and blacklist/whitelist data should be replicated. If port
   is not specified it defaults to 4001.  If protocol is not specified
-  it defaults to udp. For example:
+  it defaults to udp. This function is safe to call while wforce is running. For example:
   
 		setSiblings({"127.0.1.2", "127.0.1.3:4004", "127.0.2.23:4004:tcp"})
 
 * addSibling(\<IP[:port[:protocol]]\>) - Add a sibling to the list to which all
   stats db and blacklist/whitelist data should be replicated.  If port
   is not specified it defaults to 4001. If protocol is not specified
-  it defaults to udp. For example:
+  it defaults to udp. This function is safe to call while wforce is running. For example:
   
 		addSibling("192.168.1.23")
 		addSibling("192.168.1.23:4001:udp")
 		addSibling("192.168.1.23:4003:tcp")
+
+* removeSibling(\<IP[:port[:protocol]]\>) - Remove a sibling to the list to which all
+  stats db and blacklist/whitelist data should be replicated.  If port
+  is not specified it defaults to 4001. If protocol is not specified
+  it defaults to udp. This function is safe to call while wforce is running. For example:
+
+  	removeSibling("192.168.1.23")
+  	removeSibling("192.168.1.23:4001:udp")
+  	removeSibling("192.168.1.23:4003:tcp")
 
 * siblingListener(\<IP[:port]\>) - Listen for reports from siblings on
   the specified IP address and port.  If port is not specified
@@ -84,10 +93,15 @@ cannot be called inside the allow/report/reset functions:
   
 		siblingListener("0.0.0.0:4001")
 
+* setSiblingConnectTimeout(\<timeout ms\>) - Sets a timeout in milliseconds 
+  for new connections to siblings. Defaults to 5000 ms (5 seconds). For example:
+
+        setSiblingConnectTimeout(1000)
+
 * setMaxSiblingQueueSize(\<size\>) - Sets the maximum size of the
-  queue for replication events waiting to be processed. Defaults
-  to 5000. This is only to handle short-term spikes in load/latency -
-  if error messages relating to the queue max size being reached are
+  send and receive queues for replication events waiting to be processed.
+  Defaults to 5000. This is only to handle short-term spikes in load/latency -
+  if error messages relating to the recv queue max size being reached are
   seen, then you should consider using sharded string stats dbs
   (newShardedStringStatsDB), and/or tuning the stats db expiry sleep
   time (twSetExpireSleep).

--- a/docs/swagger/wforce_api.7.yml
+++ b/docs/swagger/wforce_api.7.yml
@@ -434,6 +434,93 @@ paths:
           description: unexpected error
           schema:
             $ref: "#/definitions/CustomError"
+  /?command=addSibling:
+    post:
+      description: This is a request to add a new Sibling for replication purposes.
+      operationId: addSibling
+      produces:
+        - application/json
+      parameters:
+        - name: "addSibling"
+          in: body
+          description: "Details about the Sibling to add"
+          required: true
+          schema:
+            $ref: "#/definitions/addSiblingParams"
+      responses:
+        "200":
+          description: "addSibling response"
+          schema:
+            type: object
+            required:
+              - status
+            properties:
+              status:
+                type: string
+            example:
+              status: ok
+        default:
+          description: unexpected error
+          schema:
+            $ref: "#/definitions/Error"
+  /?command=removeSibling:
+    post:
+      description: This is a request to add remove a Sibling for replication purposes.
+      operationId: removeSibling
+      produces:
+        - application/json
+      parameters:
+        - name: "removeSibling"
+          in: body
+          description: "Details about the Sibling to remove"
+          required: true
+          schema:
+            $ref: "#/definitions/removeSiblingParams"
+      responses:
+        "200":
+          description: "removeSibling response"
+          schema:
+            type: object
+            required:
+              - status
+            properties:
+              status:
+                type: string
+            example:
+              status: ok
+        default:
+          description: unexpected error
+          schema:
+            $ref: "#/definitions/Error"
+  /?command=setSiblings:
+    post:
+      description: This is a request to set the Siblings for replication purposes.
+      operationId: setSiblings
+      produces:
+        - application/json
+      parameters:
+        - name: "setSiblings"
+          in: body
+          description: "Details about the Sibling to add"
+          required: true
+          schema:
+            $ref: "#/definitions/setSiblingsParams"
+      responses:
+        "200":
+          description: "setSiblings response"
+          schema:
+            type: object
+            required:
+              - status
+            properties:
+              status:
+                type: string
+            example:
+              status: ok
+        default:
+          description: unexpected error
+          schema:
+            $ref: "#/definitions/Error"
   /metrics:
     get:
       description: "Retrieve prometheus metrics"
@@ -776,6 +863,8 @@ definitions:
         type: string
       callback_auth_pw:
         type: string
+      encryption_key:
+        type: string
   dumpEntriesParams:
     type: object
     required:
@@ -786,3 +875,48 @@ definitions:
         type: string
       dump_port:
         type: integer
+  addSiblingParams:
+    type: object
+    required:
+      - sibling_host
+      - sibling_port
+    properties:
+      sibling_host:
+        type: string
+      sibling_port:
+        type: integer
+      sibling_protocol:
+        type: string
+        enum: [tcp, udp]
+      encryption_key:
+        type: string
+  removeSiblingParams:
+    type: object
+    required:
+      - sibling_host
+      - sibling_port
+    properties:
+      sibling_host:
+        type: string
+      sibling_port:
+        type: integer
+  setSiblingsParams:
+    type: object
+    properties:
+      siblings:
+        type: array
+        items:
+          type: object
+          required:
+            - sibling_host
+            - sibling_port
+          properties:
+            sibling_host:
+              type: string
+            sibling_port:
+              type: integer
+            sibling_protocol:
+              type: string
+              enum: [ tcp, udp ]
+            encryption_key:
+              type: string

--- a/regression-tests/test_Replication.py
+++ b/regression-tests/test_Replication.py
@@ -326,9 +326,9 @@ class TestTimeWindowsReplication(ApiTestCase):
         self.assertNotEqual(str.find(json.dumps(j), '13.13.13.13'), -1)
 
     def test_AddRemoveSiblings(self):
-        self.removeSibling("127.0.0.1", 4002)
-        self.addSibling("127.0.0.1", 4002, "udp", "KaiQkCHloe2ysXv2HbxBAFqHI4N8+ahmwYwsbYlDdF0=")
-        self.addBLEntryIP('9.2.4.6', 60, "remove and add sibling test")
+        self.assertEqual(self.removeSibling("127.0.0.1", 4002).ok, True)
+        self.assertEqual(self.addSibling("127.0.0.1", 4002, "udp", "KaiQkCHloe2ysXv2HbxBAFqHI4N8+ahmwYwsbYlDdF0=").ok, True)
+        self.assertEqual(self.addBLEntryIP('9.2.4.6', 60, "remove and add sibling test").ok, True)
 
         time.sleep(1)
 
@@ -337,12 +337,12 @@ class TestTimeWindowsReplication(ApiTestCase):
         self.assertNotEqual(str.find(json.dumps(j), '9.2.4.6'), -1)
 
     def test_SetSiblings(self):
-        self.setSiblings({"siblings": [
+        self.assertEqual(self.setSiblings({"siblings": [
             {"sibling_host": "127.0.0.1", "sibling_port": 4001, "sibling_proto": "udp"},
             {"sibling_host": "127.0.0.1", "sibling_port": 4002, "sibling_proto": "udp", "encryption_key": "KaiQkCHloe2ysXv2HbxBAFqHI4N8+ahmwYwsbYlDdF0="},
             {"sibling_host": "127.0.0.1", "sibling_port": 4004, "sibling_proto": "tcp", "encryption_key": "lykfkV/07VPMK80nLNOTWtlMsLz9y7X0r6t9zcFNTmE="}
-        ]})
-        self.addBLEntryIP('10.2.4.6', 60, "remove and add sibling test")
+        ]}).ok, True)
+        self.assertEqual(self.addBLEntryIP('10.2.4.6', 60, "remove and add sibling test").ok, True)
 
         time.sleep(1)
 

--- a/regression-tests/test_Replication.py
+++ b/regression-tests/test_Replication.py
@@ -275,6 +275,10 @@ class TestTimeWindowsReplication(ApiTestCase):
         self.assertEquals(j['status'], 0)
         
     def test_resetField(self):
+        r = self.resetLogins("resetFieldTest")
+        j = r.json()
+        self.assertEquals(j['r_attrs']['countLogins'], '0')
+
         r = self.incLogins("resetFieldTest")
         j = r.json()
         self.assertEquals(j['r_attrs']['countLogins'], '1')

--- a/regression-tests/test_Replication.py
+++ b/regression-tests/test_Replication.py
@@ -338,9 +338,9 @@ class TestTimeWindowsReplication(ApiTestCase):
 
     def test_SetSiblings(self):
         self.assertEqual(self.setSiblings({"siblings": [
-            {"sibling_host": "127.0.0.1", "sibling_port": 4001, "sibling_proto": "udp"},
-            {"sibling_host": "127.0.0.1", "sibling_port": 4002, "sibling_proto": "udp", "encryption_key": "KaiQkCHloe2ysXv2HbxBAFqHI4N8+ahmwYwsbYlDdF0="},
-            {"sibling_host": "127.0.0.1", "sibling_port": 4004, "sibling_proto": "tcp", "encryption_key": "lykfkV/07VPMK80nLNOTWtlMsLz9y7X0r6t9zcFNTmE="}
+            {"sibling_host": "127.0.0.1", "sibling_port": 4001, "sibling_protocol": "udp"},
+            {"sibling_host": "127.0.0.1", "sibling_port": 4002, "sibling_protocol": "udp", "encryption_key": "KaiQkCHloe2ysXv2HbxBAFqHI4N8+ahmwYwsbYlDdF0="},
+            {"sibling_host": "127.0.0.1", "sibling_port": 4004, "sibling_protocol": "tcp", "encryption_key": "lykfkV/07VPMK80nLNOTWtlMsLz9y7X0r6t9zcFNTmE="}
         ]}).ok, True)
         self.assertEqual(self.addBLEntryIP('10.2.4.6', 60, "remove and add sibling test").ok, True)
 

--- a/regression-tests/test_Replication.py
+++ b/regression-tests/test_Replication.py
@@ -324,3 +324,29 @@ class TestTimeWindowsReplication(ApiTestCase):
         r = self.getWLFuncReplica();
         j = r.json()
         self.assertNotEqual(str.find(json.dumps(j), '13.13.13.13'), -1)
+
+    def test_AddRemoveSiblings(self):
+        self.removeSibling("127.0.0.1", 4002)
+        self.addSibling("127.0.0.1", 4002, "udp", "KaiQkCHloe2ysXv2HbxBAFqHI4N8+ahmwYwsbYlDdF0=")
+        self.addBLEntryIP('9.2.4.6', 60, "remove and add sibling test")
+
+        time.sleep(1)
+
+        r = self.getBLFuncReplica()
+        j = r.json()
+        self.assertNotEqual(str.find(json.dumps(j), '9.2.4.6'), -1)
+
+    def test_SetSiblings(self):
+        self.setSiblings({"siblings": [
+            {"sibling_host": "127.0.0.1", "sibling_port": 4001, "sibling_proto": "udp"},
+            {"sibling_host": "127.0.0.1", "sibling_port": 4002, "sibling_proto": "udp", "encryption_key": "KaiQkCHloe2ysXv2HbxBAFqHI4N8+ahmwYwsbYlDdF0="},
+            {"sibling_host": "127.0.0.1", "sibling_port": 4004, "sibling_proto": "tcp", "encryption_key": "lykfkV/07VPMK80nLNOTWtlMsLz9y7X0r6t9zcFNTmE="}
+        ]})
+        self.addBLEntryIP('10.2.4.6', 60, "remove and add sibling test")
+
+        time.sleep(1)
+
+        r = self.getBLFuncReplica();
+        j = r.json()
+        self.assertNotEqual(str.find(json.dumps(j), '10.2.4.6'), -1)
+

--- a/regression-tests/test_TimeWindows.py
+++ b/regression-tests/test_TimeWindows.py
@@ -196,6 +196,10 @@ class TestTimeWindows(ApiTestCase):
         self.assertEquals(j['status'], 0)
 
     def test_ResetField(self):
+        r = self.resetLogins("resetFieldTest")
+        j = r.json()
+        self.assertEquals(j['r_attrs']['countLogins'], '0')
+
         r = self.incLogins("resetFieldTest")
         j = r.json()
         self.assertEquals(j['r_attrs']['countLogins'], '1')

--- a/regression-tests/test_helper.py
+++ b/regression-tests/test_helper.py
@@ -174,7 +174,33 @@ class ApiTestCase(unittest.TestCase):
             self.docker_image_url("/?command=report"),
             data=json.dumps(payload),
             headers={'Content-Type': 'application/json'})
-    
+
+    def addSibling(self, host, port, protocol, key):
+        payload = dict()
+        payload['sibling_host'] = host
+        payload['sibling_port'] = port
+        payload['sibling_proto'] = protocol
+        payload['encryption_key'] = key
+        return self.session.post(
+            self.url("/?command=addSibling"),
+            data=json.dumps(payload),
+            headers={'Content-Type': 'application/json'})
+
+    def removeSibling(self, host, port):
+        payload = dict()
+        payload['sibling_host'] = host
+        payload['sibling_port'] = port
+        return self.session.post(
+            self.url("/?command=removeSibling"),
+            data=json.dumps(payload),
+            headers={'Content-Type': 'application/json'})
+
+    def setSiblings(self, payload):
+        return self.session.post(
+            self.url("/?command=addSibling"),
+            data=json.dumps(payload),
+            headers={'Content-Type': 'application/json'})
+
     def resetFunc(self, login, ip):
         return self.resetFuncInternal(login, ip, False)
 

--- a/regression-tests/test_helper.py
+++ b/regression-tests/test_helper.py
@@ -197,7 +197,7 @@ class ApiTestCase(unittest.TestCase):
 
     def setSiblings(self, payload):
         return self.session.post(
-            self.url("/?command=addSibling"),
+            self.url("/?command=setSiblings"),
             data=json.dumps(payload),
             headers={'Content-Type': 'application/json'})
 

--- a/regression-tests/wforce1.conf
+++ b/regression-tests/wforce1.conf
@@ -3,8 +3,8 @@ setKey("Ay9KXgU3g4ygK+qWT0Ut4gH8PPz02gbtPeXWPdjD0HE=")
 controlSocket("0.0.0.0:4104")
 
 addSibling("127.0.0.1:4001");
-addSibling("127.0.0.1:4002");
-addSibling("127.0.0.1:4004:tcp");
+addSiblingWithKey("127.0.0.1:4002", "KaiQkCHloe2ysXv2HbxBAFqHI4N8+ahmwYwsbYlDdF0=");
+addSiblingWithKey("127.0.0.1:4004:tcp", "lykfkV/07VPMK80nLNOTWtlMsLz9y7X0r6t9zcFNTmE=");
 siblingListener("0.0.0.0:4001")
 
 dofile("./wforce-tw.conf")

--- a/regression-tests/wforce2.conf
+++ b/regression-tests/wforce2.conf
@@ -1,8 +1,8 @@
 webserver("0.0.0.0:8085", "super")
-setKey("Ay9KXgU3g4ygK+qWT0Ut4gH8PPz02gbtPeXWPdjD0HE=")
+setKey("KaiQkCHloe2ysXv2HbxBAFqHI4N8+ahmwYwsbYlDdF0=")
 controlSocket("0.0.0.0:4105")
 
-addSibling("127.0.0.1:4001");
+addSiblingWithKey("127.0.0.1:4001", "Ay9KXgU3g4ygK+qWT0Ut4gH8PPz02gbtPeXWPdjD0HE=");
 addSibling("127.0.0.1:4002");
 siblingListener("0.0.0.0:4002")
 

--- a/regression-tests/wforce3.conf
+++ b/regression-tests/wforce3.conf
@@ -1,5 +1,5 @@
 webserver("0.0.0.0:8086", "super")
-setKey("Ay9KXgU3g4ygK+qWT0Ut4gH8PPz02gbtPeXWPdjD0HE=")
+setKey("MzfImn71m3bYrlPApe+PR7tY/RXoZ4IdpWvUc4o5OnQ=")
 controlSocket("0.0.0.0:4106")
 
 blacklistPersistDB("redis", 6379)
@@ -7,11 +7,11 @@ blacklistPersistRWTimeout(0, 50000)
 whitelistPersistDB("redis", 6379)
 whitelistPersistRWTimeout(0, 50000)
 
-setSiblings({"127.0.0.1:4001"})
-addSibling("127.0.0.1:4004:tcp");
+setSiblingsWithKey({{"127.0.0.1:4001", "Ay9KXgU3g4ygK+qWT0Ut4gH8PPz02gbtPeXWPdjD0HE="}})
+addSiblingWithKey("127.0.0.1:4004:tcp", "lykfkV/07VPMK80nLNOTWtlMsLz9y7X0r6t9zcFNTmE=");
 siblingListener("0.0.0.0:4003")
 
-addSyncHost("127.0.0.1:8084", "super", "127.0.0.1:4003", "127.0.0.1:8086")
+addSyncHost("http://127.0.0.1:8084", "super", "127.0.0.1:4003", "http://127.0.0.1:8086")
 setMinSyncHostUptime(10)
 
 dofile("./wforce-tw.conf")

--- a/regression-tests/wforce4.conf
+++ b/regression-tests/wforce4.conf
@@ -1,10 +1,11 @@
 webserver("0.0.0.0:8087", "super")
-setKey("Ay9KXgU3g4ygK+qWT0Ut4gH8PPz02gbtPeXWPdjD0HE=")
+setKey("lykfkV/07VPMK80nLNOTWtlMsLz9y7X0r6t9zcFNTmE=")
 controlSocket("0.0.0.0:4107")
 
 blacklistPersistDB("redis", 6379)
 
-setSiblings({"127.0.0.1:4001", "127.0.0.1:4002"});
+setSiblingsWithKey({{"127.0.0.1:4001", "Ay9KXgU3g4ygK+qWT0Ut4gH8PPz02gbtPeXWPdjD0HE="},
+                   {"127.0.0.1:4002", "KaiQkCHloe2ysXv2HbxBAFqHI4N8+ahmwYwsbYlDdF0="}});
 addSibling("127.0.0.1:4004:tcp");
 siblingListener("0.0.0.0:4004")
 

--- a/wforce/wforce-lua.cc
+++ b/wforce/wforce-lua.cc
@@ -51,25 +51,6 @@ using std::thread;
 
 static vector<std::function<void(void)>>* g_launchWork;
 
-void parseSiblingString(const std::string& str, std::string& ca_str, Sibling::Protocol& proto)
-{
-  std::vector<std::string> sres;
-  boost::split(sres, str, boost::is_any_of(":"));
-
-  if (sres.size() > 3) {
-    throw WforceException("Malformed sibling string: " + str + "(Format is <host>[:<port>[:<protocol>]]");
-  }
-  else if (sres.size() == 3) {
-    proto = Sibling::stringToProtocol(sres.back());
-    sres.pop_back();
-    ca_str = boost::join(sres, ":");
-  }
-  else {
-    proto = Sibling::Protocol::UDP;
-    ca_str = str;
-  }
-}
-
 std::vector<std::map<std::string, std::string>> getWLBLKeys(const std::vector<BlackWhiteListEntry>& blv, const char* key_name) {
   std::vector<std::map<std::string, std::string>> ret_vec;
   for (const auto& i : blv) {
@@ -249,24 +230,7 @@ vector<std::function<void(void)>> setupLua(bool client, bool multi_lua, LuaConte
 
   if (!multi_lua && !client) {
     c_lua.writeFunction("addSibling", [](const std::string& address) {
-      ComboAddress ca;
-      std::string ca_str;
-      Sibling::Protocol proto;
-      parseSiblingString(address, ca_str, proto);
-      try {
-        ca = ComboAddress(ca_str, 4001);
-      }
-      catch (const WforceException& e) {
-        const std::string errstr = (boost::format("%s [%s]. %s (%s)\n") % "addSibling() error parsing address/port" % address % "Make sure to use IP addresses not hostnames" % e.reason).str();
-        errlog(errstr.c_str());
-        g_outputBuffer += errstr;
-        return;
-      }
-      g_siblings.modify([ca, proto](vector<shared_ptr<Sibling>>& v) { v.push_back(std::make_shared<Sibling>(ca, proto)); });
-      // This is for sending when we know the port
-      addPrometheusReplicationSibling(ca.toStringWithPort());
-      // This is for receiving when the port may be ephemeral
-      addPrometheusReplicationSibling(ca.toString());
+      addSibling(address, g_siblings, g_outputBuffer);
     });
   }
   else {
@@ -275,52 +239,7 @@ vector<std::function<void(void)>> setupLua(bool client, bool multi_lua, LuaConte
 
   if (!multi_lua && !client) {
     c_lua.writeFunction("removeSibling", [](const std::string& address) {
-      ComboAddress ca;
-      std::string ca_str;
-      Sibling::Protocol proto;
-      parseSiblingString(address, ca_str, proto);
-      try {
-        ca = ComboAddress(ca_str, 4001);
-      }
-      catch (const WforceException& e) {
-        const std::string errstr = (boost::format("%s [%s]. %s (%s)\n") % "removeSibling() error parsing address/port" % address % "Make sure to use IP addresses not hostnames" % e.reason).str();
-        errlog(errstr.c_str());
-        g_outputBuffer += errstr;
-        return;
-      }
-      g_siblings.modify([ca, proto](vector<shared_ptr<Sibling>>& v) {
-        for (auto i = v.begin(); i != v.end();) {
-          if ((i->get()->rem == ca) && (i->get()->proto == proto)) {
-            i = v.erase(i);
-            break;
-          }
-          else {
-            i++;
-          }
-        }
-      });
-
-      bool found = false;
-      auto siblings = g_siblings.getLocal();
-      for (auto &s : *siblings) {
-        if (s->rem == ca) {
-          found = true;
-          break;
-        }
-      }
-      if (!found) {
-        removePrometheusReplicationSibling(ca.toStringWithPort());
-      }
-      found = false;
-      for (auto &s : *siblings) {
-        if (ComboAddress::addressOnlyEqual()(s->rem, ca)) {
-          found = true;
-          break;
-        }
-      }
-      if (!found) {
-        removePrometheusReplicationSibling(ca.toString());
-      }
+      removeSibling(address, g_siblings, g_outputBuffer);
     });
   }
   else {
@@ -329,26 +248,7 @@ vector<std::function<void(void)>> setupLua(bool client, bool multi_lua, LuaConte
 
   if (!multi_lua && !client) {
     c_lua.writeFunction("setSiblings", [](const vector<pair<int, string>>& parts) {
-      vector<shared_ptr<Sibling>> v;
-      for(const auto& p : parts) {
-        try {
-          std::string ca_string;
-          Sibling::Protocol proto;
-
-          parseSiblingString(p.second, ca_string, proto);
-          v.push_back(std::make_shared<Sibling>(ComboAddress(ca_string, 4001), proto));
-          // This is for sending when we know the port
-          addPrometheusReplicationSibling(ComboAddress(ca_string, 4001).toStringWithPort());
-          // This is for receiving when the port may be ephemeral
-          addPrometheusReplicationSibling(ComboAddress(ca_string, 4001).toString());
-        }
-        catch (const WforceException& e) {
-          const std::string errstr = (boost::format("%s [%s]. %s (%s)\n") % "addSibling() error parsing address/port" % p.second % "Make sure to use IP addresses not hostnames" % e.reason).str();
-          errlog(errstr.c_str());
-          g_outputBuffer += errstr;
-        }
-      }
-      g_siblings.setState(v);
+      setSiblings(parts, g_siblings, g_outputBuffer);
     });
   }
   else {

--- a/wforce/wforce-lua.cc
+++ b/wforce/wforce-lua.cc
@@ -193,9 +193,9 @@ vector<std::function<void(void)>> setupLua(bool client, bool multi_lua, LuaConte
   if (!multi_lua && !client) {
     c_lua.writeFunction("addSyncHost", [](const std::string& address, const std::string password, const std::string& sync_address, const std::string& webserver_address) {
       try {
-        g_sync_data.sync_hosts.push_back(std::make_pair(ComboAddress(address, 8084), password));
+        g_sync_data.sync_hosts.push_back(make_pair(address, password));
         g_sync_data.sibling_listen_addr = ComboAddress(sync_address, 4001);
-        g_sync_data.webserver_listen_addr = ComboAddress(webserver_address, 8084);
+        g_sync_data.webserver_listen_addr = webserver_address;
       }
       catch (const WforceException& e) {
         const std::string errstr = (boost::format("%s (%s)\n") % "addSyncHost(): Error parsing address/port. Make sure to use IP addresses not hostnames" % e.reason).str();
@@ -228,14 +228,22 @@ vector<std::function<void(void)>> setupLua(bool client, bool multi_lua, LuaConte
     c_lua.writeFunction("setMaxSiblingQueueSize", [](unsigned int size) {});
   }
 
-
   if (!multi_lua && !client) {
     c_lua.writeFunction("addSibling", [](const std::string& address) {
-      addSibling(address, g_siblings, g_outputBuffer);
+      (void)addSibling(address, g_siblings, g_outputBuffer);
     });
   }
   else {
     c_lua.writeFunction("addSibling", [](const std::string& address) { });
+  }
+
+  if (!multi_lua && !client) {
+    c_lua.writeFunction("addSiblingWithKey", [](const std::string& address, const std::string& key) {
+      (void)addSiblingWithKey(address, g_siblings, g_outputBuffer, key);
+    });
+  }
+  else {
+    c_lua.writeFunction("addSiblingWithKey", [](const std::string& address, const std::string& key) { });
   }
 
   if (!multi_lua && !client) {
@@ -248,8 +256,17 @@ vector<std::function<void(void)>> setupLua(bool client, bool multi_lua, LuaConte
   }
 
   if (!multi_lua && !client) {
+    c_lua.writeFunction("setSiblingsWithKey", [](const vector<std::pair<int, std::vector<std::pair<int, std::string>>>>& parts) {
+      (void)setSiblingsWithKey(parts, g_siblings, g_outputBuffer);
+    });
+  }
+  else {
+    c_lua.writeFunction("setSiblingsWithKey", [](const vector<std::pair<int, std::vector<std::pair<int, std::string>>>>& parts) { });
+  }
+
+  if (!multi_lua && !client) {
     c_lua.writeFunction("setSiblings", [](const vector<pair<int, string>>& parts) {
-      setSiblings(parts, g_siblings, g_outputBuffer);
+      (void)setSiblings(parts, g_siblings, g_outputBuffer);
     });
   }
   else {

--- a/wforce/wforce-lua.cc
+++ b/wforce/wforce-lua.cc
@@ -220,7 +220,8 @@ vector<std::function<void(void)>> setupLua(bool client, bool multi_lua, LuaConte
 
   if (!multi_lua) {
     c_lua.writeFunction("setMaxSiblingQueueSize", [](unsigned int size) {
-      setMaxSiblingQueueSize(size);
+      setMaxSiblingRecvQueueSize(size);
+      setMaxSiblingSendQueueSize(static_cast<size_t>(size));
     });
   }
   else {
@@ -253,6 +254,15 @@ vector<std::function<void(void)>> setupLua(bool client, bool multi_lua, LuaConte
   }
   else {
     c_lua.writeFunction("setSiblings", [](const vector<pair<int, string>>& parts) { });
+  }
+
+  if (!multi_lua && !client) {
+    c_lua.writeFunction("setSiblingConnectTimeout", [](int timeout_ms) {
+      setSiblingConnectTimeout(timeout_ms);
+    });
+  }
+  else {
+    c_lua.writeFunction("setSiblingConnectTimeout", [](int timeout_ms) { });
   }
 
   if (!multi_lua && !client) {

--- a/wforce/wforce-lua.cc
+++ b/wforce/wforce-lua.cc
@@ -50,6 +50,7 @@
 using std::thread;
 
 static vector<std::function<void(void)>>* g_launchWork;
+ComboAddress g_sibling_listen_addr;
 
 std::vector<std::map<std::string, std::string>> getWLBLKeys(const std::vector<BlackWhiteListEntry>& blv, const char* key_name) {
   std::vector<std::map<std::string, std::string>> ret_vec;
@@ -294,6 +295,7 @@ vector<std::function<void(void)>> setupLua(bool client, bool multi_lua, LuaConte
         g_outputBuffer += errstr;
         return;
       }
+      g_sibling_listen_addr = ca;
       auto launch = [ca]() {
         auto siblings = g_siblings.getLocal();
 

--- a/wforce/wforce-prometheus.hh
+++ b/wforce/wforce-prometheus.hh
@@ -90,6 +90,7 @@ public:
 
   void addReplicationSibling(const std::string& name);
   void removeReplicationSibling(const std::string& name);
+  void removeAllReplicationSiblings();
   void incReplicationSent(const std::string& name, bool success);
   void incReplicationRcvd(const std::string& name, bool success);
   void incReplicationConnFail(const std::string& name);
@@ -122,7 +123,8 @@ public:
     setReplRecvQueueSize(repl_queue_func());
     return PrometheusMetrics::serialize();
   }
-  
+protected:
+  void removeReplicationSiblingNoLock(const std::string& name);
 private:
   Family<Counter>* allow_status_family;
   std::map<std::string, Counter*> allow_status_metrics;
@@ -157,6 +159,7 @@ void incPrometheusAllowStatusMetric(const std::string& name);
 
 void addPrometheusReplicationSibling(const std::string& name);
 void removePrometheusReplicationSibling(const std::string& name);
+void removeAllPrometheusReplicationSiblings();
 void incPrometheusReplicationSent(const std::string& name, bool success);
 void incPrometheusReplicationRcvd(const std::string& name, bool success);
 void incPrometheusReplicationConnFail(const std::string& name);

--- a/wforce/wforce-prometheus.hh
+++ b/wforce/wforce-prometheus.hh
@@ -89,6 +89,7 @@ public:
   void incAllowStatusMetric(const std::string& name);
 
   void addReplicationSibling(const std::string& name);
+  void removeReplicationSibling(const std::string& name);
   void incReplicationSent(const std::string& name, bool success);
   void incReplicationRcvd(const std::string& name, bool success);
   void incReplicationConnFail(const std::string& name);
@@ -125,6 +126,9 @@ public:
 private:
   Family<Counter>* allow_status_family;
   std::map<std::string, Counter*> allow_status_metrics;
+  // This mutex is because replication siblings are allowed to change dynamically
+  // unlike the other mutexes
+  std::mutex repl_mutx;
   Family<Counter>* repl_sent_family;
   std::map<std::string, Counter*> repl_sent_ok_metrics;
   std::map<std::string, Counter*> repl_sent_err_metrics;
@@ -152,6 +156,7 @@ void addPrometheusAllowStatusMetric(const std::string& name);
 void incPrometheusAllowStatusMetric(const std::string& name);
 
 void addPrometheusReplicationSibling(const std::string& name);
+void removePrometheusReplicationSibling(const std::string& name);
 void incPrometheusReplicationSent(const std::string& name, bool success);
 void incPrometheusReplicationRcvd(const std::string& name, bool success);
 void incPrometheusReplicationConnFail(const std::string& name);

--- a/wforce/wforce-prometheus.hh
+++ b/wforce/wforce-prometheus.hh
@@ -129,7 +129,7 @@ private:
   Family<Counter>* allow_status_family;
   std::map<std::string, Counter*> allow_status_metrics;
   // This mutex is because replication siblings are allowed to change dynamically
-  // unlike the other mutexes
+  // unlike the other metrics
   std::mutex repl_mutx;
   Family<Counter>* repl_sent_family;
   std::map<std::string, Counter*> repl_sent_ok_metrics;

--- a/wforce/wforce-replication.cc
+++ b/wforce/wforce-replication.cc
@@ -54,7 +54,7 @@ struct SiblingQueueItem {
 static std::mutex g_sibling_queue_mutex;
 static std::queue<SiblingQueueItem> g_sibling_queue;
 static std::condition_variable g_sibling_queue_cv;
-size_t max_sibling_queue_size = 5000;
+static size_t max_sibling_queue_size = 5000;
 
 GlobalStateHolder<vector<shared_ptr<Sibling>>> g_siblings;
 unsigned int g_num_sibling_threads = WFORCE_NUM_SIBLING_THREADS;
@@ -291,7 +291,7 @@ void receiveReplicationOperations(const ComboAddress& local)
   }
 }
 
-void setMaxSiblingQueueSize(size_t size)
+void setMaxSiblingRecvQueueSize(size_t size)
 {
   max_sibling_queue_size = size;
 }

--- a/wforce/wforce-replication.cc
+++ b/wforce/wforce-replication.cc
@@ -170,7 +170,7 @@ void parseReceivedReplicationMsg(const std::string& msg, const ComboAddress& rem
   {
     std::lock_guard<std::mutex> lock(g_sibling_queue_mutex);
     if (g_sibling_queue.size() >= max_sibling_queue_size) {
-      errlog("parseReceivedReplicationMsg: max sibling queue size (%d) reached - dropping replication msg", max_sibling_queue_size);
+      errlog("parseReceivedReplicationMsg: max sibling recv queue size (%d) reached - dropping replication msg", max_sibling_queue_size);
       return;
     }
     else {

--- a/wforce/wforce-replication.cc
+++ b/wforce/wforce-replication.cc
@@ -99,17 +99,22 @@ void replicateOperation(const ReplicationOperation& rep_op)
 {
   auto siblings = g_siblings.getLocal();
   string msg = rep_op.serialize();
-  string packet;
+  string default_packet, sibling_packet;
 
-  encryptMsg(msg, packet);
+  encryptMsg(msg, default_packet);
 
   for(auto& s : *siblings) {
+    bool use_sibling_packet = false;
     if (s->d_has_key) {
       if (s->d_key != g_key) {
-        encryptMsgWithKey(msg, packet, s->d_key, s->d_nonce, s->mutx);
+        encryptMsgWithKey(msg, sibling_packet, s->d_key, s->d_nonce, s->mutx);
+        use_sibling_packet = true;
       }
     }
-    s->queueMsg(packet);
+    if (use_sibling_packet)
+      s->queueMsg(sibling_packet);
+    else
+      s->queueMsg(default_packet);
   }
 }
 

--- a/wforce/wforce-replication.hh
+++ b/wforce/wforce-replication.hh
@@ -39,6 +39,7 @@ void receiveReplicationOperations(const ComboAddress& local);
 void startReplicationWorkerThreads();
 
 void encryptMsg(const std::string& msg, std::string& packet);
+void encryptMsgWithKey(const std::string& msg, std::string& packet, const std::string& key, SodiumNonce& nonce, std::mutex& mutex);
 bool decryptMsg(const char* buf, size_t len, std::string& msg);
 
 void setMaxSiblingRecvQueueSize(size_t size);

--- a/wforce/wforce-replication.hh
+++ b/wforce/wforce-replication.hh
@@ -41,4 +41,4 @@ void startReplicationWorkerThreads();
 void encryptMsg(const std::string& msg, std::string& packet);
 bool decryptMsg(const char* buf, size_t len, std::string& msg);
 
-void setMaxSiblingQueueSize(size_t size);
+void setMaxSiblingRecvQueueSize(size_t size);

--- a/wforce/wforce-sibling.cc
+++ b/wforce/wforce-sibling.cc
@@ -299,7 +299,7 @@ void parseSiblingString(const std::string& str, ComboAddress& ca, Sibling::Proto
   else { // Everything else we can leave as it is
     address = host_port;
   }
-  ca = ComboAddress(address, 4001);
+  ca = ComboAddress(address, Sibling::defaultPort);
 }
 
 // siblingAddressPortExists returns true if a sibling already exists in the supplied siblings vector
@@ -342,7 +342,7 @@ bool removeSibling(const std::string& address,
     parseSiblingString(address, ca, proto);
   }
   catch (const WforceException& e) {
-    const std::string errstr = (boost::format("%s [%s]. %s (%s)\n") % "removeSibling() error parsing address/port" %
+    const std::string errstr = (boost::format("%s [%s]. %s (%s)") % "removeSibling() error parsing address/port" %
                                 address % "Make sure to use IP addresses not hostnames" % e.reason).str();
     errlog(errstr.c_str());
     output_buffer += errstr;
@@ -423,7 +423,7 @@ bool addSiblingWithKey(const std::string& address,
     parseSiblingString(address, ca, proto);
   }
   catch (const WforceException& e) {
-    const std::string errstr = (boost::format("%s [%s]. %s (%s)\n") % "addSibling() error parsing address/port" %
+    const std::string errstr = (boost::format("%s [%s]. %s (%s)") % "addSibling() error parsing address/port" %
                                 address % "Make sure to use IP addresses not hostnames" % e.reason).str();
     errlog(errstr.c_str());
     output_buffer += errstr;
@@ -439,7 +439,7 @@ bool addSibling(std::shared_ptr<Sibling> sibling, GlobalStateHolder<vector<share
 {
   // Ensure the Sibling isn't already there
   if (siblingAddressPortExists(siblings, sibling->rem)) {
-    const std::string errstr = (boost::format("%s [%s]\n") % "addSibling() cannot add duplicate sibling" %
+    const std::string errstr = (boost::format("%s [%s]") % "addSibling() cannot add duplicate sibling" %
                                 sibling->rem.toStringWithPort()).str();
     errlog(errstr.c_str());
     output_buffer += errstr;
@@ -502,7 +502,7 @@ bool setSiblingsWithKey(const std::vector<std::pair<int, std::vector<std::pair<i
       parseSiblingString(p.second[0].second, ca, proto);
       if ((p.second.size() != 2) && (p.second.size() != 4)) {
         errlog("setSiblings[WithKey](): Invalid values - was expecting 2 or 4 args, got %d", p.second.size());
-        output_buffer += "Invalid number of args to setSiblings[WithKey] - was expecting 2 args (sibling address & key) or 4 (sibling address, key, replicate sdb, replicate wlbl)";
+        output_buffer += "Invalid number of args - was expecting 2 args (sibling address & key) or 4 (sibling address, key, replicate sdb, replicate wlbl)";
         return false;
       }
       string raw_key;
@@ -513,7 +513,7 @@ bool setSiblingsWithKey(const std::vector<std::pair<int, std::vector<std::pair<i
       }
     }
     catch (const WforceException& e) {
-      const std::string errstr = (boost::format("%s [%s]. %s (%s)\n") % "setSiblings() error parsing address/port" %
+      const std::string errstr = (boost::format("%s [%s]. %s (%s)") % "setSiblings() error parsing address/port" %
                                   p.second[0].second % "Reason: " % e.reason).str();
       errlog(errstr.c_str());
       output_buffer += errstr;

--- a/wforce/wforce-sibling.cc
+++ b/wforce/wforce-sibling.cc
@@ -55,7 +55,9 @@ Sibling::Sibling(const ComboAddress& ca) : Sibling(ca, Protocol::UDP)
 Sibling::Sibling(const ComboAddress& ca,
                  const Protocol& p,
                  int timeout,
-                 size_t queue_size) : Sibling(ca, p, std::string(), timeout, queue_size)
+                 size_t queue_size,
+                 bool repl_send,
+                 bool wlbl_send) : Sibling(ca, p, std::string(), timeout, queue_size, repl_send, wlbl_send)
 {
 }
 
@@ -84,10 +86,14 @@ Sibling::Sibling(const ComboAddress& ca,
                  const Protocol& p,
                  const std::string& key,
                  int timeout,
-                 size_t queue_size) : rem(ca), proto(p),
+                 size_t queue_size,
+                 bool send_repl,
+                 bool send_wlbl) : rem(ca), proto(p),
                                       connect_timeout(timeout),
                                       max_queue_size(queue_size),
                                       queue_thread_run(true),
+                                      repl_send(send_repl),
+                                      wlbl_send(send_wlbl),
                                       d_ignoreself(false),
                                       d_key(key)
 {

--- a/wforce/wforce-sibling.cc
+++ b/wforce/wforce-sibling.cc
@@ -240,13 +240,11 @@ std::string siblingHostToAddress(const std::string& host)
     found_addr = true;
     break;
   }
-  if (!found_addr) {
-    if (res0)
-      freeaddrinfo(res0);
-    throw WforceException(std::string("Could not determine IP address for sibling host: ") + host);
-  }
   if (res0)
     freeaddrinfo(res0);
+  if (!found_addr) {
+    throw WforceException(std::string("Could not determine IP address for sibling host: ") + host);
+  }
   return sibling_address;
 }
 

--- a/wforce/wforce-sibling.cc
+++ b/wforce/wforce-sibling.cc
@@ -197,7 +197,7 @@ void Sibling::queueMsg(const std::string& msg)
   {
     std::lock_guard<std::mutex> lock(queue_mutx);
     if (queue.size() >= max_queue_size) {
-      errlog("Sibling::queueMsg: max sibling queue size (%d) reached - dropping replication msg", max_queue_size);
+      errlog("Sibling::queueMsg: max sibling send queue size (%d) reached - dropping replication msg", max_queue_size);
       return;
     }
     else {

--- a/wforce/wforce-sibling.cc
+++ b/wforce/wforce-sibling.cc
@@ -423,7 +423,7 @@ bool addSiblingWithKey(const std::string& address,
     parseSiblingString(address, ca, proto);
   }
   catch (const WforceException& e) {
-    const std::string errstr = (boost::format("%s [%s]. %s (%s)") % "addSibling() error parsing address/port" %
+    const std::string errstr = (boost::format("%s [%s]. %s (%s)") % "addSiblingWithKey() error parsing address/port" %
                                 address % "Make sure to use IP addresses not hostnames" % e.reason).str();
     errlog(errstr.c_str());
     output_buffer += errstr;

--- a/wforce/wforce-sibling.cc
+++ b/wforce/wforce-sibling.cc
@@ -56,8 +56,8 @@ Sibling::Sibling(const ComboAddress& ca,
                  const Protocol& p,
                  int timeout,
                  size_t queue_size,
-                 bool repl_send,
-                 bool wlbl_send) : Sibling(ca, p, std::string(), timeout, queue_size, repl_send, wlbl_send)
+                 bool sdb_send,
+                 bool wlbl_send) : Sibling(ca, p, std::string(), timeout, queue_size, sdb_send, wlbl_send)
 {
 }
 
@@ -87,12 +87,12 @@ Sibling::Sibling(const ComboAddress& ca,
                  const std::string& key,
                  int timeout,
                  size_t queue_size,
-                 bool send_repl,
+                 bool send_sdb,
                  bool send_wlbl) : rem(ca), proto(p),
                                       connect_timeout(timeout),
                                       max_queue_size(queue_size),
                                       queue_thread_run(true),
-                                      repl_send(send_repl),
+                                      sdb_send(send_sdb),
                                       wlbl_send(send_wlbl),
                                       d_ignoreself(false),
                                       d_key(key)

--- a/wforce/wforce-sibling.cc
+++ b/wforce/wforce-sibling.cc
@@ -425,6 +425,15 @@ bool setSiblings(const vector<std::pair<int, string>>& parts,
   return setSiblingsWithKey(t_vec, siblings, output_buffer);
 }
 
+bool toBool(const std::string& bool_str) {
+  std::string str(bool_str);
+  std::transform(str.begin(), str.end(), str.begin(), ::tolower);
+  std::istringstream is(str);
+  bool b;
+  is >> std::boolalpha >> b;
+  return b;
+}
+
 bool setSiblingsWithKey(const std::vector<std::pair<int, std::vector<std::pair<int, std::string>>>>& parts,
                         GlobalStateHolder<vector<shared_ptr<Sibling>>>& siblings,
                         std::string& output_buffer)
@@ -473,8 +482,8 @@ bool setSiblingsWithKey(const std::vector<std::pair<int, std::vector<std::pair<i
     parseSiblingString(p.second[0].second, ca, proto);
 
     if (p.second.size() == 4) {
-      send_sdb = boost::lexical_cast<bool>(p.second[2].second);
-      send_wlbl = boost::lexical_cast<bool>(p.second[3].second);
+      send_sdb = toBool(p.second[2].second);
+      send_wlbl = toBool(p.second[3].second);
     }
 
     for (auto& s : v) {

--- a/wforce/wforce-sibling.hh
+++ b/wforce/wforce-sibling.hh
@@ -44,10 +44,10 @@ struct Sibling {
 
   explicit Sibling(const ComboAddress& ca);
 
-  explicit Sibling(const ComboAddress& ca, const Protocol& p, int timeout = 1000, size_t queue_size = 5000);
+  explicit Sibling(const ComboAddress& ca, const Protocol& p, int timeout = 1000, size_t queue_size = 5000, bool repl_send=true, bool wlbl_send=true);
 
   explicit Sibling(const ComboAddress& ca, const Protocol& p, const std::string& key, int timeout = 1000,
-                   size_t queue_size = 5000);
+                   size_t queue_size = 5000, bool repl_send=true, bool wlbl_send=true);
 
   ~Sibling();
 
@@ -69,6 +69,10 @@ struct Sibling {
   size_t max_queue_size;
   std::thread queue_thread; // We hang on to this so that the queue thread can be terminated in the destructor
   bool queue_thread_run;
+
+  // Whether to send replication and/or wlbl events
+  bool repl_send;
+  bool wlbl_send;
 
   std::atomic<unsigned int> success{0};
   std::atomic<unsigned int> failures{0};

--- a/wforce/wforce-sibling.hh
+++ b/wforce/wforce-sibling.hh
@@ -42,6 +42,8 @@ struct Sibling {
     UDP = SOCK_DGRAM, TCP = SOCK_STREAM, NONE = -1
   };
 
+  static const int defaultPort = 4001;
+
   explicit Sibling(const ComboAddress& ca);
 
   explicit Sibling(const ComboAddress& ca, const Protocol& p, int timeout = 1000, size_t queue_size = 5000, bool sdb_send=true, bool wlbl_send=true);

--- a/wforce/wforce-sibling.hh
+++ b/wforce/wforce-sibling.hh
@@ -129,6 +129,8 @@ void setMaxSiblingSendQueueSize(size_t queue_size);
 
 void setSiblingConnectTimeout(int timeout); // milliseconds
 
+void parseSiblingString(const std::string& str, ComboAddress& ca, Sibling::Protocol& proto);
+
 std::string createSiblingAddress(const std::string& host, int port, Sibling::Protocol proto);
 
 bool removeSibling(const std::string& host, int port,
@@ -156,6 +158,10 @@ bool addSiblingWithKey(const std::string& address,
                        GlobalStateHolder<vector<shared_ptr<Sibling>>>& siblings,
                        std::string& output_buffer,
                        const std::string& key, bool send_sdb=true, bool send_wlbl=true);
+
+bool addSibling(std::shared_ptr<Sibling> sibling,
+                GlobalStateHolder<vector<shared_ptr<Sibling>>>& siblings,
+                std::string& output_buffer);
 
 bool setSiblings(const vector<pair<int, string>>& parts,
                  GlobalStateHolder<vector<shared_ptr<Sibling>>>& siblings,

--- a/wforce/wforce-sibling.hh
+++ b/wforce/wforce-sibling.hh
@@ -78,3 +78,14 @@ struct Sibling
   }
   bool d_ignoreself{false};
 };
+
+void parseSiblingString(const std::string &str, std::string &ca_str, Sibling::Protocol &proto);
+void removeSibling(const std::string& address,
+                    GlobalStateHolder<vector<shared_ptr<Sibling>>> &siblings,
+                    std::string &output_buffer);
+void addSibling(const std::string& address,
+                 GlobalStateHolder<vector<shared_ptr<Sibling>>> &siblings,
+                 std::string &output_buffer);
+void setSiblings(const vector<pair<int, string>> &parts,
+                 GlobalStateHolder<vector<shared_ptr<Sibling>>> &siblings,
+                 std::string &output_buffer);

--- a/wforce/wforce-sibling.hh
+++ b/wforce/wforce-sibling.hh
@@ -131,21 +131,21 @@ bool removeSibling(const std::string& address,
 
 bool addSibling(const std::string& address,
                 GlobalStateHolder<vector<shared_ptr<Sibling>>>& siblings,
-                std::string& output_buffer);
+                std::string& output_buffer, bool send_sdb=true, bool send_wlbl=true);
 
 bool addSibling(const std::string& host, int port, Sibling::Protocol proto,
                 GlobalStateHolder<vector<shared_ptr<Sibling>>>& siblings,
-                std::string& output_buffer);
+                std::string& output_buffer, bool send_sdb=true, bool send_wlbl=true);
 
 bool addSiblingWithKey(const std::string& host, int port, Sibling::Protocol proto,
                        GlobalStateHolder<vector<shared_ptr<Sibling>>>& siblings,
                        std::string& output_buffer,
-                       const std::string& key);
+                       const std::string& key, bool send_sdb=true, bool send_wlbl=true);
 
 bool addSiblingWithKey(const std::string& address,
                        GlobalStateHolder<vector<shared_ptr<Sibling>>>& siblings,
                        std::string& output_buffer,
-                       const std::string& key);
+                       const std::string& key, bool send_sdb=true, bool send_wlbl=true);
 
 bool setSiblings(const vector<pair<int, string>>& parts,
                  GlobalStateHolder<vector<shared_ptr<Sibling>>>& siblings,

--- a/wforce/wforce-sibling.hh
+++ b/wforce/wforce-sibling.hh
@@ -87,8 +87,10 @@ struct Sibling {
   {
     if (s.compare("tcp") == 0)
       return Sibling::Protocol::TCP;
-    else
+    else if (s.compare("udp") == 0)
       return Sibling::Protocol::UDP;
+    else
+      return Sibling::Protocol::NONE;
   }
 
   static std::string protocolToString(const Protocol& p)
@@ -112,15 +114,29 @@ struct Sibling {
 void setMaxSiblingSendQueueSize(size_t queue_size);
 
 void setSiblingConnectTimeout(int timeout); // milliseconds
-void parseSiblingString(const std::string& str, std::string& ca_str, Sibling::Protocol& proto);
 
-void removeSibling(const std::string& address,
+std::string createSiblingAddress(const std::string& host, int port, Sibling::Protocol proto);
+
+bool removeSibling(const std::string& host, int port,
+                   GlobalStateHolder<vector<shared_ptr<Sibling>>>& siblings,
+                   std::string& output_buffer);
+
+bool removeSibling(const std::string& address,
                    GlobalStateHolder<vector<shared_ptr<Sibling>>>& siblings,
                    std::string& output_buffer);
 
 bool addSibling(const std::string& address,
                 GlobalStateHolder<vector<shared_ptr<Sibling>>>& siblings,
                 std::string& output_buffer);
+
+bool addSibling(const std::string& host, int port, Sibling::Protocol proto,
+                GlobalStateHolder<vector<shared_ptr<Sibling>>>& siblings,
+                std::string& output_buffer);
+
+bool addSiblingWithKey(const std::string& host, int port, Sibling::Protocol proto,
+                       GlobalStateHolder<vector<shared_ptr<Sibling>>>& siblings,
+                       std::string& output_buffer,
+                       const std::string& key);
 
 bool addSiblingWithKey(const std::string& address,
                        GlobalStateHolder<vector<shared_ptr<Sibling>>>& siblings,

--- a/wforce/wforce-sibling.hh
+++ b/wforce/wforce-sibling.hh
@@ -93,16 +93,26 @@ struct Sibling {
       return Sibling::Protocol::TCP;
     else if (s.compare("udp") == 0)
       return Sibling::Protocol::UDP;
-    else
+    else if (s.compare("none") == 0)
       return Sibling::Protocol::NONE;
+    else if (s.empty())
+      return Sibling::Protocol::UDP; // Default to UDP if no protocol supplied
+    else {
+      std::string err = "Sibling::stringToProtocol(): Unknown protocol " + s;
+      throw WforceException(err);
+    }
   }
 
   static std::string protocolToString(const Protocol& p)
   {
     if (p == Protocol::TCP)
       return std::string("tcp");
-    else
+    else if (p == Protocol::UDP)
       return std::string("udp");
+    else if (p == Protocol::NONE)
+      return std::string("none");
+    else
+      throw WforceException("Sibling::protocolToString(): unknown protocol");
   }
 
   bool d_ignoreself{false};

--- a/wforce/wforce-sibling.hh
+++ b/wforce/wforce-sibling.hh
@@ -44,10 +44,10 @@ struct Sibling {
 
   explicit Sibling(const ComboAddress& ca);
 
-  explicit Sibling(const ComboAddress& ca, const Protocol& p, int timeout = 1000, size_t queue_size = 5000, bool repl_send=true, bool wlbl_send=true);
+  explicit Sibling(const ComboAddress& ca, const Protocol& p, int timeout = 1000, size_t queue_size = 5000, bool sdb_send=true, bool wlbl_send=true);
 
   explicit Sibling(const ComboAddress& ca, const Protocol& p, const std::string& key, int timeout = 1000,
-                   size_t queue_size = 5000, bool repl_send=true, bool wlbl_send=true);
+                   size_t queue_size = 5000, bool sdb_send=true, bool wlbl_send=true);
 
   ~Sibling();
 
@@ -71,7 +71,7 @@ struct Sibling {
   bool queue_thread_run;
 
   // Whether to send replication and/or wlbl events
-  bool repl_send;
+  bool sdb_send;
   bool wlbl_send;
 
   std::atomic<unsigned int> success{0};

--- a/wforce/wforce-web.cc
+++ b/wforce/wforce-web.cc
@@ -165,7 +165,7 @@ void parseDumpEntriesCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, con
 
   msg = Json::parse(req.body, err);
   if (msg.is_null()) {
-    resp.status = 500;
+    resp.status = 400;
     std::stringstream ss;
     ss << "{\"status\":\"failure\", \"reason\":\"" << err << "\"}";
     resp.body = ss.str();
@@ -215,7 +215,7 @@ void parseSyncCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const std:
 
   msg = Json::parse(req.body, err);
   if (msg.is_null()) {
-    resp.status = 500;
+    resp.status = 400;
     std::stringstream ss;
     ss << "{\"status\":\"failure\", \"reason\":\"" << err << "\"}";
     resp.body = ss.str();
@@ -268,7 +268,7 @@ void parseAddSiblingCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, cons
 
   msg = Json::parse(req.body, err);
   if (msg.is_null()) {
-    resp.status = 500;
+    resp.status = 400;
     std::stringstream ss;
     ss << "{\"status\":\"failure\", \"reason\":\"" << err << "\"}";
     resp.body = ss.str();
@@ -332,7 +332,7 @@ void parseRemoveSiblingCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, c
 
   msg = Json::parse(req.body, err);
   if (msg.is_null()) {
-    resp.status = 500;
+    resp.status = 400;
     std::stringstream ss;
     ss << "{\"status\":\"failure\", \"reason\":\"" << err << "\"}";
     resp.body = ss.str();
@@ -376,7 +376,7 @@ void parseSetSiblingsCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, con
 
   msg = Json::parse(req.body, err);
   if (msg.is_null()) {
-    resp.status = 500;
+    resp.status = 400;
     std::stringstream ss;
     ss << "{\"status\":\"failure\", \"reason\":\"" << err << "\"}";
     resp.body = ss.str();
@@ -439,7 +439,7 @@ void parseAddDelBLWLEntryCmd(const YaHTTP::Request& req, YaHTTP::Response& resp,
 
   msg = Json::parse(req.body, err);
   if (msg.is_null()) {
-    resp.status = 500;
+    resp.status = 400;
     std::stringstream ss;
     ss << "{\"status\":\"failure\", \"reason\":\"" << err << "\"}";
     resp.body = ss.str();
@@ -579,7 +579,7 @@ void parseResetCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const std
   string err;
   msg = Json::parse(req.body, err);
   if (msg.is_null()) {
-    resp.status = 500;
+    resp.status = 400;
     std::stringstream ss;
     ss << "{\"status\":\"failure\", \"reason\":\"" << err << "\"}";
     resp.body = ss.str();
@@ -662,7 +662,7 @@ void parseReportCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const st
   string err;
   msg = Json::parse(req.body, err);
   if (msg.is_null()) {
-    resp.status = 500;
+    resp.status = 400;
     std::stringstream ss;
     ss << "{\"status\":\"failure\", \"reason\":\"" << err << "\"}";
     resp.body = ss.str();
@@ -823,7 +823,7 @@ void parseAllowCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const std
 
   msg = Json::parse(req.body, err);
   if (msg.is_null()) {
-    resp.status = 500;
+    resp.status = 400;
     std::stringstream ss;
     ss << "{\"status\":\"failure\", \"reason\":\"" << err << "\"}";
     resp.body = ss.str();
@@ -1142,7 +1142,7 @@ void parseGetStatsCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const 
   string err;
   msg = Json::parse(req.body, err);
   if (msg.is_null()) {
-    resp.status = 500;
+    resp.status = 400;
     std::stringstream ss;
     ss << "{\"status\":\"failure\", \"reason\":\"" << err << "\"}";
     resp.body = ss.str();
@@ -1277,7 +1277,7 @@ void parseCustomCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const st
 
   msg = Json::parse(req.body, err);
   if (msg.is_null()) {
-    resp.status = 500;
+    resp.status = 400;
     std::stringstream ss;
     ss << "{\"success\":\"failure\", \"reason\":\"" << err << "\"}";
     resp.body = ss.str();

--- a/wforce/wforce-web.cc
+++ b/wforce/wforce-web.cc
@@ -229,7 +229,14 @@ void parseSyncCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const std:
       ComboAddress replication_ca(myip, myport);
       std::string callback_url = msg["callback_url"].string_value();
       std::string callback_pw = msg["callback_auth_pw"].string_value();
-      thread t(syncDBThread, replication_ca, callback_url, callback_pw);
+      std::string encryption_key;
+      if (!msg["encryption_key"].is_null()) {
+        encryption_key = msg["encryption_key"].string_value();
+      }
+      else {
+        encryption_key = g_key;
+      }
+      thread t(syncDBThread, replication_ca, callback_url, callback_pw, encryption_key);
       t.detach();
     }
     catch(const WforceException& e) {

--- a/wforce/wforce-web.cc
+++ b/wforce/wforce-web.cc
@@ -42,7 +42,10 @@
 #include "webhook.hh"
 #include "boost/date_time/posix_time/posix_time.hpp"
 #include "boost/date_time/gregorian/gregorian.hpp"
+#include "boost/regex.hpp"
 #include "wforce-prometheus.hh"
+#include "wforce-sibling.hh"
+#include "wforce-replication.hh"
 
 using std::thread;
 using namespace boost::posix_time;
@@ -53,7 +56,7 @@ GlobalStateHolder<std::map<std::string, std::pair<std::shared_ptr<std::atomic<un
 bool g_builtin_bl_enabled = true;
 bool g_builtin_wl_enabled = true;
 
-static time_t start=time(0);
+static time_t start = time(0);
 
 static int uptimeOfProcess()
 {
@@ -81,7 +84,8 @@ void reportLog(const LoginTuple& lt)
 
 bool g_allowlog_verbose = false;
 
-void allowLog(int retval, const std::string& msg, const LoginTuple& lt, const std::vector<pair<std::string, std::string>>& kvs) 
+void allowLog(int retval, const std::string& msg, const LoginTuple& lt,
+              const std::vector<pair<std::string, std::string>>& kvs)
 {
   std::ostringstream os;
   if ((retval != 0) || g_allowlog_verbose) {
@@ -96,7 +100,7 @@ void allowLog(int retval, const std::string& msg, const LoginTuple& lt, const st
     os << LtAttrsToString(lt);
     os << "rattrs={";
     for (const auto& i : kvs) {
-      os << i.first << "="<< "\"" << i.second << "\"" << " ";
+      os << i.first << "=" << "\"" << i.second << "\"" << " ";
     }
     os << "}";
   }
@@ -116,10 +120,10 @@ void addBLWLEntries(const std::vector<BlackWhiteListEntry>& blv, const char* key
 {
   using namespace json11;
   for (auto i = blv.begin(); i != blv.end(); ++i) {
-    Json my_entry = Json::object {
-      { key_name, (std::string)i->key },   
-      { "expiration", (std::string)boost::posix_time::to_simple_string(i->expiration)},
-      { "reason", (std::string)i->reason }
+    Json my_entry = Json::object{
+        {key_name,     (std::string) i->key},
+        {"expiration", (std::string) boost::posix_time::to_simple_string(i->expiration)},
+        {"reason",     (std::string) i->reason}
     };
     my_entries.push_back(my_entry);
   }
@@ -128,22 +132,22 @@ void addBLWLEntries(const std::vector<BlackWhiteListEntry>& blv, const char* key
 bool canonicalizeLogin(std::string& login, YaHTTP::Response& resp)
 {
   bool retval = true;
-  
+
   try {
     // canonicalize the login - e.g. turn "foo" into "foo@foobar.com" and bar into "bar@barfoo.com"
     login = g_luamultip->canonicalize(login);
   }
-  catch(LuaContext::ExecutionErrorException& e) {
-    resp.status=500;
+  catch (LuaContext::ExecutionErrorException& e) {
+    resp.status = 500;
     std::stringstream ss;
     ss << "{\"status\":\"failure\", \"reason\":\"" << e.what() << "\"}";
-    resp.body=ss.str();
+    resp.body = ss.str();
     errlog("Lua canonicalize function exception: %s", e.what());
     retval = false;
   }
-  catch(...) {
-    resp.status=500;
-    resp.body=R"({"status":"failure"})";
+  catch (...) {
+    resp.status = 500;
+    resp.body = R"({"status":"failure"})";
     retval = false;
   }
   return retval;
@@ -161,10 +165,10 @@ void parseDumpEntriesCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, con
 
   msg = Json::parse(req.body, err);
   if (msg.is_null()) {
-    resp.status=500;
+    resp.status = 500;
     std::stringstream ss;
     ss << "{\"status\":\"failure\", \"reason\":\"" << err << "\"}";
-    resp.body=ss.str();
+    resp.body = ss.str();
   }
   else {
     try {
@@ -184,19 +188,19 @@ void parseDumpEntriesCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, con
         resp.status = 503;
         std::stringstream ss;
         ss << "{\"status\":\"failure\", \"reason\":\"A DB dump is already in progress\"}";
-        resp.body=ss.str();
+        resp.body = ss.str();
       }
     }
-    catch(const WforceException& e) {
-      resp.status=500;
+    catch (const WforceException& e) {
+      resp.status = 500;
       std::stringstream ss;
       ss << "{\"status\":\"failure\", \"reason\":\"" << e.reason << "\"}";
-      resp.body=ss.str();
+      resp.body = ss.str();
       errlog("Exception in command [%s] exception: %s", command, e.reason);
     }
   }
   if (resp.status == 200)
-    resp.body=R"({"status":"ok"})";
+    resp.body = R"({"status":"ok"})";
   incCommandStat("dumpEntries");
   incPrometheusCommandMetric("dumpEntries");
 }
@@ -211,10 +215,10 @@ void parseSyncCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const std:
 
   msg = Json::parse(req.body, err);
   if (msg.is_null()) {
-    resp.status=500;
+    resp.status = 500;
     std::stringstream ss;
     ss << "{\"status\":\"failure\", \"reason\":\"" << err << "\"}";
-    resp.body=ss.str();
+    resp.body = ss.str();
   }
   else {
     try {
@@ -222,7 +226,8 @@ void parseSyncCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const std:
           msg["replication_port"].is_null() ||
           msg["callback_url"].is_null() ||
           msg["callback_auth_pw"].is_null()) {
-        throw WforceException("One of mandatory parameters [replication_host, replication_port, callback_url, callback_auth_pw] is missing");
+        throw WforceException(
+            "One of mandatory parameters [replication_host, replication_port, callback_url, callback_auth_pw] is missing");
       }
       string myip = msg["replication_host"].string_value();
       int myport = msg["replication_port"].int_value();
@@ -239,18 +244,189 @@ void parseSyncCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const std:
       thread t(syncDBThread, replication_ca, callback_url, callback_pw, encryption_key);
       t.detach();
     }
-    catch(const WforceException& e) {
-      resp.status=500;
+    catch (const WforceException& e) {
+      resp.status = 500;
       std::stringstream ss;
       ss << "{\"status\":\"failure\", \"reason\":\"" << e.reason << "\"}";
-      resp.body=ss.str();
+      resp.body = ss.str();
       errlog("Exception in command [%s] exception: %s", command, e.reason);
     }
   }
   if (resp.status == 200)
-    resp.body=R"({"status":"ok"})";
+    resp.body = R"({"status":"ok"})";
   incCommandStat("syncDBs");
   incPrometheusCommandMetric("syncDBs");
+}
+
+void parseAddSiblingCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const std::string& command)
+{
+  using namespace json11;
+  Json msg;
+  string err;
+
+  resp.status = 200;
+
+  msg = Json::parse(req.body, err);
+  if (msg.is_null()) {
+    resp.status = 500;
+    std::stringstream ss;
+    ss << "{\"status\":\"failure\", \"reason\":\"" << err << "\"}";
+    resp.body = ss.str();
+  }
+  else {
+    try {
+      if (msg["sibling_host"].is_null() ||
+          msg["sibling_port"].is_null()) {
+        throw WforceException("One of mandatory parameters [sibling_host, sibling_port] is missing");
+      }
+      std::string sibling_host = msg["sibling_host"].string_value();
+      int sibling_port = msg["sibling_port"].int_value();
+      bool has_encryption_key = false;
+      std::string encryption_key;
+      if (!msg["encryption_key"].is_null()) {
+        has_encryption_key = true;
+        encryption_key = msg["encryption_key"].string_value();
+      }
+
+      Sibling::Protocol proto = Sibling::Protocol::UDP;
+      if (!msg["sibling_protocol"].is_null()) {
+        proto = Sibling::stringToProtocol(msg["sibling_protocol"].string_value());
+      }
+      if (proto == Sibling::Protocol::NONE) {
+        throw WforceException(std::string("Invalid sibling_protocol: ") + msg["sibling_protocol"].string_value());
+      }
+
+      std::string error_msg;
+      if (!has_encryption_key) {
+        if (!addSibling(sibling_host, sibling_port, proto, g_siblings, error_msg)) {
+          throw WforceException(error_msg);
+        }
+      }
+      else {
+        if (!addSiblingWithKey(sibling_host, sibling_port, proto, g_siblings, error_msg, encryption_key)) {
+          throw WforceException(error_msg);
+        }
+      }
+    }
+    catch (const WforceException& e) {
+      resp.status = 500;
+      std::stringstream ss;
+      ss << "{\"status\":\"failure\", \"reason\":\"" << e.reason << "\"}";
+      resp.body = ss.str();
+      errlog("Exception in command [%s] exception: %s", command, e.reason);
+    }
+  }
+  if (resp.status == 200)
+    resp.body = R"({"status":"ok"})";
+  incCommandStat("addSibling");
+  incPrometheusCommandMetric("addSibling");
+}
+
+void parseRemoveSiblingCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const std::string& command)
+{
+  using namespace json11;
+  Json msg;
+  string err;
+
+  resp.status = 200;
+
+  msg = Json::parse(req.body, err);
+  if (msg.is_null()) {
+    resp.status = 500;
+    std::stringstream ss;
+    ss << "{\"status\":\"failure\", \"reason\":\"" << err << "\"}";
+    resp.body = ss.str();
+  }
+  else {
+    try {
+      if (msg["sibling_host"].is_null() ||
+          msg["sibling_port"].is_null()) {
+        throw WforceException("One of mandatory parameters [sibling_host, sibling_port] is missing");
+      }
+      std::string sibling_host = msg["sibling_host"].string_value();
+      int sibling_port = msg["sibling_port"].int_value();
+
+      std::string error_msg;
+      if (!removeSibling(sibling_host, sibling_port, g_siblings, error_msg)) {
+        throw WforceException(error_msg);
+      }
+    }
+    catch (const WforceException& e) {
+      resp.status = 500;
+      std::stringstream ss;
+      ss << "{\"status\":\"failure\", \"reason\":\"" << e.reason << "\"}";
+      resp.body = ss.str();
+      errlog("Exception in command [%s] exception: %s", command, e.reason);
+    }
+  }
+  if (resp.status == 200)
+    resp.body = R"({"status":"ok"})";
+  incCommandStat("removeSibling");
+  incPrometheusCommandMetric("removeSibling");
+}
+
+void parseSetSiblingsCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const std::string& command)
+{
+  using namespace json11;
+  Json msg;
+  string err;
+  std::vector<std::pair<int, std::vector<std::pair<int, std::string>>>> new_siblings;
+
+  resp.status = 200;
+
+  msg = Json::parse(req.body, err);
+  if (msg.is_null()) {
+    resp.status = 500;
+    std::stringstream ss;
+    ss << "{\"status\":\"failure\", \"reason\":\"" << err << "\"}";
+    resp.body = ss.str();
+  }
+  else {
+    try {
+      if (msg["siblings"].is_null() || !msg["siblings"].is_array()) {
+        throw WforceException("Mandatory parameter [siblings] is missing or is not an array");
+      }
+      auto siblings = msg["siblings"].array_items();
+      for (auto& i : siblings) {
+        if (i["sibling_host"].is_null() || i["sibling_port"].is_null()) {
+          throw WforceException("Mandatory parameter(s) [sibling_host, sibling_port] are missing");
+        }
+        std::string sibling_host = i["sibling_host"].string_value();
+        int sibling_port = i["sibling_port"].int_value();
+        std::string encryption_key;
+        if (!i["encryption_key"].is_null()) {
+          encryption_key = i["encryption_key"].string_value();
+        }
+        else {
+          encryption_key = Base64Encode(g_key);
+        }
+
+        Sibling::Protocol proto = Sibling::Protocol::UDP;
+        if (!i["sibling_protocol"].is_null()) {
+          proto = Sibling::stringToProtocol(i["sibling_protocol"].string_value());
+        }
+        if (proto == Sibling::Protocol::NONE) {
+          throw WforceException(std::string("Invalid sibling_protocol: ") + msg["sibling_protocol"].string_value());
+        }
+        new_siblings.emplace_back(std::pair<int, std::vector<std::pair<int, std::string>>>{0, {{0, createSiblingAddress(sibling_host, sibling_port, proto)}, {1, encryption_key}}});
+      }
+      std::string error_msg;
+      if (!setSiblingsWithKey(new_siblings, g_siblings, error_msg)) {
+        throw WforceException(error_msg);
+      }
+    }
+    catch (const WforceException& e) {
+      resp.status = 500;
+      std::stringstream ss;
+      ss << "{\"status\":\"failure\", \"reason\":\"" << e.reason << "\"}";
+      resp.body = ss.str();
+      errlog("Exception in command [%s] exception: %s", command, e.reason);
+    }
+  }
+  if (resp.status == 200)
+    resp.body = R"({"status":"ok"})";
+  incCommandStat("setSiblings");
+  incPrometheusCommandMetric("setSiblings");
 }
 
 void parseAddDelBLWLEntryCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, bool addCmd, bool blacklist)
@@ -261,18 +437,18 @@ void parseAddDelBLWLEntryCmd(const YaHTTP::Request& req, YaHTTP::Response& resp,
 
   resp.status = 200;
 
-  msg=Json::parse(req.body, err);
+  msg = Json::parse(req.body, err);
   if (msg.is_null()) {
-    resp.status=500;
+    resp.status = 500;
     std::stringstream ss;
     ss << "{\"status\":\"failure\", \"reason\":\"" << err << "\"}";
-    resp.body=ss.str();
+    resp.body = ss.str();
   }
   else {
-    bool haveIP=false;
-    bool haveLogin=false;
-    bool haveNetmask=false;
-    unsigned int bl_seconds=0;
+    bool haveIP = false;
+    bool haveLogin = false;
+    bool haveNetmask = false;
+    unsigned int bl_seconds = 0;
     std::string bl_reason;
     std::string en_login;
     ComboAddress en_ca;
@@ -280,35 +456,35 @@ void parseAddDelBLWLEntryCmd(const YaHTTP::Request& req, YaHTTP::Response& resp,
 
     try {
       if (!msg["ip"].is_null()) {
-	string myip = msg["ip"].string_value();
-	en_ca = ComboAddress(myip);
-	en_nm = Netmask(myip);
-	haveIP = true;
+        string myip = msg["ip"].string_value();
+        en_ca = ComboAddress(myip);
+        en_nm = Netmask(myip);
+        haveIP = true;
       }
       if (!msg["netmask"].is_null()) {
-	string mynm = msg["netmask"].string_value();
-	en_nm = Netmask(mynm);
-	haveNetmask = true;
+        string mynm = msg["netmask"].string_value();
+        en_nm = Netmask(mynm);
+        haveNetmask = true;
       }
       if (!msg["login"].is_null()) {
-	en_login = msg["login"].string_value();
-	if (!canonicalizeLogin(en_login, resp))
-	  return;
-	haveLogin = true;
+        en_login = msg["login"].string_value();
+        if (!canonicalizeLogin(en_login, resp))
+          return;
+        haveLogin = true;
       }
       if (addCmd) {
-	if (!msg["expire_secs"].is_null()) {
-	  bl_seconds = msg["expire_secs"].int_value();
-	}
-	else {
-	  throw std::runtime_error("Missing mandatory expire_secs field");
-	}
-	if (!msg["reason"].is_null()) {
-	  bl_reason = msg["reason"].string_value();
-	}
-	else {
-	  throw std::runtime_error("Missing mandatory reason field");
-	}
+        if (!msg["expire_secs"].is_null()) {
+          bl_seconds = msg["expire_secs"].int_value();
+        }
+        else {
+          throw std::runtime_error("Missing mandatory expire_secs field");
+        }
+        if (!msg["reason"].is_null()) {
+          bl_reason = msg["reason"].string_value();
+        }
+        else {
+          throw std::runtime_error("Missing mandatory reason field");
+        }
       }
       if (haveLogin && haveIP) {
         if (addCmd) {
@@ -317,21 +493,21 @@ void parseAddDelBLWLEntryCmd(const YaHTTP::Request& req, YaHTTP::Response& resp,
           else
             g_wl_db.addEntry(en_ca, en_login, bl_seconds, bl_reason);
         }
-	else {
+        else {
           if (blacklist)
             g_bl_db.deleteEntry(en_ca, en_login);
-          else 
+          else
             g_wl_db.deleteEntry(en_ca, en_login);
         }
       }
       else if (haveLogin) {
-	if (addCmd) {
+        if (addCmd) {
           if (blacklist)
             g_bl_db.addEntry(en_login, bl_seconds, bl_reason);
           else
-            g_wl_db.addEntry(en_login, bl_seconds, bl_reason);            
+            g_wl_db.addEntry(en_login, bl_seconds, bl_reason);
         }
-	else {
+        else {
           if (blacklist)
             g_bl_db.deleteEntry(en_login);
           else
@@ -339,32 +515,33 @@ void parseAddDelBLWLEntryCmd(const YaHTTP::Request& req, YaHTTP::Response& resp,
         }
       }
       else if (haveIP || haveNetmask) {
-	if (addCmd) {
+        if (addCmd) {
           if (blacklist)
             g_bl_db.addEntry(en_nm, bl_seconds, bl_reason);
           else
             g_wl_db.addEntry(en_nm, bl_seconds, bl_reason);
         }
-	else {
+        else {
           if (blacklist)
             g_bl_db.deleteEntry(en_nm);
           else
-            g_wl_db.deleteEntry(en_nm);            
+            g_wl_db.deleteEntry(en_nm);
         }
       }
     }
     catch (std::runtime_error& e) {
-      resp.status=500;
+      resp.status = 500;
       std::stringstream ss;
       ss << "{\"status\":\"failure\", \"reason\":\"" << e.what() << "\"}";
-      resp.body=ss.str();    }
-    catch(...) {
-      resp.status=500;
-      resp.body=R"({"status":"failure"})";
+      resp.body = ss.str();
+    }
+    catch (...) {
+      resp.status = 500;
+      resp.body = R"({"status":"failure"})";
     }
   }
   if (resp.status == 200)
-    resp.body=R"({"status":"ok"})";
+    resp.body = R"({"status":"ok"})";
 }
 
 void parseAddBLEntryCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const std::string& command)
@@ -400,76 +577,78 @@ void parseResetCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const std
   using namespace json11;
   Json msg;
   string err;
-  msg=Json::parse(req.body, err);
+  msg = Json::parse(req.body, err);
   if (msg.is_null()) {
-    resp.status=500;
+    resp.status = 500;
     std::stringstream ss;
     ss << "{\"status\":\"failure\", \"reason\":\"" << err << "\"}";
-    resp.body=ss.str();
+    resp.body = ss.str();
   }
   else {
     try {
-      bool haveIP=false;
-      bool haveLogin=false;
+      bool haveIP = false;
+      bool haveLogin = false;
       std::string en_type, en_login;
       ComboAddress en_ca;
       if (!msg["ip"].is_null()) {
-	en_ca = ComboAddress(msg["ip"].string_value());
-	haveIP = true;
+        en_ca = ComboAddress(msg["ip"].string_value());
+        haveIP = true;
       }
       if (!msg["login"].is_null()) {
-	en_login = msg["login"].string_value();
-	// canonicalize the login - e.g. turn "foo" into "foo@foobar.com" and bar into "bar@barfoo.com"
-	if (!canonicalizeLogin(en_login, resp))
-	  return;
-	haveLogin = true;
+        en_login = msg["login"].string_value();
+        // canonicalize the login - e.g. turn "foo" into "foo@foobar.com" and bar into "bar@barfoo.com"
+        if (!canonicalizeLogin(en_login, resp))
+          return;
+        haveLogin = true;
       }
       if (haveLogin && haveIP) {
-	en_type = "ip:login";
-	g_bl_db.deleteEntry(en_ca, en_login);
+        en_type = "ip:login";
+        g_bl_db.deleteEntry(en_ca, en_login);
       }
       else if (haveLogin) {
-	en_type = "login";
-	g_bl_db.deleteEntry(en_login);
+        en_type = "login";
+        g_bl_db.deleteEntry(en_login);
       }
       else if (haveIP) {
-	en_type = "ip";
-	g_bl_db.deleteEntry(en_ca);
+        en_type = "ip";
+        g_bl_db.deleteEntry(en_ca);
       }
-	  
+
       if (!haveLogin && !haveIP) {
-	resp.status = 415;
-	resp.body=R"({"status":"failure", "reason":"No ip or login field supplied"})";
+        resp.status = 415;
+        resp.body = R"({"status":"failure", "reason":"No ip or login field supplied"})";
       }
       else {
-	bool reset_ret;
-	{
-	  reset_ret = g_luamultip->reset(en_type, en_login, en_ca);
-	}
-	resp.status = 200;
-	if (reset_ret)
-	  resp.body=R"({"status":"ok"})";
-	else
-	  resp.body=R"({"status":"failure", "reason":"reset function returned false"})";
+        bool reset_ret;
+        {
+          reset_ret = g_luamultip->reset(en_type, en_login, en_ca);
+        }
+        resp.status = 200;
+        if (reset_ret)
+          resp.body = R"({"status":"ok"})";
+        else
+          resp.body = R"({"status":"failure", "reason":"reset function returned false"})";
       }
       // generate webhook events
-      Json jobj = Json::object{{"login", en_login}, {"ip", en_ca.toString()}, {"type", "wforce_reset"}};
+      Json jobj = Json::object{{"login", en_login},
+                               {"ip",    en_ca.toString()},
+                               {"type",  "wforce_reset"}};
       for (const auto& h : g_webhook_db.getWebHooksForEvent("reset")) {
-	if (auto hs = h.lock()) {
-            g_webhook_runner.runHook("reset", hs, jobj);
+        if (auto hs = h.lock()) {
+          g_webhook_runner.runHook("reset", hs, jobj);
         }
       }
     }
-    catch(LuaContext::ExecutionErrorException& e) {
-      resp.status=500;
+    catch (LuaContext::ExecutionErrorException& e) {
+      resp.status = 500;
       std::stringstream ss;
       ss << "{\"status\":\"failure\", \"reason\":\"" << e.what() << "\"}";
-      resp.body=ss.str();
+      resp.body = ss.str();
       errlog("Lua reset function exception: %s", e.what());
     }
-    catch(...) {
-      resp.status=500;
-      resp.body=R"({"status":"failure"})";
+    catch (...) {
+      resp.status = 500;
+      resp.body = R"({"status":"failure"})";
     }
   }
   incCommandStat("reset");
@@ -481,12 +660,12 @@ void parseReportCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const st
   using namespace json11;
   Json msg;
   string err;
-  msg=Json::parse(req.body, err);
+  msg = Json::parse(req.body, err);
   if (msg.is_null()) {
-    resp.status=500;
+    resp.status = 500;
     std::stringstream ss;
     ss << "{\"status\":\"failure\", \"reason\":\"" << err << "\"}";
-    resp.body=ss.str();
+    resp.body = ss.str();
   }
   else {
     try {
@@ -496,66 +675,66 @@ void parseReportCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const st
 
       // canonicalize the login - e.g. turn "foo" into "foo@foobar.com" and bar into "bar@barfoo.com"
       if (!canonicalizeLogin(lt.login, resp))
-	return;
-      lt.t=getDoubleTime(); // set the time
+        return;
+      lt.t = getDoubleTime(); // set the time
       reportLog(lt);
       g_stats.reports++;
-      resp.status=200;
+      resp.status = 200;
       {
-	g_luamultip->report(lt);
+        g_luamultip->report(lt);
       }
 
       // If any normal or named report sinks are configured, send the report to one of them
       sendReportSink(lt); // XXX - this is deprecated now in favour of NamedReportSinks
       sendNamedReportSink(lt.serialize());
-      
+
       Json msg = lt.to_json();
       Json::object jobj = msg.object_items();
       jobj.insert(make_pair("type", "wforce_report"));
       for (const auto& h : g_webhook_db.getWebHooksForEvent("report")) {
-	if (auto hs = h.lock())
-	  g_webhook_runner.runHook("report", hs, jobj);
+        if (auto hs = h.lock())
+          g_webhook_runner.runHook("report", hs, jobj);
       }
 
-      resp.status=200;
-      resp.body=R"({"status":"ok"})";
+      resp.status = 200;
+      resp.body = R"({"status":"ok"})";
     }
-    catch(LuaContext::ExecutionErrorException& e) {
-      resp.status=500;
+    catch (LuaContext::ExecutionErrorException& e) {
+      resp.status = 500;
       std::stringstream ss;
       try {
-	std::rethrow_if_nested(e);
-	ss << "{\"status\":\"failure\", \"reason\":\"" << e.what() << "\"}";
-	resp.body=ss.str();
-	errlog("Lua function [%s] exception: %s", command, e.what());
+        std::rethrow_if_nested(e);
+        ss << "{\"status\":\"failure\", \"reason\":\"" << e.what() << "\"}";
+        resp.body = ss.str();
+        errlog("Lua function [%s] exception: %s", command, e.what());
       }
       catch (const std::exception& ne) {
-	resp.status=500;
-	std::stringstream ss;
-	ss << "{\"status\":\"failure\", \"reason\":\"" << ne.what() << "\"}";
-	resp.body=ss.str();
-	errlog("Exception in command [%s] exception: %s", command, ne.what());
+        resp.status = 500;
+        std::stringstream ss;
+        ss << "{\"status\":\"failure\", \"reason\":\"" << ne.what() << "\"}";
+        resp.body = ss.str();
+        errlog("Exception in command [%s] exception: %s", command, ne.what());
       }
       catch (const WforceException& ne) {
-	resp.status=500;
-	std::stringstream ss;
-	ss << "{\"status\":\"failure\", \"reason\":\"" << ne.reason << "\"}";
-	resp.body=ss.str();
-	errlog("Exception in command [%s] exception: %s", command, ne.reason);
+        resp.status = 500;
+        std::stringstream ss;
+        ss << "{\"status\":\"failure\", \"reason\":\"" << ne.reason << "\"}";
+        resp.body = ss.str();
+        errlog("Exception in command [%s] exception: %s", command, ne.reason);
       }
     }
-    catch(const std::exception& e) {
-      resp.status=500;
+    catch (const std::exception& e) {
+      resp.status = 500;
       std::stringstream ss;
       ss << "{\"status\":\"failure\", \"reason\":\"" << e.what() << "\"}";
-      resp.body=ss.str();
+      resp.body = ss.str();
       errlog("Exception in command [%s] exception: %s", command, e.what());
     }
-    catch(const WforceException& e) {
-      resp.status=500;
+    catch (const WforceException& e) {
+      resp.status = 500;
       std::stringstream ss;
       ss << "{\"status\":\"failure\", \"reason\":\"" << e.reason << "\"}";
-      resp.body=ss.str();
+      resp.body = ss.str();
       errlog("Exception in command [%s] exception: %s", command, e.reason);
     }
   }
@@ -570,11 +749,11 @@ void genProtectHookData(const Json& lt, const std::string& msg, Json& ret_json)
   Json::object jobj;
 
   double dtime = lt["t"].number_value();
-  unsigned int isecs = (int)dtime;
+  unsigned int isecs = (int) dtime;
   unsigned int iusecs = (dtime - isecs) * 1000000;
-  
-  ptime t(date(1970,Jan,01), seconds(isecs)+microsec(iusecs));
-  jobj.insert(std::make_pair("timestamp", to_iso_extended_string(t)+"Z"));
+
+  ptime t(date(1970, Jan, 01), seconds(isecs) + microsec(iusecs));
+  jobj.insert(std::make_pair("timestamp", to_iso_extended_string(t) + "Z"));
 
   jobj.insert(std::make_pair("user", lt["login"].string_value()));
   jobj.insert(std::make_pair("device", lt["device_id"].string_value()));
@@ -591,22 +770,24 @@ bool allow_filter(std::shared_ptr<const WebHook> hook, int status)
   bool retval = false;
   if (hook->hasConfigKey("allow_filter")) {
     std::string filter = hook->getConfigKey("allow_filter");
-    if (((filter.find("reject")!=string::npos) && (status < 0)) ||
-	(((filter.find("allow")!=string::npos) && (status == 0))) ||
-	(((filter.find("tarpit")!=string::npos) && (status > 0)))) {
+    if (((filter.find("reject") != string::npos) && (status < 0)) ||
+        (((filter.find("allow") != string::npos) && (status == 0))) ||
+        (((filter.find("tarpit") != string::npos) && (status > 0)))) {
       retval = true;
       vdebuglog("allow_filter: filter evaluates to true (allowing event)");
     }
   }
   else
     retval = true;
-  
+
   return retval;
 }
 
 void runAllowWebHook(const Json& request, const Json& response, int status)
 {
-  Json jobj = Json::object{{"request", request}, {"response", response}, {"type", "wforce_allow"}};
+  Json jobj = Json::object{{"request",  request},
+                           {"response", response},
+                           {"type",     "wforce_allow"}};
   for (const auto& h : g_webhook_db.getWebHooksForEvent("allow")) {
     if (auto hs = h.lock()) {
       Json pj;
@@ -625,7 +806,9 @@ void runAllowWebHook(const Json& request, const Json& response, int status)
   }
 }
 
-enum AllowReturnFields { allowRetStatus=0, allowRetMsg=1, allowRetLogMsg=2, allowRetAttrs=3 };
+enum AllowReturnFields {
+  allowRetStatus = 0, allowRetMsg = 1, allowRetLogMsg = 2, allowRetAttrs = 3
+};
 
 void parseAllowCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const std::string& command)
 {
@@ -638,12 +821,12 @@ void parseAllowCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const std
   incPrometheusCommandMetric("allow");
   g_stats.allows++;
 
-  msg=Json::parse(req.body, err);
+  msg = Json::parse(req.body, err);
   if (msg.is_null()) {
-    resp.status=500;
+    resp.status = 500;
     std::stringstream ss;
     ss << "{\"status\":\"failure\", \"reason\":\"" << err << "\"}";
-    resp.body=ss.str();
+    resp.body = ss.str();
   }
   else {
     LoginTuple lt;
@@ -652,36 +835,36 @@ void parseAllowCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const std
 
     try {
       lt.from_json(msg, g_ua_parser_p);
-      lt.t=getDoubleTime();
+      lt.t = getDoubleTime();
     }
-    catch(const std::exception& e) {
-      resp.status=500;
+    catch (const std::exception& e) {
+      resp.status = 500;
       std::stringstream ss;
       ss << "{\"status\":\"failure\", \"reason\":\"" << e.what() << "\"}";
-      resp.body=ss.str();
+      resp.body = ss.str();
       errlog("Exception in command [%s] exception: %s", command, e.what());
     }
-    catch(const WforceException& e) {
-      resp.status=500;
+    catch (const WforceException& e) {
+      resp.status = 500;
       std::stringstream ss;
       ss << "{\"status\":\"failure\", \"reason\":\"" << e.reason << "\"}";
-      resp.body=ss.str();
+      resp.body = ss.str();
       errlog("Exception in command [%s] exception: %s", command, e.reason);
     }
 
     if (!canonicalizeLogin(lt.login, resp))
       return;
-    
+
     // check the built-in whitelists
     bool whitelisted = false;
     BlackWhiteListEntry wle;
     if (g_builtin_wl_enabled) {
       if (g_wl_db.getEntry(lt.remote, wle)) {
-        std::vector<pair<std::string, std::string>> log_attrs = 
-          { { "expiration", boost::posix_time::to_simple_string(wle.expiration) },
-            { "reason", wle.reason },
-            { "whitelisted", "1" },
-            { "key", "ip" } };
+        std::vector<pair<std::string, std::string>> log_attrs =
+            {{"expiration",  boost::posix_time::to_simple_string(wle.expiration)},
+             {"reason",      wle.reason},
+             {"whitelisted", "1"},
+             {"key",         "ip"}};
         status = 0;
         allowLog(status, std::string("whitelisted IP"), lt, log_attrs);
         ret_msg = g_wl_db.getIPRetMsg();
@@ -689,11 +872,11 @@ void parseAllowCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const std
         whitelisted = true;
       }
       else if (g_wl_db.getEntry(lt.login, wle)) {
-        std::vector<pair<std::string, std::string>> log_attrs = 
-          { { "expiration", boost::posix_time::to_simple_string(wle.expiration) },
-            { "reason", wle.reason },
-            { "whitelisted", "1" },
-            { "key", "login" } };
+        std::vector<pair<std::string, std::string>> log_attrs =
+            {{"expiration",  boost::posix_time::to_simple_string(wle.expiration)},
+             {"reason",      wle.reason},
+             {"whitelisted", "1"},
+             {"key",         "login"}};
         status = 0;
         allowLog(status, std::string("whitelisted Login"), lt, log_attrs);
         ret_msg = g_wl_db.getLoginRetMsg();
@@ -701,11 +884,11 @@ void parseAllowCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const std
         whitelisted = true;
       }
       else if (g_wl_db.getEntry(lt.remote, lt.login, wle)) {
-        std::vector<pair<std::string, std::string>> log_attrs = 
-          { { "expiration", boost::posix_time::to_simple_string(wle.expiration) },
-            { "reason", wle.reason },
-            { "whitelisted", "1" },
-            { "key", "iplogin" } };
+        std::vector<pair<std::string, std::string>> log_attrs =
+            {{"expiration",  boost::posix_time::to_simple_string(wle.expiration)},
+             {"reason",      wle.reason},
+             {"whitelisted", "1"},
+             {"key",         "iplogin"}};
         status = 0;
         allowLog(status, std::string("whitelisted IPLogin"), lt, log_attrs);
         ret_msg = g_wl_db.getIPLoginRetMsg();
@@ -713,59 +896,61 @@ void parseAllowCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const std
         whitelisted = true;
       }
     }
-    
+
     // next check the built-in blacklists
     bool blacklisted = false;
     BlackWhiteListEntry ble;
     if (g_builtin_bl_enabled) {
       if (g_bl_db.getEntry(lt.remote, ble)) {
-        std::vector<pair<std::string, std::string>> log_attrs = 
-          { { "expiration", boost::posix_time::to_simple_string(ble.expiration) },
-            { "reason", ble.reason },
-            { "blacklisted", "1" },
-            { "key", "ip" } };
+        std::vector<pair<std::string, std::string>> log_attrs =
+            {{"expiration",  boost::posix_time::to_simple_string(ble.expiration)},
+             {"reason",      ble.reason},
+             {"blacklisted", "1"},
+             {"key",         "ip"}};
         allowLog(status, std::string("blacklisted IP"), lt, log_attrs);
         ret_msg = g_bl_db.getIPRetMsg();
         ret_attrs = std::move(log_attrs);
         blacklisted = true;
       }
       else if (g_bl_db.getEntry(lt.login, ble)) {
-        std::vector<pair<std::string, std::string>> log_attrs = 
-          { { "expiration", boost::posix_time::to_simple_string(ble.expiration) },
-            { "reason", ble.reason },
-            { "blacklisted", "1" },
-            { "key", "login" } };
+        std::vector<pair<std::string, std::string>> log_attrs =
+            {{"expiration",  boost::posix_time::to_simple_string(ble.expiration)},
+             {"reason",      ble.reason},
+             {"blacklisted", "1"},
+             {"key",         "login"}};
         allowLog(status, std::string("blacklisted Login"), lt, log_attrs);
         ret_msg = g_bl_db.getLoginRetMsg();
         ret_attrs = std::move(log_attrs);
         blacklisted = true;
       }
       else if (g_bl_db.getEntry(lt.remote, lt.login, ble)) {
-        std::vector<pair<std::string, std::string>> log_attrs = 
-          { { "expiration", boost::posix_time::to_simple_string(ble.expiration) },
-            { "reason", ble.reason },
-            { "blacklisted", "1" },
-            { "key", "iplogin" } };
+        std::vector<pair<std::string, std::string>> log_attrs =
+            {{"expiration",  boost::posix_time::to_simple_string(ble.expiration)},
+             {"reason",      ble.reason},
+             {"blacklisted", "1"},
+             {"key",         "iplogin"}};
         allowLog(status, std::string("blacklisted IPLogin"), lt, log_attrs);
-        ret_msg =g_bl_db.getIPLoginRetMsg();
+        ret_msg = g_bl_db.getIPLoginRetMsg();
         ret_attrs = std::move(log_attrs);
         blacklisted = true;
       }
     }
-    
+
     if (blacklisted || whitelisted) {
       // run webhook
       Json::object jattrs;
       for (auto& i : ret_attrs) {
         jattrs.insert(make_pair(i.first, Json(i.second)));
       }
-      msg=Json::object{{"status", status}, {"msg", ret_msg}, {"r_attrs", jattrs}};
+      msg = Json::object{{"status",  status},
+                         {"msg",     ret_msg},
+                         {"r_attrs", jattrs}};
       runAllowWebHook(lt.to_json(), msg, status);
       if (blacklisted) {
         g_stats.denieds++;
         incCommandStat("allow_blacklisted");
         incPrometheusAllowStatusMetric("blacklisted");
-        incCommandStat("allow_denied");        
+        incCommandStat("allow_denied");
         incPrometheusAllowStatusMetric("denied");
       }
       if (whitelisted) {
@@ -775,94 +960,99 @@ void parseAllowCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const std
     }
     else {
       try {
-	AllowReturn ar;
-	{
-	  ar=g_luamultip->allow(lt);
-	}
-	status = std::get<allowRetStatus>(ar);
-	ret_msg = std::get<allowRetMsg>(ar);
-	std::string log_msg = std::get<allowRetLogMsg>(ar);
-	std::vector<pair<std::string, std::string>> log_attrs = std::get<allowRetAttrs>(ar);
+        AllowReturn ar;
+        {
+          ar = g_luamultip->allow(lt);
+        }
+        status = std::get<allowRetStatus>(ar);
+        ret_msg = std::get<allowRetMsg>(ar);
+        std::string log_msg = std::get<allowRetLogMsg>(ar);
+        std::vector<pair<std::string, std::string>> log_attrs = std::get<allowRetAttrs>(ar);
 
-	// log the results of the allow function
-	allowLog(status, log_msg, lt, log_attrs);
+        // log the results of the allow function
+        allowLog(status, log_msg, lt, log_attrs);
 
-	ret_attrs = std::move(log_attrs);
-	if(status < 0) {
-	  g_stats.denieds++;
+        ret_attrs = std::move(log_attrs);
+        if (status < 0) {
+          g_stats.denieds++;
           incCommandStat("allow_denied");
           incPrometheusAllowStatusMetric("denied");
         }
         else if (status > 0) {
           incCommandStat("allow_tarpitted");
           incPrometheusAllowStatusMetric("tarpitted");
-        } else {
+        }
+        else {
           incCommandStat("allow_allowed");
           incPrometheusAllowStatusMetric("allowed");
         }
-	Json::object jattrs;
-	for (auto& i : ret_attrs) {
-	  jattrs.insert(make_pair(i.first, Json(i.second)));
-	}
-	msg=Json::object{{"status", status}, {"msg", ret_msg}, {"r_attrs", jattrs}};
+        Json::object jattrs;
+        for (auto& i : ret_attrs) {
+          jattrs.insert(make_pair(i.first, Json(i.second)));
+        }
+        msg = Json::object{{"status",  status},
+                           {"msg",     ret_msg},
+                           {"r_attrs", jattrs}};
 
-	// generate webhook events
+        // generate webhook events
         runAllowWebHook(lt.to_json(), msg, status);
 
-	resp.status=200;
-	resp.body=msg.dump();
-	return;
+        resp.status = 200;
+        resp.body = msg.dump();
+        return;
       }
-      catch(LuaContext::ExecutionErrorException& e) {
-	resp.status=500;
-	std::stringstream ss;
-	try {
-	  std::rethrow_if_nested(e);
-	  ss << "{\"status\":\"failure\", \"reason\":\"" << e.what() << "\"}";
-	  resp.body=ss.str();
-	  errlog("Lua function [%s] exception: %s", command, e.what());
-	  return;
-	}
-	catch (const std::exception& ne) {
-	  resp.status=500;
-	  std::stringstream ss;
-	  ss << "{\"status\":\"failure\", \"reason\":\"" << ne.what() << "\"}";
-	  resp.body=ss.str();
-	  errlog("Exception in command [%s] exception: %s", command, ne.what());
-	  return;
-	}
-	catch (const WforceException& ne) {
-	  resp.status=500;
-	  std::stringstream ss;
-	  ss << "{\"status\":\"failure\", \"reason\":\"" << ne.reason << "\"}";
-	  resp.body=ss.str();
-	  errlog("Exception in command [%s] exception: %s", command, ne.reason);
-	  return;
-	}
+      catch (LuaContext::ExecutionErrorException& e) {
+        resp.status = 500;
+        std::stringstream ss;
+        try {
+          std::rethrow_if_nested(e);
+          ss << "{\"status\":\"failure\", \"reason\":\"" << e.what() << "\"}";
+          resp.body = ss.str();
+          errlog("Lua function [%s] exception: %s", command, e.what());
+          return;
+        }
+        catch (const std::exception& ne) {
+          resp.status = 500;
+          std::stringstream ss;
+          ss << "{\"status\":\"failure\", \"reason\":\"" << ne.what() << "\"}";
+          resp.body = ss.str();
+          errlog("Exception in command [%s] exception: %s", command, ne.what());
+          return;
+        }
+        catch (const WforceException& ne) {
+          resp.status = 500;
+          std::stringstream ss;
+          ss << "{\"status\":\"failure\", \"reason\":\"" << ne.reason << "\"}";
+          resp.body = ss.str();
+          errlog("Exception in command [%s] exception: %s", command, ne.reason);
+          return;
+        }
       }
-      catch(const std::exception& e) {
-	resp.status=500;
-	std::stringstream ss;
-	ss << "{\"status\":\"failure\", \"reason\":\"" << e.what() << "\"}";
-	resp.body=ss.str();
-	errlog("Exception in command [%s] exception: %s", command, e.what());
-	return;
+      catch (const std::exception& e) {
+        resp.status = 500;
+        std::stringstream ss;
+        ss << "{\"status\":\"failure\", \"reason\":\"" << e.what() << "\"}";
+        resp.body = ss.str();
+        errlog("Exception in command [%s] exception: %s", command, e.what());
+        return;
       }
-      catch(const WforceException& e) {
-	resp.status=500;
-	std::stringstream ss;
-	ss << "{\"status\":\"failure\", \"reason\":\"" << e.reason << "\"}";
-	resp.body=ss.str();
-	errlog("Exception in command [%s] exception: %s", command, e.reason);
+      catch (const WforceException& e) {
+        resp.status = 500;
+        std::stringstream ss;
+        ss << "{\"status\":\"failure\", \"reason\":\"" << e.reason << "\"}";
+        resp.body = ss.str();
+        errlog("Exception in command [%s] exception: %s", command, e.reason);
       }
     }
     Json::object jattrs;
     for (auto& i : ret_attrs) {
       jattrs.insert(make_pair(i.first, Json(i.second)));
     }
-    msg=Json::object{{"status", status}, {"msg", ret_msg}, {"r_attrs", jattrs}};
-    resp.status=200;
-    resp.body=msg.dump();
+    msg = Json::object{{"status",  status},
+                       {"msg",     ret_msg},
+                       {"r_attrs", jattrs}};
+    resp.status = 200;
+    resp.body = msg.dump();
   }
 }
 
@@ -873,21 +1063,21 @@ void parseStatsCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const std
   struct rusage ru;
   getrusage(RUSAGE_SELF, &ru);
 
-  resp.status=200;
-  Json my_json = Json::object {
-    { "reports", (int)g_stats.reports },
-    { "allows", (int)g_stats.allows },
-    { "denieds", (int)g_stats.denieds },
-    { "user-msec", (int)(ru.ru_utime.tv_sec*1000ULL + ru.ru_utime.tv_usec/1000) },
-    { "sys-msec", (int)(ru.ru_stime.tv_sec*1000ULL + ru.ru_stime.tv_usec/1000) },
-    { "uptime", uptimeOfProcess()},
-    { "perfstats", perfStatsToJson()},
-    { "commandstats", commandStatsToJson()},
-    { "customstats", customStatsToJson()}
+  resp.status = 200;
+  Json my_json = Json::object{
+      {"reports",      (int) g_stats.reports},
+      {"allows",       (int) g_stats.allows},
+      {"denieds",      (int) g_stats.denieds},
+      {"user-msec",    (int) (ru.ru_utime.tv_sec * 1000ULL + ru.ru_utime.tv_usec / 1000)},
+      {"sys-msec",     (int) (ru.ru_stime.tv_sec * 1000ULL + ru.ru_stime.tv_usec / 1000)},
+      {"uptime",       uptimeOfProcess()},
+      {"perfstats",    perfStatsToJson()},
+      {"commandstats", commandStatsToJson()},
+      {"customstats",  customStatsToJson()}
   };
 
-  resp.status=200;
-  resp.body=my_json.dump();
+  resp.status = 200;
+  resp.body = my_json.dump();
   incCommandStat("stats");
   incPrometheusCommandMetric("stats");
 }
@@ -900,7 +1090,7 @@ void parseGetBLWLCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const s
   std::vector<BlackWhiteListEntry> lv;
   std::string key_name;
   std::string cmd_stat;
-  
+
   if (blacklist) {
     key_name = "bl_entries";
     cmd_stat = "getBL";
@@ -909,7 +1099,7 @@ void parseGetBLWLCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const s
     key_name = "wl_entries";
     cmd_stat = "getWL";
   }
-  
+
   if (blacklist)
     lv = g_bl_db.getIPEntries();
   else
@@ -923,13 +1113,13 @@ void parseGetBLWLCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const s
   if (blacklist)
     lv = g_bl_db.getIPLoginEntries();
   else
-    lv = g_wl_db.getIPLoginEntries();    
+    lv = g_wl_db.getIPLoginEntries();
   addBLWLEntries(lv, "iplogin", my_entries);
-      
-  Json ret_json = Json::object {
-    { key_name, my_entries }
+
+  Json ret_json = Json::object{
+      {key_name, my_entries}
   };
-  resp.status=200;
+  resp.status = 200;
   resp.body = ret_json.dump();
   incCommandStat(cmd_stat);
   incPrometheusCommandMetric(cmd_stat);
@@ -950,21 +1140,21 @@ void parseGetStatsCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const 
   using namespace json11;
   Json msg;
   string err;
-  msg=Json::parse(req.body, err);
+  msg = Json::parse(req.body, err);
   if (msg.is_null()) {
-    resp.status=500;
+    resp.status = 500;
     std::stringstream ss;
     ss << "{\"status\":\"failure\", \"reason\":\"" << err << "\"}";
-    resp.body=ss.str();
+    resp.body = ss.str();
   }
   else {
-    bool haveIP=false;
-    bool haveLogin=false;
+    bool haveIP = false;
+    bool haveLogin = false;
     std::string en_type, en_login;
     std::string key_name, key_value;
     TWKeyType lookup_key;
-    bool is_blacklisted=false;
-    bool is_whitelisted=false;
+    bool is_blacklisted = false;
+    bool is_whitelisted = false;
     std::string bl_reason;
     std::string bl_expire;
     std::string wl_reason;
@@ -974,20 +1164,20 @@ void parseGetStatsCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const 
 
     try {
       if (!msg["ip"].is_null()) {
-	string myip = msg["ip"].string_value();
-	en_ca = ComboAddress(myip);
-	haveIP = true;
+        string myip = msg["ip"].string_value();
+        en_ca = ComboAddress(myip);
+        haveIP = true;
       }
       if (!msg["login"].is_null()) {
-	en_login = msg["login"].string_value();
-	if (!canonicalizeLogin(en_login, resp))
-	  return;
-	haveLogin = true;
+        en_login = msg["login"].string_value();
+        if (!canonicalizeLogin(en_login, resp))
+          return;
+        haveLogin = true;
       }
       if (haveLogin && haveIP) {
-	key_name = "ip_login";
-	key_value = en_ca.toString() + ":" + en_login;
-	lookup_key = key_value;
+        key_name = "ip_login";
+        key_value = en_ca.toString() + ":" + en_login;
+        lookup_key = key_value;
         if (g_bl_db.getEntry(en_ca, en_login, bwle)) {
           is_blacklisted = true;
           bl_reason = bwle.reason;
@@ -1000,9 +1190,9 @@ void parseGetStatsCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const 
         }
       }
       else if (haveLogin) {
-	key_name = "login";
-	key_value = en_login;
-	lookup_key = en_login;
+        key_name = "login";
+        key_value = en_login;
+        lookup_key = en_login;
         if (g_bl_db.getEntry(en_login, bwle)) {
           is_blacklisted = true;
           bl_reason = bwle.reason;
@@ -1015,9 +1205,9 @@ void parseGetStatsCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const 
         }
       }
       else if (haveIP) {
-	key_name = "ip";
-	key_value = en_ca.toString();
-	lookup_key = en_ca;
+        key_name = "ip";
+        key_value = en_ca.toString();
+        lookup_key = en_ca;
         if (g_bl_db.getEntry(en_ca, bwle)) {
           is_blacklisted = true;
           bl_reason = bwle.reason;
@@ -1030,51 +1220,53 @@ void parseGetStatsCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const 
         }
       }
     }
-    catch(...) {
-	resp.status=500;
-	resp.body=R"({"status":"failure", "reason":"Could not parse input"})";
-	return;
+    catch (...) {
+      resp.status = 500;
+      resp.body = R"({"status":"failure", "reason":"Could not parse input"})";
+      return;
     }
-    
+
     if (!haveLogin && !haveIP) {
       resp.status = 415;
-      resp.body=R"({"status":"failure", "reason":"No ip or login field supplied"})";
-    } 
+      resp.body = R"({"status":"failure", "reason":"No ip or login field supplied"})";
+    }
     else {
       Json::object js_db_stats;
       {
-	std::lock_guard<std::mutex> lock(dbMap_mutx);
-	for (auto i = dbMap.begin(); i != dbMap.end(); ++i) {
-	  std::string dbName = i->first;
-	  std::vector<std::pair<std::string, int>> db_fields;
-	  if (i->second.get_all_fields(lookup_key, db_fields)) {
-	    Json::object js_db_fields;
-	    for (auto j = db_fields.begin(); j != db_fields.end(); ++j) {
-	      js_db_fields.insert(make_pair(j->first, j->second));
-	    }
-	    js_db_stats.insert(make_pair(dbName, js_db_fields));
-	  }
-	}
+        std::lock_guard<std::mutex> lock(dbMap_mutx);
+        for (auto i = dbMap.begin(); i != dbMap.end(); ++i) {
+          std::string dbName = i->first;
+          std::vector<std::pair<std::string, int>> db_fields;
+          if (i->second.get_all_fields(lookup_key, db_fields)) {
+            Json::object js_db_fields;
+            for (auto j = db_fields.begin(); j != db_fields.end(); ++j) {
+              js_db_fields.insert(make_pair(j->first, j->second));
+            }
+            js_db_stats.insert(make_pair(dbName, js_db_fields));
+          }
+        }
       }
-      Json ret_json = Json::object {
-	{ key_name, key_value },
-	{ "whitelisted", is_whitelisted },
-        { "wl_reason", wl_reason },
-        { "wl_expire", wl_expire },
-	{ "blacklisted", is_blacklisted },
-        { "bl_reason", bl_reason },
-        { "bl_expire", bl_expire },
-	{ "stats", js_db_stats }
+      Json ret_json = Json::object{
+          {key_name,      key_value},
+          {"whitelisted", is_whitelisted},
+          {"wl_reason",   wl_reason},
+          {"wl_expire",   wl_expire},
+          {"blacklisted", is_blacklisted},
+          {"bl_reason",   bl_reason},
+          {"bl_expire",   bl_expire},
+          {"stats",       js_db_stats}
       };
-      resp.status=200;
-      resp.body = ret_json.dump();  
+      resp.status = 200;
+      resp.body = ret_json.dump();
     }
   }
   incCommandStat("getDBStats");
   incPrometheusCommandMetric("getDBStats");
 }
 
-enum CustomReturnFields { customRetStatus=0, customRetAttrs=1 };
+enum CustomReturnFields {
+  customRetStatus = 0, customRetAttrs = 1
+};
 
 void parseCustomCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const std::string& command)
 {
@@ -1083,76 +1275,77 @@ void parseCustomCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const st
   string err;
   KeyValVector ret_attrs;
 
-  msg=Json::parse(req.body, err);
+  msg = Json::parse(req.body, err);
   if (msg.is_null()) {
-    resp.status=500;
+    resp.status = 500;
     std::stringstream ss;
     ss << "{\"success\":\"failure\", \"reason\":\"" << err << "\"}";
-    resp.body=ss.str();
+    resp.body = ss.str();
   }
   else {
     CustomFuncArgs cfa;
     bool status = false;
-    
+
     try {
       cfa.setAttrs(msg);
     }
-    catch(...) {
-      resp.status=500;
-      resp.body=R"({"success":false, "reason":"Could not parse input"})";
+    catch (...) {
+      resp.status = 500;
+      resp.body = R"({"success":false, "reason":"Could not parse input"})";
       return;
     }
 
     try {
-      bool reportSink=false;
+      bool reportSink = false;
       CustomFuncReturn cr;
       {
-	cr=g_luamultip->custom_func(command, cfa, reportSink);
+        cr = g_luamultip->custom_func(command, cfa, reportSink);
       }
       status = std::get<customRetStatus>(cr);
       ret_attrs = std::get<customRetAttrs>(cr);
       Json::object jattrs;
       for (auto& i : ret_attrs) {
-	jattrs.insert(make_pair(i.first, Json(i.second)));
+        jattrs.insert(make_pair(i.first, Json(i.second)));
       }
-      msg=Json::object{{"success", status}, {"r_attrs", jattrs}};
+      msg = Json::object{{"success", status},
+                         {"r_attrs", jattrs}};
 
       // send the custom parameters to the report sink if configured
       if (reportSink)
-	sendNamedReportSink(cfa.serialize());
-      
-      resp.status=200;
-      resp.body=msg.dump();
+        sendNamedReportSink(cfa.serialize());
+
+      resp.status = 200;
+      resp.body = msg.dump();
     }
-    catch(LuaContext::ExecutionErrorException& e) {
-      resp.status=500;
+    catch (LuaContext::ExecutionErrorException& e) {
+      resp.status = 500;
       std::stringstream ss;
       try {
-	std::rethrow_if_nested(e);
-	ss << "{\"success\":false, \"reason\":\"" << e.what() << "\"}";
-	resp.body=ss.str();
-	errlog("Lua custom function [%s] exception: %s", command, e.what());
+        std::rethrow_if_nested(e);
+        ss << "{\"success\":false, \"reason\":\"" << e.what() << "\"}";
+        resp.body = ss.str();
+        errlog("Lua custom function [%s] exception: %s", command, e.what());
       }
       catch (const std::exception& ne) {
-	resp.status=500;
-	std::stringstream ss;
-	ss << "{\"success\":false, \"reason\":\"" << ne.what() << "\"}";
-	resp.body=ss.str();
-	errlog("Exception in command [%s] exception: %s", command, ne.what());
+        resp.status = 500;
+        std::stringstream ss;
+        ss << "{\"success\":false, \"reason\":\"" << ne.what() << "\"}";
+        resp.body = ss.str();
+        errlog("Exception in command [%s] exception: %s", command, ne.what());
       }
       catch (const WforceException& ne) {
-	resp.status=500;
-	std::stringstream ss;
-	ss << "{\"success\":false, \"reason\":\"" << ne.reason << "\"}";
-	resp.body=ss.str();
-	errlog("Exception in command [%s] exception: %s", command, ne.reason);
+        resp.status = 500;
+        std::stringstream ss;
+        ss << "{\"success\":false, \"reason\":\"" << ne.reason << "\"}";
+        resp.body = ss.str();
+        errlog("Exception in command [%s] exception: %s", command, ne.reason);
       }
     }
-    catch(const std::exception& e) {
-      resp.status=500;
+    catch (const std::exception& e) {
+      resp.status = 500;
       std::stringstream ss;
       ss << "{\"success\":false, \"reason\":\"" << e.what() << "\"}";
-      resp.body=ss.str();
+      resp.body = ss.str();
       errlog("Exception in command [%s] exception: %s", command, e.what());
     }
   }
@@ -1166,43 +1359,43 @@ void parseCustomGetCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const
   string err;
 
   try {
-    std::string ret_msg =g_luamultip->custom_get_func(command);
-    resp.status=200;
-    resp.body=ret_msg;
+    std::string ret_msg = g_luamultip->custom_get_func(command);
+    resp.status = 200;
+    resp.body = ret_msg;
   }
-  catch(LuaContext::ExecutionErrorException& e) {
-    resp.status=500;
+  catch (LuaContext::ExecutionErrorException& e) {
+    resp.status = 500;
     std::stringstream ss;
     try {
       std::rethrow_if_nested(e);
       ss << "{\"success\":false, \"reason\":\"" << e.what() << "\"}";
-      resp.body=ss.str();
+      resp.body = ss.str();
       errlog("Lua custom function [%s] exception: %s", command, e.what());
     }
     catch (const std::exception& ne) {
-      resp.status=500;
+      resp.status = 500;
       std::stringstream ss;
       ss << "{\"success\":false, \"reason\":\"" << ne.what() << "\"}";
-      resp.body=ss.str();
+      resp.body = ss.str();
       errlog("Exception in command [%s] exception: %s", command, ne.what());
     }
     catch (const WforceException& ne) {
-      resp.status=500;
+      resp.status = 500;
       std::stringstream ss;
       ss << "{\"success\":false, \"reason\":\"" << ne.reason << "\"}";
-      resp.body=ss.str();
+      resp.body = ss.str();
       errlog("Exception in command [%s] exception: %s", command, ne.reason);
     }
   }
-  catch(const std::exception& e) {
-    resp.status=500;
+  catch (const std::exception& e) {
+    resp.status = 500;
     std::stringstream ss;
     ss << "{\"success\":false, \"reason\":\"" << e.what() << "\"}";
-    resp.body=ss.str();
+    resp.body = ss.str();
     errlog("Exception in command [%s] exception: %s", command, e.what());
   }
-  incCommandStat(command+"_Get");
-  incPrometheusCommandMetric(command+"_Get");
+  incCommandStat(command + "_Get");
+  incPrometheusCommandMetric(command + "_Get");
 }
 
 std::atomic<bool> g_ping_up{false};
@@ -1222,7 +1415,7 @@ void parseSyncDoneCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, const 
 {
   resp.status = 200;
   g_ping_up = true;
-  
+
   resp.body = R"({"status":"ok"})";
   incCommandStat("syncDone");
   incPrometheusCommandMetric("syncDone");
@@ -1285,4 +1478,13 @@ void registerWebserverCommands()
   addCommandStat("dumpEntries");
   addPrometheusCommandMetric("dumpEntries");
   g_webserver.registerFunc("dumpEntries", HTTPVerb::POST, WforceWSFunc(parseDumpEntriesCmd));
+  addCommandStat("addSibling");
+  addPrometheusCommandMetric("addSibling");
+  g_webserver.registerFunc("addSibling", HTTPVerb::POST, WforceWSFunc(parseAddSiblingCmd));
+  addCommandStat("removeSibling");
+  addPrometheusCommandMetric("removeSibling");
+  g_webserver.registerFunc("removeSibling", HTTPVerb::POST, WforceWSFunc(parseRemoveSiblingCmd));
+  addCommandStat("setSiblings");
+  addPrometheusCommandMetric("setSiblings");
+  g_webserver.registerFunc("setSiblings", HTTPVerb::POST, WforceWSFunc(parseSetSiblingsCmd));
 }

--- a/wforce/wforce.hh
+++ b/wforce/wforce.hh
@@ -94,13 +94,13 @@ extern bool g_allowlog_verbose; // Whether to log allow returns of 0
 
 void dumpEntriesThread(const ComboAddress& ca, std::unique_lock<std::mutex> lock);
 void syncDBThread(const ComboAddress& ca, const std::string& callback_url,
-                  const std::string& calback_pw);
+                  const std::string& calback_pw, const std::string& encryption_key);
 
 struct syncData {
-  std::vector<std::pair<ComboAddress, std::string>> sync_hosts;
+  std::vector<std::pair<std::string, std::string>> sync_hosts;
   unsigned int min_sync_host_uptime;
   ComboAddress sibling_listen_addr;
-  ComboAddress webserver_listen_addr;
+  std::string  webserver_listen_addr;
   std::string  webserver_password;
 };
 


### PR DESCRIPTION
This PR addresses two issues with the current version of wforce:
1) the single encryption key that has to be shared between all wforce instances
2) the inability to dynamically add siblings, which would extremely useful in environments such as kubernetes, where cluster membership could be highly dynamic

Utility functions for adding/removing/setting siblings are also added, which are used to manage siblings from Lua as well as from the new REST API commands to manage siblings.