### PR TITLE
docker: Use fixed tags for kafka images not latest to avoid regression surprises

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -60,13 +60,13 @@ services:
       - kafka-rest
   # The following three images are for kafka regression testing
   zookeeper:
-    image: confluentinc/cp-zookeeper:latest
+    image: confluentinc/cp-zookeeper:7.9.2
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
 
   kafka:
-    image: confluentinc/cp-kafka:latest
+    image: confluentinc/cp-kafka:7.9.2
     depends_on:
       - zookeeper
     ports:
@@ -80,7 +80,7 @@ services:
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
 
   kafka-rest:
-    image: confluentinc/cp-kafka-rest:latest
+    image: confluentinc/cp-kafka-rest:7.9.2
     ports:
       - 8082:8082
     environment:


### PR DESCRIPTION
This fixes regression tests