### PR TITLE
Use debian-bullseye-slim for docker image saving over 100MB and also

### DIFF
--- a/docker/wforce_image/Dockerfile
+++ b/docker/wforce_image/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster as wforce_build
+FROM debian:bullseye-slim as wforce_build
 
 RUN apt-get update && \
     apt-get dist-upgrade -y && \
@@ -61,7 +61,7 @@ RUN ./configure --prefix /usr --enable-trackalert --disable-systemd --disable-do
 RUN make clean
 RUN make install DESTDIR=/wforce/install
 
-FROM debian:buster as wforce_image
+FROM debian:bullseye-slim as wforce_image
 
 WORKDIR /wforce/
 
@@ -72,18 +72,18 @@ COPY --from=wforce_build /wforce/report_api /wforce/report_api
 RUN apt-get update && \
     apt-get dist-upgrade -y && \
     apt-get -y -f install \
-               libboost-date-time1.67.0 \
-               libboost-regex1.67.0 \
-               libboost-system1.67.0 \
-               libboost-filesystem1.67.0 \
+               libboost-date-time1.74.0 \
+               libboost-regex1.74.0 \
+               libboost-system1.74.0 \
+               libboost-filesystem1.74.0 \
                libcurl4 \
                libgeoip1 \
                libgetdns10 \
                libhiredis0.14 \
                libluajit-5.1-2 \
                libmaxminddb0 \
-               libreadline7 \
-               libprotobuf17 \
+               libreadline8 \
+               libprotobuf23 \
                libssl1.1 \
                libsodium23 \
                libyaml-cpp0.6 \

--- a/docker/wforce_image/docker-entrypoint.sh
+++ b/docker/wforce_image/docker-entrypoint.sh
@@ -18,6 +18,11 @@ if [[ "x$TRACKALERT" == "x" ]]; then
     if [[ "$WFORCE_VERBOSE" -eq "1" ]]; then
         WFORCE_CMD="$WFORCE_CMD -v"
     fi
+    # Check if they just supplied their own wforce.conf file
+    if [[ -f /etc/wforce/wforce.conf ]]; then
+      echo "Using supplied wforce config file"
+      WFORCE_CONFIG_FILE=/etc/wforce/wforce.conf
+    fi
     if [[ "x$WFORCE_CONFIG_FILE" == "x" ]]; then
         if [[ "x$WFORCE_HTTP_PASSWORD" == "x" ]]; then
             2>&1 echo "WFORCE_HTTP_PASSWORD environment variable must be set"

--- a/docker/wforce_image/docker-entrypoint.sh
+++ b/docker/wforce_image/docker-entrypoint.sh
@@ -20,7 +20,7 @@ if [[ "x$TRACKALERT" == "x" ]]; then
     fi
     # Check if they just supplied their own wforce.conf file
     if [[ -f /etc/wforce/wforce.conf ]]; then
-      echo "Using supplied wforce config file"
+      echo "Using supplied wforce config file /etc/wforce/wforce.conf"
       WFORCE_CONFIG_FILE=/etc/wforce/wforce.conf
     fi
     if [[ "x$WFORCE_CONFIG_FILE" == "x" ]]; then


### PR DESCRIPTION
- Use debian bullseye-slim to save space (over 100MB)
- Check for users providing their own config file (e.g. via a volume mount) and use that instead of generating a new config file