### PR TITLE
Fix wforce docker image issue

### DIFF
--- a/docker/wforce_image/Dockerfile
+++ b/docker/wforce_image/Dockerfile
@@ -67,6 +67,9 @@ WORKDIR /wforce/
 
 COPY --from=wforce_build /wforce/install/ /
 
+# Remove the default wforce.conf and trackalert.conf files
+RUN rm /etc/wforce/wforce.conf /etc/wforce/trackalert.conf
+
 COPY --from=wforce_build /wforce/report_api /wforce/report_api
 
 RUN apt-get update && \

--- a/docker/wforce_image/Makefile.am
+++ b/docker/wforce_image/Makefile.am
@@ -1,11 +1,15 @@
 DCMP = docker-compose
 WFORCE_IMAGE_COMPOSE_TARGET = .wforce_image_docker
 WFORCE_IMAGE_SERVICE = wforce_image
+TRACKALERT_IMAGE_SERVICE = trackalert
 COMPOSE_SOURCE=Dockerfile create_config.sh docker-compose.yml docker-entrypoint.sh wforce.conf.j2
 export BUILD_DATE= $(shell date)
 export LICENSE= $(shell echo GPLv3)
 export GIT_REVISION= $(shell git rev-parse --short HEAD)
 export VERSION = $(shell git describe --tags)
+export WFORCE_PASSWORD = super
+export WFORCE_PORT = 18084
+export TRACKALERT_PORT = 18085
 
 $(WFORCE_IMAGE_COMPOSE_TARGET): $(shell find weakforced/common -type f) $(shell find weakforced/wforce -type f) $(shell find weakforced/trackalert -type f) $(shell find weakforced/ext -type f) $(shell find weakforced/report_api -type f) $(COMPOSE_SOURCE)
 	$(DCMP) down -v
@@ -32,9 +36,8 @@ test_wforce_image: build_wforce_image
 	$(DCMP) up -d
 	$(DCMP) exec -T $(WFORCE_IMAGE_SERVICE) test -f /usr/bin/wforce
 	$(DCMP) exec -T $(WFORCE_IMAGE_SERVICE) test -f /usr/bin/trackalert
-	$(DCMP) exec -T $(WFORCE_IMAGE_SERVICE) test -f /etc/wforce/wforce.conf
-	$(DCMP) exec -T $(WFORCE_IMAGE_SERVICE) test -f /etc/wforce/trackalert.conf
-	$(DCMP) exec -T $(WFORCE_IMAGE_SERVICE) wforce -e 'showStringStatsDB()'
+	curl -u foo:$(WFORCE_PASSWORD) http://localhost:$(WFORCE_PORT)/metrics
+	$(DCMP) exec -T $(WFORCE_IMAGE_SERVICE) wforce -e 'showStringStatsDB()' | grep "Shards"
+	curl -u foo:$(WFORCE_PASSWORD) http://localhost:$(TRACKALERT_PORT)/metrics
+	$(DCMP) exec -T $(TRACKALERT_IMAGE_SERVICE) trackalert -e 'stats()' | grep reports
 	$(DCMP) stop
-
-

--- a/docker/wforce_image/docker-compose.yml
+++ b/docker/wforce_image/docker-compose.yml
@@ -14,9 +14,17 @@ services:
         - MAXMIND_LICENSE_KEY=${MAXMIND_LICENSE_KEY}
     environment:
       - WFORCE_VERBOSE
-      - WFORCE_HTTP_PORT=18084
-      - WFORCE_HTTP_PASSWORD=super
+      - WFORCE_HTTP_PORT=${WFORCE_PORT}
+      - WFORCE_HTTP_PASSWORD=${WFORCE_PASSWORD}
       - WFORCE_LOGSTASH_URL
       - WFORCE_CONFIG_FILE
     ports:
-      - "18084:18084"
+      - "${WFORCE_PORT}:${WFORCE_PORT}"
+  trackalert:
+    image: powerdns/wforce:${VERSION}
+    environment:
+      - TRACKALERT=1
+      - TRACKALERT_HTTP_PORT=${TRACKALERT_PORT}
+      - TRACKALERT_HTTP_PASSWORD=${WFORCE_PASSWORD}
+    ports:
+      - "${TRACKALERT_PORT}:${TRACKALERT_PORT}"

--- a/docker/wforce_image/docker-entrypoint.sh
+++ b/docker/wforce_image/docker-entrypoint.sh
@@ -28,7 +28,8 @@ if [[ "x$TRACKALERT" == "x" ]]; then
             2>&1 echo "WFORCE_HTTP_PASSWORD environment variable must be set"
         else
             echo "Note you are using the default config file - to take full advantage of the capabilities of weakforced, you should specify a custom config file with the WFORCE_CONFIG_FILE environment variable or just replace /etc/wforce/wforce.conf with your own config file."
-            export WFORCE_KEY=`echo "makeKey()" | wforce | grep setKey`
+            MYKEY=`cat /proc/sys/kernel/random/uuid | sed 's/[-]//g' | head -c 32 | base64`
+            export WFORCE_KEY="setKey(\"$MYKEY\")"
             create_config.sh /etc/wforce/wforce.conf.j2 /etc/wforce/wforce.conf
             echo "Starting $WFORCE_CMD"
             exec $WFORCE_CMD
