### PR TITLE
Add Ubuntu LTS build targets (jammy, noble, resolute)

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -21,6 +21,7 @@ jobs:
           - debian-bullseye
           - debian-bookworm
           - debian-trixie
+          - ubuntu-noble
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -21,7 +21,9 @@ jobs:
           - debian-bullseye
           - debian-bookworm
           - debian-trixie
+          - ubuntu-jammy
           - ubuntu-noble
+          - ubuntu-resolute
     steps:
       - uses: actions/checkout@v7
         with:

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ git clone https://github.com/PowerDNS/weakforced.git
 $ cd weakforced
 $ git submodule init
 $ git submodule update
-$ builder/build.sh debian-bullseye | debian-bookworm | el-7 | el-8  | el-9 | amazon-2
+$ builder/build.sh debian-bullseye | debian-bookworm | debian-trixie | ubuntu-noble | el-8 | el-9 | el-10 | ol-8 | ol-9 | rl-10 | amazon-2023
 ```
 This will build packages (`wforce`,`wforce-trackalert` and `wforce-debuginfo`) for the appropriate OS. You will need docker for the builder to work.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ git clone https://github.com/PowerDNS/weakforced.git
 $ cd weakforced
 $ git submodule init
 $ git submodule update
-$ builder/build.sh debian-bullseye | debian-bookworm | debian-trixie | ubuntu-noble | el-8 | el-9 | el-10 | ol-8 | ol-9 | rl-10 | amazon-2023
+$ builder/build.sh debian-bullseye | debian-bookworm | debian-trixie | ubuntu-jammy | ubuntu-noble | ubuntu-resolute | el-8 | el-9 | el-10 | ol-8 | ol-9 | rl-10 | amazon-2023
 ```
 This will build packages (`wforce`,`wforce-trackalert` and `wforce-debuginfo`) for the appropriate OS. You will need docker for the builder to work.
 

--- a/builder-support/debian/control
+++ b/builder-support/debian/control
@@ -31,7 +31,7 @@ Build-Depends: cdbs,
 
 Package: wforce
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}, wforce-lua-dist
 Description: Daemon for detecting brute force attacks
  The goal of 'wforce' is to detect brute forcing of passwords across many
  servers, services and instances. In order to support the real world, brute
@@ -42,7 +42,7 @@ Description: Daemon for detecting brute force attacks
 
 Package: wforce-trackalert
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}, wforce-lua-dist
 Description: Longterm abuse data reporting and alerter
  Trackalert is designed to be an optional service to complement
  wforce. Whereas wforce provides a toolkit to combat  abuse of

--- a/builder-support/dockerfiles/Dockerfile.debbuild
+++ b/builder-support/dockerfiles/Dockerfile.debbuild
@@ -1,6 +1,6 @@
 FROM dist-base as package-builder-base
 ARG APT_URL
-RUN apt-get -y install devscripts dpkg-dev build-essential wget curl \
+RUN apt-get -y install devscripts equivs dpkg-dev build-essential wget curl \
                        python3 python3-pip python3-setuptools \
                        libjsoncpp-dev uuid-dev libz-dev libssl-dev libldap2-dev cmake
 

--- a/builder-support/dockerfiles/Dockerfile.debbuild
+++ b/builder-support/dockerfiles/Dockerfile.debbuild
@@ -1,6 +1,6 @@
 FROM dist-base as package-builder-base
 ARG APT_URL
-RUN apt-get -y install devscripts equivs dpkg-dev build-essential wget curl \
+RUN apt-get -y install devscripts equivs dpkg-dev build-essential wget curl git \
                        python3 python3-pip python3-setuptools \
                        libjsoncpp-dev uuid-dev libz-dev libssl-dev libldap2-dev cmake
 

--- a/builder-support/dockerfiles/Dockerfile.debtest
+++ b/builder-support/dockerfiles/Dockerfile.debtest
@@ -6,6 +6,11 @@ FROM dist-base as dist
 COPY --from=sdist /sdist /sdist
 COPY --from=package-builder /dist /dist
 
