### PR TITLE
Enable ip and login substitution in blacklist return messages

### DIFF
--- a/docs/manpages/wforce.conf.5.md
+++ b/docs/manpages/wforce.conf.5.md
@@ -403,19 +403,23 @@ cannot be called inside the allow/report/reset functions:
         whitelistPersistRWTimeout(0, 50000)
 
 * setBlacklistIPRetMsg(<msg>) - Set the message to be returned to
-  clients whose IP address is blacklisted. For example:
+  clients whose IP address is blacklisted. The strings "{ip}" and
+  "{login}" will be substituted for the actual IP address and login name. 
+  For example:
 
-        setBlackistIPRetMsg("Go away your IP is blacklisted")
+        setBlackistIPRetMsg("Go away your IP {ip} is blacklisted")
 
 * setBlacklistLoginRetMsg(<msg>) - Set the message to be returned to
-  clients whose login is blacklisted. For example:
+  clients whose login is blacklisted. The strings "{ip}" and
+  "{login}" will be substituted for the actual IP address and login name. For example:
 
-        setBlackistLoginRetMsg("Go away your login is blacklisted")
+        setBlackistLoginRetMsg("Go away your login {login} is blacklisted")
 
 * setBlacklistIPLoginRetMsg(<msg>) - Set the message to be returned to
-  clients whose IP address/login is blacklisted. For example:
+  clients whose IP address/login is blacklisted. The strings "{ip}" and
+  "{login}" will be substituted for the actual IP address and login name. For example:
 
-        setBlackistIPLoginRetMsg("Go away your IP/Login is blacklisted")
+        setBlackistIPLoginRetMsg("Go away your IP {ip}/Login {login} is blacklisted")
 
 * setAllow(\<allow func\>) - Tell wforce to use the specified Lua
   function for handling all "allow" commands. For example:


### PR DESCRIPTION
Example template: "your IP address {ip} has been blocked temporarily for bad behaviour"
This is so that clients can get messages such as:
"Your IP address 8fea::1 has been blocked temporarily for bad behaviour"

Similarly the the template: "Your login {login} for IP address {ip} has been blocked due to excessive badness"
etc.

This PR does mean that in all cases a blacklist response will incur an extra allocation for a new string compared with before, even if there are no {ip} or {login} templates in the message.
