### PR TITLE
Include stdint.hh everywhere that uses (u)int[NN]_t types

### DIFF
--- a/common/common-lua.cc
+++ b/common/common-lua.cc
@@ -20,6 +20,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <stdint.h>
 #include "common-lua.hh"
 
 #ifdef HAVE_GEOIP

--- a/common/dns_lookup.hh
+++ b/common/dns_lookup.hh
@@ -28,6 +28,7 @@
 #include <memory>
 #include <mutex>
 #include <atomic>
+#include <stdint.h>
 #include "iputils.hh"
 
 struct GetDNSContext {

--- a/common/iputils.hh
+++ b/common/iputils.hh
@@ -38,6 +38,7 @@
 #include <sstream>
 #include <boost/tuple/tuple.hpp>
 #include <boost/tuple/tuple_comparison.hpp>
+#include <stdint.h>
 
 #include "namespaces.hh"
 

--- a/common/minicurl.hh
+++ b/common/minicurl.hh
@@ -26,6 +26,7 @@
 #include <sstream>
 #include <vector>
 #include <memory>
+#include <stdint.h>
 #include <curl/curlver.h>
 #if defined(LIBCURL_VERSION_NUM) && LIBCURL_VERSION_NUM >= 0x073200
 /* we need this so that 'CURL' is not typedef'd to void,

--- a/common/misc.hh
+++ b/common/misc.hh
@@ -27,6 +27,7 @@
 #include <cstdio>
 #include <regex.h>
 #include <limits.h>
+#include <stdint.h>
 #include <boost/algorithm/string.hpp>
 #include <boost/multi_index_container.hpp>
 #include <boost/multi_index/ordered_index.hpp>

--- a/common/twmap.hh
+++ b/common/twmap.hh
@@ -34,6 +34,7 @@
 #include <boost/optional.hpp>
 #include <iostream>
 #include <sstream>
+#include <stdint.h>
 #include "ext/hyperloglog.hpp"
 #include "ext/count_min_sketch.hpp"
 #include "iputils.hh"

--- a/common/webhook.hh
+++ b/common/webhook.hh
@@ -24,11 +24,12 @@
 #include <mutex>
 #include <curl/curl.h>
 #include <condition_variable>
+#include <queue>
+#include <stdint.h>
 #include "json11.hpp"
 #include "dolog.hh"
 #include "minicurl.hh"
 #include "prometheus.hh"
-#include <queue>
 
 using WHConfigMap = std::map<std::string, std::string>;
 using WHEvents = std::vector<std::string>;

--- a/common/wforce-geoip.hh
+++ b/common/wforce-geoip.hh
@@ -27,6 +27,7 @@
 #include <GeoIP.h>
 #include <GeoIPCity.h>
 #endif
+#include <stdint.h>
 #include "lock.hh"
 #include "iputils.hh"
 

--- a/common/wforce-geoip2.hh
+++ b/common/wforce-geoip2.hh
@@ -24,6 +24,7 @@
 #include <string>
 #include <mutex>
 #include <vector>
+#include <stdint.h>
 #include "lock.hh"
 #include "iputils.hh"
 #include "wforce-geoip.hh"

--- a/ext/ext/hyperloglog.hpp
+++ b/ext/ext/hyperloglog.hpp
@@ -25,6 +25,7 @@ THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #include <sstream>
 #include <stdexcept>
 #include <algorithm>
+#include <stdint.h>
 #include "murmur3.h"
 
 #define HLL_HASH_SEED 313

--- a/ext/json11/json11.cpp
+++ b/ext/json11/json11.cpp
@@ -26,6 +26,7 @@
 #include <cstdio>
 #include <limits>
 #include <string>
+#include <stdint.h>
 
 namespace json11 {
 

--- a/trackalert/trackalert.hh
+++ b/trackalert/trackalert.hh
@@ -28,6 +28,7 @@
 #include <atomic>
 #include <mutex>
 #include <thread>
+#include <stdint.h>
 #include "sholder.hh"
 #include "sstuff.hh"
 #include "webhook.hh"

--- a/wforce/wforce-replication.cc
+++ b/wforce/wforce-replication.cc
@@ -32,6 +32,7 @@
 #include "json11.hpp"
 #include <unistd.h>
 #include <sys/stat.h>
+#include <stdint.h>
 #include "sodcrypto.hh"
 #include "perf-stats.hh"
 #include "lock.hh"

--- a/wforce/wforce-sibling.cc
+++ b/wforce/wforce-sibling.cc
@@ -25,6 +25,7 @@
 #include "wforce_exception.hh"
 #include "wforce_ns.hh"
 #include <stddef.h>
+#include <stdint.h>
 #include <netdb.h>
 
 #define SYSLOG_NAMES

--- a/wforce/wforce.hh
+++ b/wforce/wforce.hh
@@ -29,6 +29,7 @@
 #include <boost/circular_buffer.hpp>
 #include <mutex>
 #include <thread>
+#include <stdint.h>
 #include "sholder.hh"
 #include "sstuff.hh"
 #include "replication.hh"


### PR DESCRIPTION
Debian package building is failing for some folks due to missing defines integer types  e.g. uint64_t. This PR includes `stdint.h` in every file that uses these types.

Note that strictly speaking `<cstdint>` should be used, but that is not guaranteed to include the types in the global namespace.

Using <cstdint> and prefixing everything with std:: is a future task.