### PR TITLE
Build minimal docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-      - run: cd docker/wforce_image && TAG=`git describe --tags` docker buildx build -f Dockerfile.minimal weakforced -t powerdns/wforce-minimal:$TAG --load
+      - run: cd docker/wforce_image && docker buildx build -f Dockerfile.minimal weakforced -t powerdns/wforce-minimal:`git describe --tags` --load
       - run: cd docker && bash docker_push.sh "powerdns/wforce-minimal"
         env:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,7 +29,12 @@ jobs:
       - run: ./configure --enable-docker --disable-dns --disable-sodium --disable-geoip
       - run: cd docker/wforce_image && make test_wforce_image
       - run: cd docker/wforce_image && make build_wforce_image
-      - run: cd docker && bash docker_push.sh
+      - run: cd docker && bash docker_push.sh "powerdns/wforce"
+        env:
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      - run: cd docker/wforce_image && TAG=`git describe --tags` docker buildx build -f Dockerfile.minimal weakforced -t powerdns/wforce-minimal:$TAG --load
+      - run: cd docker && bash docker_push.sh "powerdns/wforce-minimal"
         env:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}

--- a/docker/docker_push.sh
+++ b/docker/docker_push.sh
@@ -14,7 +14,7 @@ push_tag()
   local tag=$1
   echo "Docker username is: '"$DOCKER_USERNAME"'"
   docker_login
-  docker push powerdns/wforce:$tag
+  docker push $IMAGE:$tag
 }
 
 TAG=`git describe --tags`
@@ -24,10 +24,12 @@ then
     push_tag $TAG
 fi
 
+IMAGE=$1
+
 BRANCH=`git branch --show-current`
 if [ "$BRANCH" = "master" ]
 then
-    docker tag powerdns/wforce:$TAG powerdns/wforce:unstable
+    docker tag $IMAGE:$TAG $IMAGE:unstable
     push_tag unstable
 fi
 

--- a/docker/wforce_image/Dockerfile
+++ b/docker/wforce_image/Dockerfile
@@ -120,8 +120,7 @@ ENV TRACKALERT_HTTP_PORT=8085
 ENV TRACKALERT_HTTP_PASSWORD=
 ENV TRACKALERT_CONFIG_FILE=
 
-LABEL org.label-schema.build-date="${build_date}" \
-  org.label-schema.license="${license}" \
+LABEL   org.label-schema.license="${license}" \
   org.label-schema.name="Weakforced" \
   org.label-schema.schema-version="1.0" \
   org.label-schema.url="https://powerdns.github.io/weakforced" \
@@ -130,7 +129,6 @@ LABEL org.label-schema.build-date="${build_date}" \
   org.label-schema.vcs-url="https://github.com/PowerDNS/weakforced" \
   org.label-schema.vendor="PowerDNS" \
   org.label-schema.version="${version}" \
-  org.opencontainers.image.created="${build_date}" \
   org.opencontainers.image.documentation="https://powerdns.github.io/weakforced" \
   org.opencontainers.image.licenses="${license}" \
   org.opencontainers.image.revision="${git_revision}" \

--- a/docker/wforce_image/Dockerfile.minimal
+++ b/docker/wforce_image/Dockerfile.minimal
@@ -1,7 +1,5 @@
 FROM alpine:3.19 as wforce_build
 
-#RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >>/etc/apk/repositories
-
 RUN apk update && \
     apk add \
                autoconf \

