### PR TITLE
Better redis error checking in BlackWhiteListDB::loadPersistEntries()

### DIFF
--- a/wforce/blackwhitelist.cc
+++ b/wforce/blackwhitelist.cc
@@ -55,7 +55,7 @@ void BlackWhiteListDB::addEntry(const Netmask& nm, time_t seconds, const std::st
 void BlackWhiteListDB::addEntry(const ComboAddress& ca, time_t seconds, const std::string& reason)
 {
   std::string key = Netmask(ca).toStringNetwork();
-  
+
   addEntryInternal(key, seconds, IP_BLWL, reason, true);
   addEntryLog(IP_BLWL, key, seconds, reason);
 }
@@ -66,81 +66,87 @@ void BlackWhiteListDB::addEntry(const std::string& login, time_t seconds, const 
   addEntryLog(LOGIN_BLWL, login, seconds, reason);
 }
 
-void BlackWhiteListDB::addEntry(const ComboAddress& ca, const std::string& login, time_t seconds, const std::string& reason)
+void
+BlackWhiteListDB::addEntry(const ComboAddress& ca, const std::string& login, time_t seconds, const std::string& reason)
 {
   std::string key = ipLoginStr(ca, login);
   addEntryInternal(key, seconds, IP_LOGIN_BLWL, reason, true);
   addEntryLog(IP_LOGIN_BLWL, key, seconds, reason);
 }
 
-void BlackWhiteListDB::addEntryInternal(const std::string& key, time_t seconds, BLWLType blwl_type, const std::string& reason, bool replicate)
+void BlackWhiteListDB::addEntryInternal(const std::string& key, time_t seconds, BLWLType blwl_type,
+                                        const std::string& reason, bool replicate)
 {
   WriteLock wl(&rwlock);
 
   switch (blwl_type) {
-  case IP_BLWL:
-    _addEntry(key, seconds, ip_list, reason);
-    iplist_netmask.addMask(key);
-    addEntryLog(IP_BLWL, key, seconds, reason);
-    if (persist && ((replicate == true) || ((replicate == false) && persist_replicated)))
-      addPersistEntry(key, seconds, IP_BLWL, reason);
-    if (replicate == true) {
-      if (db_type == BLWLDBType::BLACKLIST) {
-        std::shared_ptr<BLReplicationOperation> bl_rop;
-        bl_rop = std::make_shared<BLReplicationOperation>(BLOperation_BLOpType_BLAdd, IP_BLWL, key, seconds, reason);
-        ReplicationOperation rep_op(bl_rop, WforceReplicationMsg_RepType_BlacklistType);
-        replicateOperation(rep_op);
+    case IP_BLWL:
+      _addEntry(key, seconds, ip_list, reason);
+      iplist_netmask.addMask(key);
+      addEntryLog(IP_BLWL, key, seconds, reason);
+      if (persist && ((replicate == true) || ((replicate == false) && persist_replicated)))
+        addPersistEntry(key, seconds, IP_BLWL, reason);
+      if (replicate == true) {
+        if (db_type == BLWLDBType::BLACKLIST) {
+          std::shared_ptr<BLReplicationOperation> bl_rop;
+          bl_rop = std::make_shared<BLReplicationOperation>(BLOperation_BLOpType_BLAdd, IP_BLWL, key, seconds, reason);
+          ReplicationOperation rep_op(bl_rop, WforceReplicationMsg_RepType_BlacklistType);
+          replicateOperation(rep_op);
+        }
+        else {
+          std::shared_ptr<WLReplicationOperation> wl_rop;
+          wl_rop = std::make_shared<WLReplicationOperation>(BLOperation_BLOpType_BLAdd, IP_BLWL, key, seconds, reason);
+          ReplicationOperation rep_op(wl_rop, WforceReplicationMsg_RepType_WhitelistType);
+          replicateOperation(rep_op);
+        }
       }
-      else {
-        std::shared_ptr<WLReplicationOperation> wl_rop;
-        wl_rop = std::make_shared<WLReplicationOperation>(BLOperation_BLOpType_BLAdd, IP_BLWL, key, seconds, reason);
-        ReplicationOperation rep_op(wl_rop, WforceReplicationMsg_RepType_WhitelistType);
-        replicateOperation(rep_op);
+      break;
+    case LOGIN_BLWL:
+      _addEntry(key, seconds, login_list, reason);
+      addEntryLog(LOGIN_BLWL, key, seconds, reason);
+      if (persist && ((replicate == true) || ((replicate == false) && persist_replicated)))
+        addPersistEntry(key, seconds, LOGIN_BLWL, reason);
+      if (replicate == true) {
+        if (db_type == BLWLDBType::BLACKLIST) {
+          std::shared_ptr<BLReplicationOperation> bl_rop;
+          bl_rop = std::make_shared<BLReplicationOperation>(BLOperation_BLOpType_BLAdd, LOGIN_BLWL, key, seconds,
+                                                            reason);
+          ReplicationOperation rep_op(bl_rop, WforceReplicationMsg_RepType_BlacklistType);
+          replicateOperation(rep_op);
+        }
+        else {
+          std::shared_ptr<WLReplicationOperation> wl_rop;
+          wl_rop = std::make_shared<WLReplicationOperation>(BLOperation_BLOpType_BLAdd, LOGIN_BLWL, key, seconds,
+                                                            reason);
+          ReplicationOperation rep_op(wl_rop, WforceReplicationMsg_RepType_WhitelistType);
+          replicateOperation(rep_op);
+        }
       }
-    }
-    break;
-  case LOGIN_BLWL:
-    _addEntry(key, seconds, login_list, reason);
-    addEntryLog(LOGIN_BLWL, key, seconds, reason);
-    if (persist && ((replicate == true) || ((replicate == false) && persist_replicated)))
-      addPersistEntry(key, seconds, LOGIN_BLWL, reason);
-    if (replicate == true) {
-      if (db_type == BLWLDBType::BLACKLIST) {
-        std::shared_ptr<BLReplicationOperation> bl_rop;
-        bl_rop = std::make_shared<BLReplicationOperation>(BLOperation_BLOpType_BLAdd, LOGIN_BLWL, key, seconds, reason);
-        ReplicationOperation rep_op(bl_rop, WforceReplicationMsg_RepType_BlacklistType);
-        replicateOperation(rep_op);
+      break;
+    case IP_LOGIN_BLWL:
+      _addEntry(key, seconds, ip_login_list, reason);
+      addEntryLog(IP_LOGIN_BLWL, key, seconds, reason);
+      if (persist && ((replicate == true) || ((replicate == false) && persist_replicated)))
+        addPersistEntry(key, seconds, IP_LOGIN_BLWL, reason);
+      if (replicate == true) {
+        if (db_type == BLWLDBType::BLACKLIST) {
+          std::shared_ptr<BLReplicationOperation> bl_rop;
+          bl_rop = std::make_shared<BLReplicationOperation>(BLOperation_BLOpType_BLAdd, IP_LOGIN_BLWL, key, seconds,
+                                                            reason);
+          ReplicationOperation rep_op(bl_rop, WforceReplicationMsg_RepType_BlacklistType);
+          replicateOperation(rep_op);
+        }
+        else {
+          std::shared_ptr<WLReplicationOperation> wl_rop;
+          wl_rop = std::make_shared<WLReplicationOperation>(BLOperation_BLOpType_BLAdd, IP_LOGIN_BLWL, key, seconds,
+                                                            reason);
+          ReplicationOperation rep_op(wl_rop, WforceReplicationMsg_RepType_WhitelistType);
+          replicateOperation(rep_op);
+        }
       }
-      else {
-        std::shared_ptr<WLReplicationOperation> wl_rop;
-        wl_rop = std::make_shared<WLReplicationOperation>(BLOperation_BLOpType_BLAdd, LOGIN_BLWL, key, seconds, reason);
-        ReplicationOperation rep_op(wl_rop, WforceReplicationMsg_RepType_WhitelistType);
-        replicateOperation(rep_op);
-      }
-    }
-    break;
-  case IP_LOGIN_BLWL:
-    _addEntry(key, seconds, ip_login_list, reason);
-    addEntryLog(IP_LOGIN_BLWL, key, seconds, reason);
-    if (persist && ((replicate == true) || ((replicate == false) && persist_replicated)))
-      addPersistEntry(key, seconds, IP_LOGIN_BLWL, reason);
-    if (replicate == true) {
-      if (db_type == BLWLDBType::BLACKLIST) {
-        std::shared_ptr<BLReplicationOperation> bl_rop;
-        bl_rop = std::make_shared<BLReplicationOperation>(BLOperation_BLOpType_BLAdd, IP_LOGIN_BLWL, key, seconds, reason);
-        ReplicationOperation rep_op(bl_rop, WforceReplicationMsg_RepType_BlacklistType);
-        replicateOperation(rep_op);
-      }
-      else {
-        std::shared_ptr<WLReplicationOperation> wl_rop;
-        wl_rop = std::make_shared<WLReplicationOperation>(BLOperation_BLOpType_BLAdd, IP_LOGIN_BLWL, key, seconds, reason);
-        ReplicationOperation rep_op(wl_rop, WforceReplicationMsg_RepType_WhitelistType);
-        replicateOperation(rep_op);
-      }
-    }
-    break;
-  default:
-    break;
+      break;
+    default:
+      break;
   }
   std::string event_name;
   std::string type_name;
@@ -154,15 +160,20 @@ void BlackWhiteListDB::addEntryInternal(const std::string& key, time_t seconds, 
   }
   // only generate webhook for this event for the first add, not for replicas
   if (replicate == true) {
-    Json jobj = Json::object{{"key", key}, {type_name, BLWLTypeToName(blwl_type)}, {"reason", reason}, {"expire_secs", (int)seconds}, {"type", "wforce_addblwl"}};
-    for (const auto& h : g_webhook_db.getWebHooksForEvent(event_name)) {
+    Json jobj = Json::object{{"key",         key},
+                             {type_name,     BLWLTypeToName(blwl_type)},
+                             {"reason",      reason},
+                             {"expire_secs", (int) seconds},
+                             {"type",        "wforce_addblwl"}};
+    for (const auto& h: g_webhook_db.getWebHooksForEvent(event_name)) {
       if (auto hs = h.lock())
-	g_webhook_runner.runHook(event_name, hs, jobj);
+        g_webhook_runner.runHook(event_name, hs, jobj);
     }
   }
 }
 
-void BlackWhiteListDB::_addEntry(const std::string& key, time_t seconds, blackwhitelist_t& blackwhitelist, const std::string& reason)
+void BlackWhiteListDB::_addEntry(const std::string& key, time_t seconds, blackwhitelist_t& blackwhitelist,
+                                 const std::string& reason)
 {
   BlackWhiteListEntry bl;
 
@@ -195,7 +206,7 @@ bool BlackWhiteListDB::checkEntry(const ComboAddress& ca, const std::string& log
 bool BlackWhiteListDB::_checkEntry(const std::string& key, const blackwhitelist_t& blackwhitelist) const
 {
   ReadLock rl(&rwlock);
-  
+
   auto& keyindex = blackwhitelist.get<KeyTag>();
   auto kit = keyindex.find(key);
 
@@ -212,19 +223,20 @@ bool BlackWhiteListDB::getEntry(const ComboAddress& ca, BlackWhiteListEntry& ret
     iplist_netmask.lookup(ca, &nm);
   }
   return _getEntry(nm.toString(), ip_list, ret);
-} 
+}
 
 bool BlackWhiteListDB::getEntry(const std::string& login, BlackWhiteListEntry& ret) const
 {
   return _getEntry(login, login_list, ret);
-} 
+}
 
 bool BlackWhiteListDB::getEntry(const ComboAddress& ca, const std::string& login, BlackWhiteListEntry& ret) const
 {
   return _getEntry(ipLoginStr(ca, login), ip_login_list, ret);
-} 
+}
 
-bool BlackWhiteListDB::_getEntry(const std::string& key, const blackwhitelist_t& blackwhitelist, BlackWhiteListEntry& ret_ble) const
+bool BlackWhiteListDB::_getEntry(const std::string& key, const blackwhitelist_t& blackwhitelist,
+                                 BlackWhiteListEntry& ret_ble) const
 {
   ReadLock rl(&rwlock);
 
@@ -269,72 +281,72 @@ void BlackWhiteListDB::deleteEntryInternal(const std::string& key, BLWLType blwl
   WriteLock wl(&rwlock);
 
   switch (blwl_type) {
-  case IP_BLWL:
-    deleteEntryLog(IP_BLWL, key);
-    _deleteEntry(key, ip_list);
-    iplist_netmask.deleteMask(key);
-    if (persist && ((replicate == true) || ((replicate == false) && persist_replicated))) {
-      deletePersistEntry(key, blwl_type, ip_list);
-    }
-    if (replicate == true) {
-      if (db_type == BLWLDBType::BLACKLIST) {
-        std::shared_ptr<BLReplicationOperation> bl_rop;
-        bl_rop = std::make_shared<BLReplicationOperation>(BLOperation_BLOpType_BLDelete, IP_BLWL, key, 0, "");
-        ReplicationOperation rep_op(bl_rop, WforceReplicationMsg_RepType_BlacklistType);
-        replicateOperation(rep_op);
+    case IP_BLWL:
+      deleteEntryLog(IP_BLWL, key);
+      _deleteEntry(key, ip_list);
+      iplist_netmask.deleteMask(key);
+      if (persist && ((replicate == true) || ((replicate == false) && persist_replicated))) {
+        deletePersistEntry(key, blwl_type, ip_list);
       }
-      else {
-        std::shared_ptr<WLReplicationOperation> wl_rop;
-        wl_rop = std::make_shared<WLReplicationOperation>(BLOperation_BLOpType_BLDelete, IP_BLWL, key, 0, "");
-        ReplicationOperation rep_op(wl_rop, WforceReplicationMsg_RepType_WhitelistType);
-        replicateOperation(rep_op);
+      if (replicate == true) {
+        if (db_type == BLWLDBType::BLACKLIST) {
+          std::shared_ptr<BLReplicationOperation> bl_rop;
+          bl_rop = std::make_shared<BLReplicationOperation>(BLOperation_BLOpType_BLDelete, IP_BLWL, key, 0, "");
+          ReplicationOperation rep_op(bl_rop, WforceReplicationMsg_RepType_BlacklistType);
+          replicateOperation(rep_op);
+        }
+        else {
+          std::shared_ptr<WLReplicationOperation> wl_rop;
+          wl_rop = std::make_shared<WLReplicationOperation>(BLOperation_BLOpType_BLDelete, IP_BLWL, key, 0, "");
+          ReplicationOperation rep_op(wl_rop, WforceReplicationMsg_RepType_WhitelistType);
+          replicateOperation(rep_op);
+        }
       }
-    }
-    break;
-  case LOGIN_BLWL:
-    deleteEntryLog(LOGIN_BLWL, key);
-    _deleteEntry(key, login_list);
-    if (persist && ((replicate == true) || ((replicate == false) && persist_replicated))) {
-      deletePersistEntry(key, blwl_type, login_list);
-    }
-    if (replicate == true) {
-      if (db_type == BLWLDBType::BLACKLIST) {
-        std::shared_ptr<BLReplicationOperation> bl_rop;
-        bl_rop = std::make_shared<BLReplicationOperation>(BLOperation_BLOpType_BLDelete, LOGIN_BLWL, key, 0, "");
-        ReplicationOperation rep_op(bl_rop, WforceReplicationMsg_RepType_BlacklistType);
-        replicateOperation(rep_op);
+      break;
+    case LOGIN_BLWL:
+      deleteEntryLog(LOGIN_BLWL, key);
+      _deleteEntry(key, login_list);
+      if (persist && ((replicate == true) || ((replicate == false) && persist_replicated))) {
+        deletePersistEntry(key, blwl_type, login_list);
       }
-      else {
-        std::shared_ptr<WLReplicationOperation> wl_rop;
-        wl_rop = std::make_shared<WLReplicationOperation>(BLOperation_BLOpType_BLDelete, LOGIN_BLWL, key, 0, "");
-        ReplicationOperation rep_op(wl_rop, WforceReplicationMsg_RepType_WhitelistType);
-        replicateOperation(rep_op);
+      if (replicate == true) {
+        if (db_type == BLWLDBType::BLACKLIST) {
+          std::shared_ptr<BLReplicationOperation> bl_rop;
+          bl_rop = std::make_shared<BLReplicationOperation>(BLOperation_BLOpType_BLDelete, LOGIN_BLWL, key, 0, "");
+          ReplicationOperation rep_op(bl_rop, WforceReplicationMsg_RepType_BlacklistType);
+          replicateOperation(rep_op);
+        }
+        else {
+          std::shared_ptr<WLReplicationOperation> wl_rop;
+          wl_rop = std::make_shared<WLReplicationOperation>(BLOperation_BLOpType_BLDelete, LOGIN_BLWL, key, 0, "");
+          ReplicationOperation rep_op(wl_rop, WforceReplicationMsg_RepType_WhitelistType);
+          replicateOperation(rep_op);
+        }
       }
-    }
-    break;
-  case IP_LOGIN_BLWL:
-    deleteEntryLog(IP_LOGIN_BLWL, key);
-    _deleteEntry(key, ip_login_list);
-    if (persist && ((replicate == true) || ((replicate == false) && persist_replicated))) {
-      deletePersistEntry(key, blwl_type, ip_login_list);
-    }
-    if (replicate == true) {
-      if (db_type == BLWLDBType::BLACKLIST) {
-        std::shared_ptr<BLReplicationOperation> bl_rop;
-        bl_rop = std::make_shared<BLReplicationOperation>(BLOperation_BLOpType_BLDelete, IP_LOGIN_BLWL, key, 0, "");
-        ReplicationOperation rep_op(bl_rop, WforceReplicationMsg_RepType_BlacklistType);
-        replicateOperation(rep_op);
+      break;
+    case IP_LOGIN_BLWL:
+      deleteEntryLog(IP_LOGIN_BLWL, key);
+      _deleteEntry(key, ip_login_list);
+      if (persist && ((replicate == true) || ((replicate == false) && persist_replicated))) {
+        deletePersistEntry(key, blwl_type, ip_login_list);
       }
-      else {
-        std::shared_ptr<WLReplicationOperation> wl_rop;
-        wl_rop = std::make_shared<WLReplicationOperation>(BLOperation_BLOpType_BLDelete, IP_LOGIN_BLWL, key, 0, "");
-        ReplicationOperation rep_op(wl_rop, WforceReplicationMsg_RepType_WhitelistType);
-        replicateOperation(rep_op);
+      if (replicate == true) {
+        if (db_type == BLWLDBType::BLACKLIST) {
+          std::shared_ptr<BLReplicationOperation> bl_rop;
+          bl_rop = std::make_shared<BLReplicationOperation>(BLOperation_BLOpType_BLDelete, IP_LOGIN_BLWL, key, 0, "");
+          ReplicationOperation rep_op(bl_rop, WforceReplicationMsg_RepType_BlacklistType);
+          replicateOperation(rep_op);
+        }
+        else {
+          std::shared_ptr<WLReplicationOperation> wl_rop;
+          wl_rop = std::make_shared<WLReplicationOperation>(BLOperation_BLOpType_BLDelete, IP_LOGIN_BLWL, key, 0, "");
+          ReplicationOperation rep_op(wl_rop, WforceReplicationMsg_RepType_WhitelistType);
+          replicateOperation(rep_op);
+        }
       }
-    }
-    break;
-  default:
-    break;
+      break;
+    default:
+      break;
   }
   std::string event_name;
   std::string type_name;
@@ -348,10 +360,12 @@ void BlackWhiteListDB::deleteEntryInternal(const std::string& key, BLWLType blwl
   }
   // only generate webhook for this event for the first delete, not for replicas
   if (replicate == true) {
-    Json jobj = Json::object{{"key", key}, {type_name, BLWLTypeToName(blwl_type)}, {"type", "wforce_delblwl"}};
-    for (const auto& h : g_webhook_db.getWebHooksForEvent(event_name)) {
+    Json jobj = Json::object{{"key",     key},
+                             {type_name, BLWLTypeToName(blwl_type)},
+                             {"type",    "wforce_delblwl"}};
+    for (const auto& h: g_webhook_db.getWebHooksForEvent(event_name)) {
       if (auto hs = h.lock())
-	g_webhook_runner.runHook(event_name, hs, jobj);
+        g_webhook_runner.runHook(event_name, hs, jobj);
     }
   }
 
@@ -366,7 +380,7 @@ bool BlackWhiteListDB::_deleteEntry(const std::string& key, blackwhitelist_t& bl
     keyindex.erase(key);
     return true;
   }
-  return false;  
+  return false;
 }
 
 time_t BlackWhiteListDB::getExpiration(const ComboAddress& ca) const
@@ -412,7 +426,7 @@ time_t BlackWhiteListDB::_getExpiration(const std::string& key, const blackwhite
     else
       return -1; // expired already
   }
-  return (time_t)-1; // not found
+  return (time_t) -1; // not found
 }
 
 void BlackWhiteListDB::purgeEntries()
@@ -432,7 +446,7 @@ void BlackWhiteListDB::purgeEntries()
       else {
         setPrometheusWLIPEntries(ip_list.size());
         setPrometheusWLLoginEntries(login_list.size());
-        setPrometheusWLIPLoginEntries(ip_login_list.size());        
+        setPrometheusWLIPLoginEntries(ip_login_list.size());
       }
     }
   }
@@ -442,9 +456,9 @@ void BlackWhiteListDB::_purgeEntries(BLWLType blt, blackwhitelist_t& blackwhitel
 {
   WriteLock wl(&rwlock);
   boost::system_time now = boost::get_system_time();
-  
+
   auto& timeindex = blackwhitelist.get<TimeTag>();
-  
+
   std::string event_name;
   std::string type_name;
   if (db_type == BLWLDBType::BLACKLIST) {
@@ -457,14 +471,16 @@ void BlackWhiteListDB::_purgeEntries(BLWLType blt, blackwhitelist_t& blackwhitel
   }
   for (auto tit = timeindex.begin(); tit != timeindex.end();) {
     if (tit->expiration <= now) {
-      Json jobj = Json::object{{"key", tit->key}, {type_name, BLWLTypeToName(blwl_type)}, {"type", "wforce_expireblwl"}};
-      for (const auto& h : g_webhook_db.getWebHooksForEvent(event_name)) {
-	if (auto hs = h.lock())
-	  g_webhook_runner.runHook(event_name, hs, jobj);
+      Json jobj = Json::object{{"key",     tit->key},
+                               {type_name, BLWLTypeToName(blwl_type)},
+                               {"type",    "wforce_expireblwl"}};
+      for (const auto& h: g_webhook_db.getWebHooksForEvent(event_name)) {
+        if (auto hs = h.lock())
+          g_webhook_runner.runHook(event_name, hs, jobj);
       }
       expireEntryLog(blt, tit->key);
       if (blwl_type == IP_BLWL)
-	iplist_netmask.deleteMask(tit->key);
+        iplist_netmask.deleteMask(tit->key);
       tit = timeindex.erase(tit);
     }
     else
@@ -477,8 +493,8 @@ std::vector<BlackWhiteListEntry> BlackWhiteListDB::getIPEntries() const
   ReadLock rl(&rwlock);
   std::vector<BlackWhiteListEntry> ret;
 
-  auto& seqindex = ip_list.get<SeqTag>();  
-  for(const auto& a : seqindex)
+  auto& seqindex = ip_list.get<SeqTag>();
+  for (const auto& a: seqindex)
     ret.push_back(a);
   return ret;
 }
@@ -488,9 +504,9 @@ std::vector<BlackWhiteListEntry> BlackWhiteListDB::getLoginEntries() const
   ReadLock rl(&rwlock);
   std::vector<BlackWhiteListEntry> ret;
 
-  auto& seqindex = login_list.get<SeqTag>();  
-  for(const auto& a : seqindex)
-    ret.push_back(a); 
+  auto& seqindex = login_list.get<SeqTag>();
+  for (const auto& a: seqindex)
+    ret.push_back(a);
   return ret;
 }
 
@@ -499,13 +515,14 @@ std::vector<BlackWhiteListEntry> BlackWhiteListDB::getIPLoginEntries() const
   ReadLock rl(&rwlock);
   std::vector<BlackWhiteListEntry> ret;
 
-  auto& seqindex = ip_login_list.get<SeqTag>();  
-  for(const auto& a : seqindex)
+  auto& seqindex = ip_login_list.get<SeqTag>();
+  for (const auto& a: seqindex)
     ret.push_back(a);
   return ret;
 }
 
-void BlackWhiteListDB::addEntryLog(BLWLType blt, const std::string& key, time_t seconds, const std::string& reason) const
+void
+BlackWhiteListDB::addEntryLog(BLWLType blt, const std::string& key, time_t seconds, const std::string& reason) const
 {
   std::ostringstream os;
   std::string blwl_name = list_names[blt];
@@ -516,8 +533,9 @@ void BlackWhiteListDB::addEntryLog(BLWLType blt, const std::string& key, time_t 
     event_name = "addBLEntry";
   else
     event_name = "addWLEntry";
-  
-  os << event_name << " " << blwl_name << ": " << key_name << "=" << key << " expire_secs=" << std::to_string(seconds) << " reason=\"" << reason + "\"";
+
+  os << event_name << " " << blwl_name << ": " << key_name << "=" << key << " expire_secs=" << std::to_string(seconds)
+     << " reason=\"" << reason + "\"";
   noticelog(os.str().c_str());
 }
 
@@ -527,7 +545,7 @@ void BlackWhiteListDB::deleteEntryLog(BLWLType blt, const std::string& key) cons
   std::string blwl_name = list_names[blt];
   std::string key_name = string(key_names[blt]);
   std::string event_name;
-  
+
   if (db_type == BLWLDBType::BLACKLIST)
     event_name = "deleteBLEntry";
   else
@@ -543,7 +561,7 @@ void BlackWhiteListDB::expireEntryLog(BLWLType blt, const std::string& key) cons
   std::string blwl_name = list_names[blt];
   std::string key_name = string(key_names[blt]);
   std::string event_name;
-  
+
   if (db_type == BLWLDBType::BLACKLIST)
     event_name = "deleteBLEntry";
   else
@@ -576,8 +594,8 @@ bool BlackWhiteListDB::checkSetupContext()
     redis_context = redisConnectWithTimeout(redis_server.c_str(), redis_port, tv);
     if (redis_context == NULL || redis_context->err) {
       if (redis_context) {
-	redisFree(redis_context);
-	redis_context = NULL;
+        redisFree(redis_context);
+        redis_context = NULL;
       }
       errlog("checkSetupContext: could not connect to redis BlackWhiteListDB (%s:%d)", redis_server, redis_port);
       if (db_type == BLWLDBType::BLACKLIST)
@@ -606,14 +624,15 @@ bool BlackWhiteListDB::checkSetupContext()
   return true;
 }
 
-void BlackWhiteListDB::makePersistent(const std::string& host, unsigned int port=6379)
+void BlackWhiteListDB::makePersistent(const std::string& host, unsigned int port = 6379)
 {
   persist = true;
   redis_server = host;
   redis_port = port;
 }
 
-bool BlackWhiteListDB::addPersistEntry(const std::string& key, time_t seconds, BLWLType blwl_type, const std::string& reason)
+bool
+BlackWhiteListDB::addPersistEntry(const std::string& key, time_t seconds, BLWLType blwl_type, const std::string& reason)
 {
   bool retval = false;
   if (checkSetupContext()) {
@@ -621,16 +640,17 @@ bool BlackWhiteListDB::addPersistEntry(const std::string& key, time_t seconds, B
     std::stringstream redis_value_s;
     std::string blwl_key = string(key_names[blwl_type]);
     time_t expiration_time = time(NULL) + seconds;
-    
+
     redis_key_s << redis_prefix << ":" << blwl_key << ":" << key;
     redis_value_s << expiration_time << ":" << reason;
-    redisReply* reply = (redisReply*)redisCommand(redis_context, "SET %s %b EX %d", redis_key_s.str().c_str(), redis_value_s.str().c_str(), redis_value_s.str().length(), seconds);
+    redisReply* reply = (redisReply*) redisCommand(redis_context, "SET %s %b EX %d", redis_key_s.str().c_str(),
+                                                   redis_value_s.str().c_str(), redis_value_s.str().length(), seconds);
     if (reply != NULL) {
       if (reply->type == REDIS_REPLY_ERROR) {
-	errlog("addPersistEntry: Error adding %s to persistent redis BlackWhiteListDB (%s)", key, reply->str);
+        errlog("addPersistEntry: Error adding %s to persistent redis BlackWhiteListDB (%s)", key, reply->str);
       }
       else
-	retval = true;
+        retval = true;
       freeReplyObject(reply);
     }
   }
@@ -648,15 +668,15 @@ bool BlackWhiteListDB::deletePersistEntry(const std::string& key, BLWLType blwl_
     BlackWhiteListEntry ble;
     std::stringstream redis_key_s;
     std::string blwl_key = string(key_names[blwl_type]);
-    
+
     redis_key_s << redis_prefix << ":" << blwl_key << ":" << key;
-    redisReply* reply = (redisReply*)redisCommand(redis_context, "DEL %s", redis_key_s.str().c_str());
+    redisReply* reply = (redisReply*) redisCommand(redis_context, "DEL %s", redis_key_s.str().c_str());
     if (reply != NULL) {
       if (reply->type == REDIS_REPLY_ERROR) {
-	errlog("deletePersistEntry: Error deleting %s from persistent redis BlackWhiteListDB (%s)", key, reply->str);
+        errlog("deletePersistEntry: Error deleting %s from persistent redis BlackWhiteListDB (%s)", key, reply->str);
       }
       else
-	retval = true;
+        retval = true;
       freeReplyObject(reply);
     }
   }
@@ -667,96 +687,98 @@ bool BlackWhiteListDB::loadPersistEntries()
 {
   bool retval = true;
   WriteLock wl(&rwlock);
-  
+
   if (persist != false) {
     unsigned int num_entries = 0;
     if (checkSetupContext()) {
       bool end_it = false;
       unsigned int count_it = 0;
-      
+
       while (end_it != true) {
         std::ostringstream oss;
         oss << "SCAN %d MATCH " << redis_prefix << ":* COUNT 1000";
-	redisReply* reply = (redisReply*)redisCommand(redis_context, oss.str().c_str(), count_it);
-	if (reply != NULL) {
-	  if (reply->type == REDIS_REPLY_ERROR) {
-	    errlog("loadPersistEntries: Error scanning keys in persistent redis BlackWhiteListDB (%s)", reply->str);
-	    retval = false;
-	  }
-	  else if (reply->type == REDIS_REPLY_ARRAY) {
-	    if (reply->elements == 2) {
-	      redisReply* rcounter = reply->element[0];
-	      count_it = rcounter->integer;
-	      if (count_it == 0) {
-		end_it = true;
-	      }
-	      redisReply* keys = reply->element[1];
-	      unsigned int num_keys = keys->elements;
-	      for (unsigned int i=0; i<num_keys; ++i) {
-		redisReply* key = keys->element[i];
-		if (key->type == REDIS_REPLY_STRING) {
-		  redisAppendCommand(redis_context, "GET %b", key->str, key->len);
-		}
-	      }
-	      for (unsigned int i=0; i<num_keys; ++i) {
-		redisReply* get_reply = NULL;
-		redisReply* key = keys->element[i];
-		redisGetReply(redis_context, (void**)&get_reply);
-		if (get_reply != NULL) {
-		  if (get_reply->type == REDIS_REPLY_ERROR) {
-		    errlog("loadPersistEntries: Error getting key %b in persistent redis BlackWhiteListDB (%s)", key->str, key->len, get_reply->str);
-		    retval = false;
-		  }
-		  else if (get_reply->type == REDIS_REPLY_STRING) {
-		    std::string keystr(key->str, key->len);
-		    std::string valstr(get_reply->str, get_reply->len);
+        redisReply* reply = (redisReply*) redisCommand(redis_context, oss.str().c_str(), count_it);
+        if (reply != NULL) {
+          if (reply->type == REDIS_REPLY_ERROR) {
+            errlog("loadPersistEntries: Error scanning keys in persistent redis BlackWhiteListDB (%s)", reply->str);
+            retval = false;
+          }
+          else if (reply->type == REDIS_REPLY_ARRAY) {
+            if (reply->elements == 2) {
+              redisReply* rcounter = reply->element[0];
+              count_it = rcounter->integer;
+              if (count_it == 0) {
+                end_it = true;
+              }
+              redisReply* keys = reply->element[1];
+              unsigned int num_keys = keys->elements;
+              for (unsigned int i = 0; i < num_keys; ++i) {
+                redisReply* key = keys->element[i];
+                if (key->type == REDIS_REPLY_STRING) {
+                  redisAppendCommand(redis_context, "GET %b", key->str, key->len);
+                }
+              }
+              for (unsigned int i = 0; i < num_keys; ++i) {
+                redisReply* get_reply = NULL;
+                redisReply* key = keys->element[i];
+                redisGetReply(redis_context, (void**) &get_reply);
+                if (get_reply != NULL) {
+                  if (get_reply->type == REDIS_REPLY_ERROR) {
+                    errlog("loadPersistEntries: Error getting key %b in persistent redis BlackWhiteListDB (%s)",
+                           key->str, key->len, get_reply->str);
+                    retval = false;
+                  }
+                  else if (get_reply->type == REDIS_REPLY_STRING) {
+                    std::string keystr(key->str, key->len);
+                    std::string valstr(get_reply->str, get_reply->len);
 
-		    // keystr looks like <redis_prefix>:ip_bl:key
-		    pair<string, string> headersplit=splitField(keystr, ':');
-		    pair<string, string> keysplit=splitField(headersplit.second, ':');
-		    // valstr looks like seconds:reason
-		    pair<string, string> valsplit=splitField(valstr, ':');
-		    std::string blwl_name = keysplit.first;
-		    std::string blwl_key = keysplit.second;
-		    time_t blwl_seconds = std::stoi(valsplit.first) - time(NULL);
-		    std::string blwl_reason = valsplit.second;
+                    // keystr looks like <redis_prefix>:ip_bl:key
+                    pair<string, string> headersplit = splitField(keystr, ':');
+                    pair<string, string> keysplit = splitField(headersplit.second, ':');
+                    // valstr looks like seconds:reason
+                    pair<string, string> valsplit = splitField(valstr, ':');
+                    std::string blwl_name = keysplit.first;
+                    std::string blwl_key = keysplit.second;
+                    time_t blwl_seconds = std::stoi(valsplit.first) - time(NULL);
+                    std::string blwl_reason = valsplit.second;
 
-		    BLWLType blwl_type = BLWLNameToType(blwl_name);
-		    switch (blwl_type) {
-		    case IP_BLWL:
-		      _addEntry(blwl_key, blwl_seconds, ip_list, blwl_reason);
-		      iplist_netmask.addMask(blwl_key);
-		      ++num_entries;
-		      break;
-		    case LOGIN_BLWL:
-		      _addEntry(blwl_key, blwl_seconds, login_list, blwl_reason);
-		      ++num_entries;
-		      break;
-		    case IP_LOGIN_BLWL:
-		      _addEntry(blwl_key, blwl_seconds, ip_login_list, blwl_reason);
-		      ++num_entries;
-		      break;
-		    default:
-		      errlog("loadPersistEntries: Error in blackwhitelist name retrieved from key: %s", blwl_name);
-		      retval = false;
-		    }
-		  }
-		  freeReplyObject(get_reply);
-		}
-		if (retval == false)
-		  break;
-	      }
-	    }
-	  }
-	  freeReplyObject(reply);
-	}
-	if (retval == false)
-	  break;
+                    BLWLType blwl_type = BLWLNameToType(blwl_name);
+                    switch (blwl_type) {
+                      case IP_BLWL:
+                        _addEntry(blwl_key, blwl_seconds, ip_list, blwl_reason);
+                        iplist_netmask.addMask(blwl_key);
+                        ++num_entries;
+                        break;
+                      case LOGIN_BLWL:
+                        _addEntry(blwl_key, blwl_seconds, login_list, blwl_reason);
+                        ++num_entries;
+                        break;
+                      case IP_LOGIN_BLWL:
+                        _addEntry(blwl_key, blwl_seconds, ip_login_list, blwl_reason);
+                        ++num_entries;
+                        break;
+                      default:
+                        errlog("loadPersistEntries: Error in blackwhitelist name retrieved from key: %s", blwl_name);
+                        retval = false;
+                    }
+                  }
+                  freeReplyObject(get_reply);
+                }
+                if (retval == false)
+                  break;
+              }
+            }
+          }
+          freeReplyObject(reply);
+        }
+        if (retval == false)
+          break;
       }
     }
     else {
       retval = false;
-      std::string myerr = "Error - could not connect to configured persistent redis DB (" + redis_server + ":" + std::to_string(redis_port);
+      std::string myerr = "Error - could not connect to configured persistent redis DB (" + redis_server + ":" +
+                          std::to_string(redis_port);
       errlog(myerr.c_str());
       throw WforceException(myerr);
     }
@@ -768,9 +790,9 @@ bool BlackWhiteListDB::loadPersistEntries()
 
 BLWLType BlackWhiteListDB::BLWLNameToType(const std::string& blwl_name) const
 {
-  for (unsigned int i=0; key_names[i]!=NULL; i++) {
+  for (unsigned int i = 0; key_names[i] != NULL; i++) {
     if (blwl_name.compare(key_names[i]) == 0)
-      return (BLWLType)i;
+      return (BLWLType) i;
   }
   return NONE_BLWL;
 }

--- a/wforce/blackwhitelist.cc
+++ b/wforce/blackwhitelist.cc
@@ -764,12 +764,20 @@ bool BlackWhiteListDB::loadPersistEntries()
                   }
                   freeReplyObject(get_reply);
                 }
+                else {
+                  retval = false;
+                  errlog("loadPersistEntries: Redis GET failed: %s", redis_context->errstr);
+                }
                 if (retval == false)
                   break;
               }
             }
           }
           freeReplyObject(reply);
+        }
+        else {
+          retval = false;
+          errlog("loadPersistEntries: Redis SCAN failed: %s", redis_context->errstr);
         }
         if (retval == false)
           break;


### PR DESCRIPTION
The error checking in BlackWhiteListDB::loadPersistEntries() was somewhat deficient, leading to the function getting stuck in an infinite loop in the event of certain Redis failure conditions. This has been corrected.