+# Refresh the apt index before installing -- the dist-base layer's index
+# can be hours stale by the time we get here, and version-pinned URLs for
+# security updates get 404 on the mirror once a new point release is out.
+RUN apt-get update
+
 # Install built packages with dependencies
 RUN apt install -y /dist/*.deb
 

--- a/builder-support/dockerfiles/Dockerfile.target.debuild
+++ b/builder-support/dockerfiles/Dockerfile.target.debuild
@@ -1,6 +1,6 @@
 FROM dist-base as package-builder
 ARG APT_URL
-RUN apt-get -y install devscripts dpkg-dev build-essential
+RUN apt-get -y install devscripts equivs dpkg-dev build-essential
 
 RUN mkdir /dist /wforce
 WORKDIR /wforce

--- a/builder-support/dockerfiles/Dockerfile.target.ubuntu-jammy
+++ b/builder-support/dockerfiles/Dockerfile.target.ubuntu-jammy
@@ -1,0 +1,12 @@
+# First do the source builds
+@INCLUDE Dockerfile.target.sdist
+
+FROM ubuntu:22.04 as dist-base
+ARG APT_URL
+RUN apt-get update && apt-get -y dist-upgrade
+
+@INCLUDE Dockerfile.debbuild
+
+# Do a test install and verify
+# Can be skipped with skiptests=1 in the environment
+@EXEC [ "$skiptests" = "" ] && include Dockerfile.debtest

--- a/builder-support/dockerfiles/Dockerfile.target.ubuntu-noble
+++ b/builder-support/dockerfiles/Dockerfile.target.ubuntu-noble
@@ -1,0 +1,12 @@
+# First do the source builds
+@INCLUDE Dockerfile.target.sdist
+
+FROM ubuntu:24.04 as dist-base
+ARG APT_URL
+RUN apt-get update && apt-get -y dist-upgrade
+
+@INCLUDE Dockerfile.debbuild
+
+# Do a test install and verify
+# Can be skipped with skiptests=1 in the environment
+@EXEC [ "$skiptests" = "" ] && include Dockerfile.debtest

--- a/builder-support/dockerfiles/Dockerfile.target.ubuntu-resolute
+++ b/builder-support/dockerfiles/Dockerfile.target.ubuntu-resolute
@@ -1,0 +1,12 @@
+# First do the source builds
+@INCLUDE Dockerfile.target.sdist
+
+FROM ubuntu:26.04 as dist-base
+ARG APT_URL
+RUN apt-get update && apt-get -y dist-upgrade
+
+@INCLUDE Dockerfile.debbuild
+
+# Do a test install and verify
+# Can be skipped with skiptests=1 in the environment
+@EXEC [ "$skiptests" = "" ] && include Dockerfile.debtest

--- a/builder-support/luajit-debian/wforce-lua-dist.postinst
+++ b/builder-support/luajit-debian/wforce-lua-dist.postinst
@@ -4,6 +4,12 @@
 
 set -e
 
-/sbin/ldconfig
+# Force synchronous ldconfig. On Ubuntu (>= 24.04), /sbin/ldconfig is a
+# wrapper that defers via `dpkg-trigger --no-await ldconfig` when invoked
+# from a maintscript -- meaning the ld.so.cache update would land at the
+# end of the dpkg run, after dependent packages' (wforce/wforce-trackalert)
+# postinst scripts have already tried to exec the wforce binary and failed
+# to find libluajit-5.1.so.2. Opt out so the cache is updated immediately.
+LDCONFIG_NOTRIGGER=y /sbin/ldconfig
 
 exit 0


### PR DESCRIPTION
Fixes #468: adds `ubuntu-jammy` (22.04 LTS), `ubuntu-noble` (24.04 LTS) and `ubuntu-resolute` (26.04 LTS) build targets for the package builder, mirroring the existing `debian-trixie` target — each a 12-line `Dockerfile.target.*` file based on the corresponding `ubuntu:` image, registered in the CI matrix and README. `build.sh` auto-discovers them via the existing `Dockerfile.target.*` glob, so no script changes are needed.

As noted in #468, Ubuntu support wasn't completely straightforward — four small fixes surfaced while porting, bundled here because the targets don't build without them:

- **`equivs` installed explicitly** in `Dockerfile.debbuild` / `Dockerfile.target.debuild` — Ubuntu 24.04's `devscripts` no longer pulls it in transitively, so `mk-build-deps` can't create its build-deps meta-package. Harmless on Debian, where `devscripts` still brings `equivs` along.

- **`git` installed explicitly** in `Dockerfile.debbuild` — on Ubuntu 26.04 it no longer arrives transitively either, so the drogon `git clone` in the static-libs stage fails with exit 127. Harmless on the other targets.

- **`apt-get update` before installing built debs** in `Dockerfile.debtest`, matching the existing fix in `builder/helpers/build-debs.sh` — the `dist-base` layer's apt index can be hours stale by the time the install-test stage runs, and version-pinned security-update URLs 404 on the mirror once a point release ships.

- **`wforce-lua-dist` declared as a runtime `Depends`** of `wforce` and `wforce-trackalert`, and its postinst runs `LDCONFIG_NOTRIGGER=y /sbin/ldconfig`. On Ubuntu >= 24.04, `/sbin/ldconfig` invoked from a maintscript defers via `dpkg-trigger`, batching the `ld.so.cache` update to the end of the dpkg run — after `wforce.postinst` has already tried (and failed) to load `libluajit-5.1.so.2`. The env var forces a synchronous update and is ignored on older Debian.

All three targets build and pass the debtest install/verify stage (checked locally on arm64 in addition to the CI runs here).

While touching the README's target list I refreshed it to the current full set of `Dockerfile.target.*` targets (it still referenced the removed `el-7` / `amazon-2`).