@@ -49,7 +50,8 @@ else
             2>&1 echo "TRACKALERT_HTTP_PASSWORD environment variable must be set"
         else
             echo "Note you are using the default config file - to take full advantage of the capabilities of trackalert, you should specify a custom config file with the TRACKALERT_CONFIG_FILE environment variable or just replace /etc/wforce/trackalert.conf with your own config file."
-            export TRACKALERT_KEY=`echo "makeKey()" | trackalert | grep setKey`
+            MYKEY=`cat /proc/sys/kernel/random/uuid | sed 's/[-]//g' | head -c 32 | base64`
+            export TRACKALERT_KEY="setKey(\"$MYKEY\")"
             create_config.sh /etc/wforce/trackalert.conf.j2 /etc/wforce/trackalert.conf
             echo "Starting $TRACKALERT_CMD"
             exec $TRACKALERT_CMD

--- a/docker/wforce_image/docker-entrypoint.sh
+++ b/docker/wforce_image/docker-entrypoint.sh
@@ -57,7 +57,7 @@ else
             exec $TRACKALERT_CMD
         fi
     else
-        TRACKALERT_CMD="$WFORCE_CMD -C $TRACKALERT_CONFIG_FILE"
+        TRACKALERT_CMD="$TRACKALERT_CMD -C $TRACKALERT_CONFIG_FILE"
         exec $TRACKALERT_CMD
     fi
 fi

--- a/docker/wforce_image/trackalert.conf.j2
+++ b/docker/wforce_image/trackalert.conf.j2
@@ -1,4 +1,6 @@
-webserver("0.0.0.0:{{env['TRACKALERT_HTTP_PORT']}}", "{{env['TRACKALERT_HTTP_PASSWORD']}}")
+addListener("0.0.0.0:{{env['TRACKALERT_HTTP_PORT']}}", false,    "",             "",         {})
+setWebserverPassword("{{env['TRACKALERT_HTTP_PASSWORD']}}")
+
 {{env['TRACKALERT_KEY']}}
 controlSocket("127.0.0.1:4005")
 

--- a/docker/wforce_image/trackalert.conf.j2
+++ b/docker/wforce_image/trackalert.conf.j2
@@ -1,4 +1,4 @@
-addListener("0.0.0.0:{{env['TRACKALERT_HTTP_PORT']}}", false,    "",             "",         {})
+addListener("0.0.0.0:{{env['TRACKALERT_HTTP_PORT']}}", false, "", "", {})
 setWebserverPassword("{{env['TRACKALERT_HTTP_PASSWORD']}}")
 
 {{env['TRACKALERT_KEY']}}

--- a/docker/wforce_image/wforce.conf.j2
+++ b/docker/wforce_image/wforce.conf.j2
@@ -1,7 +1,7 @@
 -- This configuration file is provided as an example
 -- It only scratches the surface of what weakforced policy can do
 
-addListener("0.0.0.0:{{env['WFORCE_HTTP_PORT']}}", false,    "",             "",         {})
+addListener("0.0.0.0:{{env['WFORCE_HTTP_PORT']}}", false, "", "", {})
 setWebserverPassword("{{env['WFORCE_HTTP_PASSWORD']}}")
 
 {{env['WFORCE_KEY']}}

--- a/docker/wforce_image/wforce.conf.j2
+++ b/docker/wforce_image/wforce.conf.j2
@@ -1,7 +1,9 @@
 -- This configuration file is provided as an example
 -- It only scratches the surface of what weakforced policy can do
 
-webserver("0.0.0.0:{{env['WFORCE_HTTP_PORT']}}", "{{env['WFORCE_HTTP_PASSWORD']}}")
+addListener("0.0.0.0:{{env['WFORCE_HTTP_PORT']}}", false,    "",             "",         {})
+setWebserverPassword("{{env['WFORCE_HTTP_PASSWORD']}}")
+
 {{env['WFORCE_KEY']}}
 controlSocket("0.0.0.0:4004")
 

--- a/trackalert/trackalert.conf
+++ b/trackalert/trackalert.conf
@@ -1,4 +1,10 @@
-webserver("0.0.0.0:8085", "--WEBPWD")
+-- Old way to configure the webserver
+-- webserver("0.0.0.0:8085", "--WEBPWD")
+-- New way to configure the webserver
+--          IP addr:port    Use SSL? Certificate File Private Key TLS Options - see https://www.openssl.org/docs/manmaster/man3/SSL_CONF_cmd.html
+addListener("0.0.0.0:8085", false,    "",             "",         {})
+setWebserverPassword("--WEBPWD")
+
 --SETKEY
 controlSocket("127.0.0.1:4005")
 


### PR DESCRIPTION
- Image was using the sample wforce and trackalerrt config files instead of "no"config file as should be the case
- Generate the console/replication key from kernel random uuid rather than try to use wforce itself to generate it (which can lead to a deadlock)
- Don't use deprecated version of webserver listen command when generating config
- Test wforce image properly in regression (previously some tests were failing but not being picked up)
- Test trackalert binary in regression