### PR TITLE
Fix upload warnings on startup and syncDone issue

### DIFF
--- a/common/wforce-webserver.hh
+++ b/common/wforce-webserver.hh
@@ -147,7 +147,7 @@ public:
       drogon::app().disableSigtermHandling();
       drogon::app().setLogLevel(trantor::Logger::kWarn);
       // We will never allow uploads, but drogon wants to create a bunch of temp files in uploadPath/tmp/xx
-      drogon::app().setUploadPath("/var");
+      drogon::app().setUploadPath("/tmp/wforce");
       // Set custom 404 response
       auto resp = drogon::HttpResponse::newHttpResponse();
       resp->setBody(R"({"status":"failure", "reason":"Not found"})");

--- a/common/wforce-webserver.hh
+++ b/common/wforce-webserver.hh
@@ -228,6 +228,11 @@ public:
     }
   }
 
+  bool isRunning()
+  {
+    return drogon::app().isRunning();
+  }
+
 protected:
   template <typename Clock>
   void updateWTR(const std::chrono::time_point<Clock>& start_time)

--- a/common/wforce-webserver.hh
+++ b/common/wforce-webserver.hh
@@ -146,6 +146,8 @@ public:
       drogon::app().disableSession();
       drogon::app().disableSigtermHandling();
       drogon::app().setLogLevel(trantor::Logger::kWarn);
+      // We will never allow uploads, but drogon wants to create a bunch of temp files in uploadPath/tmp/xx
+      drogon::app().setUploadPath("/var");
       // Set custom 404 response
       auto resp = drogon::HttpResponse::newHttpResponse();
       resp->setBody(R"({"status":"failure", "reason":"Not found"})");

--- a/wforce/wforce-common-lua.cc
+++ b/wforce/wforce-common-lua.cc
@@ -28,7 +28,6 @@
 #include "webhook.hh"
 #include "wforce-webserver.hh"
 #include "wforce-common-lua.hh"
-#include "wforce-web.hh"
 #include <boost/filesystem.hpp>
 
 using std::thread;

--- a/wforce/wforce.cc
+++ b/wforce/wforce.cc
@@ -1126,6 +1126,11 @@ try
   for(auto& t : todo)
     t();
 
+  // Give time for the webserver to start
+  while (!g_webserver.isRunning()) {
+    sleep(1);
+  }
+
   // Loop through the list of configured sync hosts, check if any have been
   // up long enough and if so, kick off a DB sync operation to fill our DBs
   checkSyncHosts();


### PR DESCRIPTION
The drogon HTTP framework we now use for the REST API also allows file uploads, which we don't use. Unfortunately, by default it tries to create a bunch of directories in the working directory, which is usually not writable (e.g. /etc/wforce), as described in #355.

This PR modifies the drogon upload directory so that the warnings do not occur.

This PR also ensures that before the syncDB functions are called, that the webserver is running, otherwise it sleeps until the webserver is running. This fixes the issue described in #358.
