### PR TITLE
Logging improvements

### DIFF
--- a/common/dolog.hh
+++ b/common/dolog.hh
@@ -74,6 +74,10 @@ extern bool g_console;
 extern bool g_verbose;
 extern bool g_docker;
 
+enum class LogLevel { Emerg=0, Alert, Crit, Err, Warning, Notice, Info, Debug};
+
+extern LogLevel g_loglevel;
+
 template<typename... Args>
 void genlog(int level, const char* s, Args... args)
 {
@@ -81,7 +85,7 @@ void genlog(int level, const char* s, Args... args)
   std::ostringstream str;
   dolog(str, s, args...);
   syslog(level, "%s", str.str().c_str());
-  if(g_console) {
+  if(g_console && level <= static_cast<int>(g_loglevel)) {
     // For docker we include a datetime string
     if (g_docker) {
       auto now = system_clock::now();

--- a/common/testrunner.cc
+++ b/common/testrunner.cc
@@ -6,6 +6,8 @@
 #include "config.h"
 #endif
 #include <boost/test/unit_test.hpp>
+#include "dolog.hh"
 
 bool g_console = false;
 bool g_docker = false;
+LogLevel g_loglevel{LogLevel::Info};

--- a/common/wforce-webserver.hh
+++ b/common/wforce-webserver.hh
@@ -132,9 +132,31 @@ public:
                    const std::string& cert_file, const std::string& private_key,
                    bool enable_oldtls, std::vector<std::pair<std::string, std::string>> opts);
 
-  void setWebLogLevel(trantor::Logger::LogLevel level)
+  void setWebLogLevel(LogLevel level)
   {
-    drogon::app().setLogLevel(level);
+    switch (level) {
+      case LogLevel::Emerg:
+      case LogLevel::Alert:
+      case LogLevel::Crit:
+        d_loglevel = trantor::Logger::kFatal;
+        break;
+      case LogLevel::Err:
+        d_loglevel = trantor::Logger::kError;
+        break;
+      case LogLevel::Warning:
+        d_loglevel = trantor::Logger::kWarn;
+        break;
+      case LogLevel::Notice:
+      case LogLevel::Info:
+        d_loglevel = trantor::Logger::kInfo;
+        break;
+      case LogLevel::Debug:
+        d_loglevel = trantor::Logger::kTrace;
+        break;
+      default:
+        d_loglevel = trantor::Logger::kWarn;
+        break;
+    }
   }
 
   // Initialize the webserver
@@ -145,7 +167,7 @@ public:
     if (init.test_and_set() == false) {
       drogon::app().disableSession();
       drogon::app().disableSigtermHandling();
-      drogon::app().setLogLevel(trantor::Logger::kWarn);
+      drogon::app().setLogLevel(d_loglevel);
       // We will never allow uploads, but drogon wants to create a bunch of temp files in uploadPath/tmp/xx
       drogon::app().setUploadPath("/tmp/wforce");
       // Set custom 404 response
@@ -253,4 +275,5 @@ private:
   std::unordered_map<std::string, WforceWSFunc> d_delete_map;
   unsigned int d_num_worker_threads = WFORCE_NUM_WORKER_THREADS;
   unsigned int d_max_conns = WFORCE_MAX_WS_CONNS;
+  trantor::Logger::LogLevel d_loglevel = trantor::Logger::kWarn;
 };

--- a/docs/manpages/trackalert.1.md
+++ b/docs/manpages/trackalert.1.md
@@ -53,6 +53,10 @@ on "report") integrated with it using the HTTP/JSON API.
 -f,--facility *FACILITY NAME*
 :    Log using the specified facility name, e.g. local0
 
+-l,--loglevel <0-7>
+:    Logs sent to stdout will be filtered according to the specified log level,
+     matching the equivalent syslog level (0 - Emerg to 7 - Debug).
+
 -h,--help
 :    Display a helpful message and exit.
 

--- a/docs/manpages/wforce.1.md
+++ b/docs/manpages/wforce.1.md
@@ -60,6 +60,10 @@ ensure that any firewalls forward UDP on the configured ports.
 -f,--facility *FACILITY NAME*
 :    Log using the specified facility name, e.g. local0
 
+-l,--loglevel <0-7>
+:    Logs sent to stdout will be filtered according to the specified log level,
+     matching the equivalent syslog level (0 - Emerg to 7 - Debug).
+
 -h,--help
 :    Display a helpful message and exit.
 

--- a/wforce/dump_entries.cc
+++ b/wforce/dump_entries.cc
@@ -35,6 +35,7 @@
 #include "json11.hpp"
 #include "base64.hh"
 #include "sstuff.hh"
+#include "dolog.hh"
 
 using namespace std;
 using namespace json11;
@@ -54,6 +55,7 @@ void print_help()
 
 bool g_console = true;
 bool g_docker = false;
+LogLevel g_loglevel{LogLevel::Info};
 
 int main(int argc, char** argv)
 {

--- a/wforce/wforce.cc
+++ b/wforce/wforce.cc
@@ -64,6 +64,7 @@ using std::atomic;
 using std::thread;
 bool g_verbose=false;
 bool g_docker=false;
+LogLevel g_loglevel{LogLevel::Info};
 
 struct WForceStats g_stats;
 bool g_console;
@@ -927,12 +928,13 @@ try
     {"daemon", optional_argument, 0, 'd'},
     {"docker", optional_argument, 0, 'D'},
     {"facility", required_argument, 0, 'f'},
+    {"loglevel", required_argument, 0, 'l'},
     {"help", 0, 0, 'h'}, 
     {0,0,0,0} 
   };
   int longindex=0;
   for(;;) {
-    int c=getopt_long(argc, argv, ":hsdDc:e:C:R:f:v", longopts, &longindex);
+    int c=getopt_long(argc, argv, ":hsdDc:e:C:R:f:l:v", longopts, &longindex);
     if(c==-1)
       break;
     switch(c) {
@@ -988,6 +990,15 @@ try
         break;
       }
       break;
+    case 'l':
+      try {
+        g_loglevel = static_cast<LogLevel>(std::stoi(optarg));
+      }
+      catch (const std::invalid_argument &ia) {
+        cout << "Bad log level (" << optarg << ") - must be an integer" << endl;
+        exit(1);
+      }
+      break;
     case 'h':
       cout<<"Syntax: wforce [-C,--config file] [-R,--regexes file] [-c,--client] [-d,--daemon] [-e,--execute cmd]\n";
       cout<<"[-h,--help] [-l,--local addr]\n";
@@ -1000,12 +1011,14 @@ try
       cout<<"-D,--docker           Enable logging for docker\n";
       cout<<"-e,--execute cmd      Connect to wforce and execute 'cmd'\n";
       cout<<"-f,--facility name    Use log facility 'name'\n";
+      cout<<"-l,--loglevel level   Log level as an integer. 0 is Emerg, 7 is Debug. Defaults to 6 (Info).\n";
       cout<<"-h,--help             Display this helpful message\n";
       cout<<"\n";
       exit(EXIT_SUCCESS);
       break;
     case 'v':
       g_verbose=true;
+      g_loglevel=LogLevel::Debug;
       break;
     case '?':
     default:
@@ -1015,6 +1028,7 @@ try
   argc-=optind;
   argv+=optind;
 
+  g_webserver.setWebLogLevel(g_loglevel);
   openlog("wforce", LOG_PID, g_cmdLine.facility);
   
   g_singleThreaded = false;


### PR DESCRIPTION
Previous to this PR, stdout would log everything, even debug logs. Additionally, the new webserver would log only errors, with no way to debug issues.

This PR:
- Adds a log level command line flag to wforce and trackalert
- Adds a global log level variable used by dolog.hh used to filter logging to stdout
- Uses the configured log level to set drogon webserver log level (which also logs to stdout - it has no syslog capability)