### PR TITLE
Set 'setKey' and 'webpwd' in debian postinst script only on new installations.

### DIFF
--- a/builder-support/debian/wforce-trackalert.postinst
+++ b/builder-support/debian/wforce-trackalert.postinst
@@ -16,11 +16,13 @@ case "$1" in
       adduser --quiet --system --home /var/spool/wforce --shell /bin/false --ingroup wforce --disabled-password --disabled-login --gecos "wforce" wforce
       echo "done"
     fi
-    echo -n "Modifying trackalert.conf to replace password and key..."
-    SETKEY=`echo "makeKey()" | trackalert | grep setKey`
-    WEBPWD=`dd if=/dev/urandom bs=1 count=32 2>/dev/null | base64 | rev | cut -b 2-14 | rev`
-    sed -e "s#--WEBPWD#$WEBPWD#" -e "s#--SETKEY#$SETKEY#" -i $TRACKALERTCONF
-    echo "done"
+    if [ -z "$2" ]; then
+        echo -n "Modifying trackalert.conf to replace password and key..."
+        SETKEY=`echo "makeKey()" | trackalert | grep setKey`
+        WEBPWD=`dd if=/dev/urandom bs=1 count=32 2>/dev/null | base64 | rev | cut -b 2-14 | rev`
+        sed -e "s#--WEBPWD#$WEBPWD#" -e "s#--SETKEY#$SETKEY#" -i $TRACKALERTCONF
+        echo "done"
+    fi
   ;;
 
   *)

--- a/builder-support/debian/wforce.postinst
+++ b/builder-support/debian/wforce.postinst
@@ -28,11 +28,13 @@ case "$1" in
        mv /etc/wforce.conf /etc/wforce/wforce.conf && \
        echo "Moved /etc/wforce.conf to /etc/wforce/wforce.conf"
     fi
-    echo -n "Modifying wforce.conf to replace password and key..."
-    SETKEY=`echo "makeKey()" | wforce | grep setKey`
-    WEBPWD=`dd if=/dev/urandom bs=1 count=32 2>/dev/null | base64 | rev | cut -b 2-14 | rev`
-    sed -e "s#--WEBPWD#$WEBPWD#" -e "s#--SETKEY#$SETKEY#" -i $WFORCECONF
-    echo "done"
+    if [ -z "$2" ]; then
+        echo -n "Modifying wforce.conf to replace password and key..."
+        SETKEY=`echo "makeKey()" | wforce | grep setKey`
+        WEBPWD=`dd if=/dev/urandom bs=1 count=32 2>/dev/null | base64 | rev | cut -b 2-14 | rev`
+        sed -e "s#--WEBPWD#$WEBPWD#" -e "s#--SETKEY#$SETKEY#" -i $WFORCECONF
+        echo "done"
+    fi
   ;;
 
   *)


### PR DESCRIPTION
Change debian postinst scripts to run some shell commands for setting 'setKey' and 'webpwd' parameter only if no weakforce is already installed (or configurations are left). This is necessary because running these commands if weakforce is already runnig they will fail and upgrading exits with failure.
postinst maintainer script is only run _without_ additional arguments beside 'configure' if it's a new installation.
See https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html#summary-of-ways-maintainer-scripts-are-called