### PR TITLE
Bump jinja2 to 2.11.3 and bottle to 2.10.3 in report_api and regression tests

### DIFF
--- a/regression-tests/requirements.txt
+++ b/regression-tests/requirements.txt
@@ -7,10 +7,10 @@ Flask==1.0.4
 Flask-Elastic==0.2
 Flask-HTTPAuth==3.2.3
 itsdangerous==0.24
-Jinja2==2.10.1
+Jinja2==2.11.3
 MarkupSafe==1.0
 pytz==2017.2
 urllib3==1.24.2
 Werkzeug==0.15.3
-bottle==0.12.16
+bottle==0.12.19
 prometheus_client==0.7.1

--- a/report_api/requirements.txt
+++ b/report_api/requirements.txt
@@ -5,7 +5,7 @@ Flask==1.0.4
 Flask-Elastic==0.2
 Flask-HTTPAuth==3.2.3
 itsdangerous==0.24
-Jinja2==2.10.1
+Jinja2==2.11.3
 MarkupSafe==1.1.0
 pytz==2017.2
 urllib3==1.24.2


### PR DESCRIPTION
Because security