--- a/docker/wforce_image/Dockerfile.minimal
+++ b/docker/wforce_image/Dockerfile.minimal
@@ -1,0 +1,126 @@
+FROM alpine:3.19 as wforce_build
+
+#RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >>/etc/apk/repositories
+
+RUN apk update && \
+    apk add \
+               autoconf \
+               automake \
+               boost-dev \
+               curl-dev \
+               openssl-dev \
+               hiredis-dev \
+               readline-dev \
+               libmaxminddb-dev \
+               luajit-dev \
+               protobuf-dev \
+               yaml-cpp-dev \
+               jsoncpp-dev \
+               zlib-dev \
+               libtool \
+               pkgconf \
+               protobuf \
+               wget \
+               util-linux-dev \
+               make \
+               cmake \
+               git \
+               binutils \
+               g++
+
+WORKDIR /wforce/
+RUN mkdir /wforce/install
+
+RUN git clone https://github.com/drogonframework/drogon.git
+RUN cd drogon && git checkout tags/v1.9.1 -b v1.9.1
+RUN cd drogon && git submodule init && git submodule update && mkdir _build && cd _build && cmake .. -DBUILD_BROTLI=OFF -DBUILD_C-ARES=OFF -DBUILD_REDIS=OFF -DCMAKE_BUILD_TYPE=Release -DBUILD_ORM=OFF && make && make install
+
+RUN git clone https://github.com/jupp0r/prometheus-cpp.git
+RUN cd prometheus-cpp && git checkout tags/v1.0.1 -b v1.0.1
+RUN cd prometheus-cpp && \
+    mkdir _build && cd _build && cmake .. -DBUILD_SHARED_LIBS=off -DENABLE_PULL=off \
+    -DENABLE_PUSH=off -DENABLE_COMPRESSION=off -DENABLE_TESTING=off \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON && make && make install
+
+RUN wget https://getdnsapi.net/dist/getdns-1.7.3.tar.gz && tar -xvf getdns-1.7.3.tar.gz
+RUN cd getdns-1.7.3 && cmake . -DCMAKE_BUILD_TYPE=Release -DENABLE_SHARED=off -DENABLE_STUB_ONLY=on -DBUILD_GETDNS_QUERY=off -DBUILD_GETDNS_SERVER_MON=off -DBUILD_TESTING:BOOL=OFF -DUSE_LIBIDN2=off && make install
+
+ADD CHANGELOG.md configure.ac ext LICENSE Makefile.am README.md NOTICE /wforce/
+COPY m4/ /wforce/m4/
+COPY ext/ /wforce/ext/
+COPY docs/ /wforce/docs/
+COPY wforce/ /wforce/wforce/
+COPY common/ /wforce/common/
+COPY trackalert/ /wforce/trackalert/
+COPY docker/Makefile.am /wforce/docker/
+RUN  mkdir /wforce/docker/wforce_image
+COPY docker/wforce_image/Makefile.am /wforce/docker/wforce_image
+COPY elk/ /wforce/elk/
+
+RUN autoreconf -ivf
+RUN ./configure --prefix /usr --enable-trackalert --disable-systemd --disable-sodium --disable-docker --with-luajit --sysconfdir=/etc/wforce
+RUN make clean
+RUN make install DESTDIR=/wforce/install
+RUN strip /wforce/install/usr/bin/wforce /wforce/install/usr/bin/trackalert
+# Remove the default wforce.conf and trackalert.conf files
+RUN rm /wforce/install/etc/wforce/wforce.conf /wforce/install/etc/wforce/trackalert.conf
+
+FROM alpine:3.19 as wforce_image
+
+WORKDIR /wforce/
+
+COPY --from=wforce_build /wforce/install/ /
+
+RUN apk update && \
+    apk add \
+               boost-filesystem \
+               curl \
+               openssl \
+               hiredis \
+               readline \
+               libmaxminddb \
+               luajit \
+               libprotobuf \
+               yaml-cpp \
+               jsoncpp \
+               zlib \
+               protobuf \
+               abseil-cpp \
+               abseil-cpp-flags-marshalling \
+               util-linux \
+               tini
+
+RUN addgroup --gid 1000 wforce && \
+    adduser -u 1000 -S -G wforce wforce && \
+    chmod -R 0775 /etc/wforce && \
+    chgrp -R 1000 /etc/wforce
+
+ARG license
+ARG git_revision
+ARG version
+
+LABEL   org.label-schema.license="${license}" \
+  org.label-schema.name="Weakforced" \
+  org.label-schema.schema-version="1.0" \
+  org.label-schema.url="https://powerdns.github.io/weakforced" \
+  org.label-schema.usage="https://powerdns.github.io/weakforced" \
+  org.label-schema.vcs-ref="${git_revision}" \
+  org.label-schema.vcs-url="https://github.com/PowerDNS/weakforced" \
+  org.label-schema.vendor="PowerDNS" \
+  org.label-schema.version="${version}" \
+  org.opencontainers.image.documentation="https://powerdns.github.io/weakforced" \
+  org.opencontainers.image.licenses="${license}" \
+  org.opencontainers.image.revision="${git_revision}" \
+  org.opencontainers.image.source="https://github.com/PowerDNS/weakforced" \
+  org.opencontainers.image.title="Weakforced" \
+  org.opencontainers.image.url="https://powerdns.github.io/weakforced" \
+  org.opencontainers.image.vendor="PowerDNS" \
+  org.opencontainers.image.version="${version}"
+
+USER wforce:wforce
+
+EXPOSE 8084
+
+ENTRYPOINT ["tini", "--"]
+
+CMD ["/usr/bin/wforce", "-D"]

--- a/docker/wforce_image/docker-compose.yml
+++ b/docker/wforce_image/docker-compose.yml
@@ -7,7 +7,6 @@ services:
       context: weakforced
       dockerfile: docker/wforce_image/Dockerfile
       args:
-        - build_date=${BUILD_DATE}
         - license=${LICENSE}
         - git_revision=${GIT_REVISION}
         - version=${VERSION}


### PR DESCRIPTION
The existing docker image that is built is based on debian and is very heavyweight. This adds a new minimal image based on alpine that is approx 5x smaller, but with less features for casual users.