### PR TITLE
Fix Synchronization Bug

### DIFF
--- a/docker/wforce_image/Dockerfile
+++ b/docker/wforce_image/Dockerfile
@@ -113,7 +113,7 @@ RUN rm -rf /wforce/*
 ENV TINI_VERSION v0.18.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc /tini.asc
-RUN gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
+RUN gpg --batch --keyserver hkps://peegeepee.com --recv-keys 6380DC428747F6C393FEACA59A84159D7001A4E5 \
  && gpg --batch --verify /tini.asc /tini
 RUN chmod 755 /tini
 

--- a/wforce/wforce-replication.cc
+++ b/wforce/wforce-replication.cc
@@ -193,7 +193,7 @@ void WforceReplication::parseTCPReplication(std::shared_ptr<Socket> sockp, const
   
   try {
     while(true) {
-      len = sockp->read((char*)&size, ssize);
+      len = sockp->readAll((char*)&size, ssize);
       if (len != ssize) {
         if (len)
           errlog("parseTCPReplication: error reading size, got %d bytes, but was expecting %d bytes", len, ssize);

--- a/wforce/wforce.cc
+++ b/wforce/wforce.cc
@@ -502,7 +502,7 @@ unsigned int dumpEntriesToNetwork(const ComboAddress& ca)
     my_dbmap = dbMap;
   }
   sock.writen("{");
-  for (auto& i : dbMap) {
+  for (auto& i : my_dbmap) {
     TWStringStatsDBWrapper sdb = i.second;
     std::string db_name = i.first;
     sock.writen("\"" + db_name + "\": {");
@@ -582,7 +582,7 @@ unsigned int dumpDBToNetwork(const ComboAddress& ca, const std::string& encrypti
     // copy (this is safe - everything important is in a shared ptr)
     my_dbmap = dbMap;
   }
-  for (auto& i : dbMap) {
+  for (auto& i : my_dbmap) {
     TWStringStatsDBWrapper sdb = i.second;
     std::string db_name = i.first;
     for (auto vi = sdb.begin(); vi != sdb.end(); ++vi) {


### PR DESCRIPTION
Wait for the whole replication length parameter when reading replication messages over TCP. **Should** fix #342

Also fix issue where dbMap was being used instead of the copy in Sync/Dump DBs commands - this would cause issues if a sync was taking place while a statsDB was being added or deleted. Unlikely, but possible.