### PR TITLE
Refactor wforce-replication.cc from a collection of functions into a class

### DIFF
--- a/wforce/wforce-prometheus.cc
+++ b/wforce/wforce-prometheus.cc
@@ -347,7 +347,7 @@ void setPrometheusReplRecvQueueSize(int value)
   }
 }
 
-void setPrometheusReplRecvQueueRetrieveFunc(int (* func)())
+void setPrometheusReplRecvQueueRetrieveFunc(std::function<int()> func)
 {
   if (wforce_prom_metrics) {
     wforce_prom_metrics->setReplRecvQueueRetrieveFunc(func);

--- a/wforce/wforce-prometheus.hh
+++ b/wforce/wforce-prometheus.hh
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <functional>
 #include "prometheus.hh"
 #include "wforce_exception.hh"
 
@@ -111,7 +112,7 @@ public:
     repl_recv_queue_size->Set(value);
   }
 
-  void setReplRecvQueueRetrieveFunc(int (*func)())
+  void setReplRecvQueueRetrieveFunc(std::function<int()> func)
   {
     repl_queue_func = func;
   }
@@ -150,7 +151,7 @@ private:
   Gauge* wl_entries_login;
   Gauge* wl_entries_iplogin;
   Gauge* repl_recv_queue_size;
-  int (*repl_queue_func)();
+  std::function<int()> repl_queue_func;
 };
 
 void initWforcePrometheusMetrics(std::shared_ptr<WforcePrometheus> wpmp);
@@ -176,4 +177,4 @@ void setPrometheusBLIPLoginEntries(int);
 void setPrometheusWLIPLoginEntries(int);
 
 void setPrometheusReplRecvQueueSize(int value);
-void setPrometheusReplRecvQueueRetrieveFunc(int (*func)());
+void setPrometheusReplRecvQueueRetrieveFunc(std::function<int()> func);

--- a/wforce/wforce-web.cc
+++ b/wforce/wforce-web.cc
@@ -298,12 +298,12 @@ void parseAddSiblingCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, cons
 
       std::string error_msg;
       if (!has_encryption_key) {
-        if (!addSibling(sibling_host, sibling_port, proto, g_siblings, error_msg)) {
+        if (!addSibling(sibling_host, sibling_port, proto, g_replication.getSiblings(), error_msg)) {
           throw WforceException(error_msg);
         }
       }
       else {
-        if (!addSiblingWithKey(sibling_host, sibling_port, proto, g_siblings, error_msg, encryption_key)) {
+        if (!addSiblingWithKey(sibling_host, sibling_port, proto, g_replication.getSiblings(), error_msg, encryption_key)) {
           throw WforceException(error_msg);
         }
       }
@@ -347,7 +347,7 @@ void parseRemoveSiblingCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, c
       int sibling_port = msg["sibling_port"].int_value();
 
       std::string error_msg;
-      if (!removeSibling(sibling_host, sibling_port, g_siblings, error_msg)) {
+      if (!removeSibling(sibling_host, sibling_port, g_replication.getSiblings(), error_msg)) {
         throw WforceException(error_msg);
       }
     }
@@ -411,7 +411,7 @@ void parseSetSiblingsCmd(const YaHTTP::Request& req, YaHTTP::Response& resp, con
         new_siblings.emplace_back(std::pair<int, std::vector<std::pair<int, std::string>>>{0, {{0, createSiblingAddress(sibling_host, sibling_port, proto)}, {1, encryption_key}}});
       }
       std::string error_msg;
-      if (!setSiblingsWithKey(new_siblings, g_siblings, error_msg)) {
+      if (!setSiblingsWithKey(new_siblings, g_replication.getSiblings(), error_msg)) {
         throw WforceException(error_msg);
       }
     }

--- a/wforce/wforce.hh
+++ b/wforce/wforce.hh
@@ -41,6 +41,7 @@
 #include <boost/multi_index/identity.hpp>
 #include <boost/multi_index/sequenced_index.hpp>
 #include "wforce-sibling.hh"
+#include "wforce-replication.hh"
 
 struct WForceStats
 {
@@ -65,6 +66,7 @@ extern std::mutex g_luamutex;
 extern LuaContext g_lua;
 extern std::string g_outputBuffer; // locking for this is ok, as locked by g_luamutex (functions using g_outputBuffer MUST NOT be enabled for the allow/report lua contexts)
 extern WforceWebserver g_webserver;
+extern WforceReplication g_replication;
 
 extern GlobalStateHolder<NetmaskGroup> g_ACL;
 extern ComboAddress g_sibling_listen;
@@ -103,6 +105,8 @@ struct syncData {
   std::string  webserver_listen_addr;
   std::string  webserver_password;
 };
+
+void replicateOperation(const ReplicationOperation& rep_op);
 
 extern syncData g_sync_data;
 extern bool g_builtin_bl_enabled;


### PR DESCRIPTION
This not only provides better modularity, but it also allows key
functions to be overidden in subclasses. This change affects quite a lot
of other files, so this is a fairly chunky commit.
Using a class also replaces a whole bunch of globals with a single global for
the class instance.