### PR TITLE
Update wforce.postinst

### DIFF
--- a/builder-support/debian/wforce.postinst
+++ b/builder-support/debian/wforce.postinst
@@ -29,7 +29,7 @@ case "$1" in
        echo "Moved /etc/wforce.conf to /etc/wforce/wforce.conf"
     fi
     echo -n "Modifying wforce.conf to replace password and key..."
-    SETKEY=`echo "makeKey()" | wforce | grep setKey`
+    SETKEY=`wforce -e "makeKey()" | grep setKey`
     WEBPWD=`dd if=/dev/urandom bs=1 count=32 2>/dev/null | base64 | rev | cut -b 2-14 | rev`
     sed -e "s#--WEBPWD#$WEBPWD#" -e "s#--SETKEY#$SETKEY#" -i $WFORCECONF
     echo "done"


### PR DESCRIPTION
Call wforce binary with --execute option instead command via pipe in debian postinstall. The later one fails if the wforce daemon is running.

Setting up wforce (2.10.2+39.g194df92-1pdns.bullseye) ... Modifying wforce.conf to replace password and key...dpkg: error processing package wforce (--configure): installed wforce package post-installation script subprocess returned error exit status 1 Errors were encountered while processing:
wforce


~# echo "makeKey()" | wforce
Read configuration from '/etc/wforce/wforce.conf'
Adding webserver listener on 0.0.0.0:8085 with SSL=0, cert_file=, key_file= Adding webserver listener on 0.0.0.0:8084 with SSL=1,  [...]
Unable to bind to control socket on 127.0.0.1:4004: binding socket to 127.0.0.1:4004: Address already in use